### PR TITLE
fix: quicksight check in china region

### DIFF
--- a/src/control-plane/backend/click-stream-api.ts
+++ b/src/control-plane/backend/click-stream-api.ts
@@ -295,6 +295,7 @@ export class ClickStreamApiConstruct extends Construct {
         STS_UPLOAD_ROLE_ARN: uploadRole.roleArn,
         API_ROLE_NAME: clickStreamApiFunctionRole.roleName,
         HEALTH_CHECK_PATH: props.healthCheckPath,
+        QUICKSIGHT_CONTROL_PLANE_REGION: props.targetToCNRegions ? 'cn-north-1' : 'us-east-1',
         ... POWERTOOLS_ENVS,
       },
       architecture: Architecture.X86_64,

--- a/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
@@ -122,7 +122,8 @@ export const quickSightPing = async (region: string): Promise<boolean> => {
   } catch (err) {
     if ((err as Error).name === 'TimeoutError' ||
     (err as Error).message.includes('getaddrinfo ENOTFOUND') ||
-    (err as Error).name === 'UnrecognizedClientException') {
+    (err as Error).name === 'UnrecognizedClientException' ||
+    (err as Error).name === 'InternalFailure') {
       return false;
     }
   }

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -136,6 +136,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
             Ref: 'AWS::AccountId',
           },
           LOG_LEVEL: 'WARN',
+          QUICKSIGHT_CONTROL_PLANE_REGION: 'us-east-1',
         },
       },
       MemorySize: 512,
@@ -1016,6 +1017,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
           DICTIONARY_TABLE_NAME: {
             Ref: 'testClickStreamCloudfrontApiClickstreamDictionaryB094D60B',
           },
+          QUICKSIGHT_CONTROL_PLANE_REGION: 'us-east-1',
         },
       },
       MemorySize: 512,
@@ -1075,6 +1077,11 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
       Architectures: [
         'x86_64',
       ],
+      Environment: {
+        Variables: {
+          QUICKSIGHT_CONTROL_PLANE_REGION: 'cn-north-1',
+        },
+      },
       Description: 'Lambda function for api of solution Click Stream Analytics on AWS',
     });
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. catch InternalFailure Exception
2. set quicksight default control plane region in China region

Closes: #10 

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module