### PR TITLE
chore: deploy backend lambda as zip

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,8 @@ test*
 script
 coverage
 deployment/
+docs/
+coverage/
+.git/
+.gitlab/
+.github/

--- a/.github/workflows/dist-scan.yml
+++ b/.github/workflows/dist-scan.yml
@@ -19,7 +19,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: templates-${{ github.event.pull_request.number }}
-          path: deployment/global-s3-assets
+          path: |
+            deployment/global-s3-assets
+            !deployment/global-s3-assets/**/asset.*
   cfn-lint-scan:
     name: cfn-lint scan
     needs: build-dist

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -250,7 +250,6 @@ const apiProject = new typescript.TypeScriptProject({
     },
   },
   tsconfigDev: {
-    exclude: ['dist'],
     compilerOptions: {
       emitDecoratorMetadata: true,
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -244,11 +244,13 @@ const apiProject = new typescript.TypeScriptProject({
   eslint: false,
   minNodeVersion: '16.18.0',
   tsconfig: {
+    exclude: ['dist'],
     compilerOptions: {
       emitDecoratorMetadata: true,
     },
   },
   tsconfigDev: {
+    exclude: ['dist'],
     compilerOptions: {
       emitDecoratorMetadata: true,
     },

--- a/Dockerfile.backend.build
+++ b/Dockerfile.backend.build
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/docker/library/node:16
 RUN mkdir -p /home/node/app
 WORKDIR /home/node/app
-COPY . .
+COPY ./src ./src
 RUN cd src/control-plane/backend/lambda/api && yarn install && yarn build
 RUN cd src/control-plane/backend/lambda/api && rm -rf node_modules && yarn install --production
 

--- a/Dockerfile.backend.build
+++ b/Dockerfile.backend.build
@@ -1,0 +1,11 @@
+FROM public.ecr.aws/docker/library/node:16
+RUN mkdir -p /home/node/app
+WORKDIR /home/node/app
+COPY . .
+RUN cd src/control-plane/backend/lambda/api && yarn install && yarn build
+RUN cd src/control-plane/backend/lambda/api && rm -rf node_modules && yarn install --production
+
+RUN mkdir -p /asset
+RUN cp -r /home/node/app/src/control-plane/backend/lambda/api/node_modules /asset/
+RUN cp -r /home/node/app/src/control-plane/backend/lambda/api/dist /asset/
+RUN cp -r /home/node/app/src/control-plane/backend/lambda/api/run.sh /asset/run.sh

--- a/src/control-plane/backend/lambda/api/run.sh
+++ b/src/control-plane/backend/lambda/api/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+node dist/index.js

--- a/src/control-plane/backend/lambda/api/tsconfig.dev.json
+++ b/src/control-plane/backend/lambda/api/tsconfig.dev.json
@@ -32,6 +32,7 @@
     "test//**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "dist"
   ]
 }

--- a/src/control-plane/backend/lambda/api/tsconfig.json
+++ b/src/control-plane/backend/lambda/api/tsconfig.json
@@ -31,5 +31,7 @@
   "include": [
     ".//**/*.ts"
   ],
-  "exclude": []
+  "exclude": [
+    "dist"
+  ]
 }

--- a/src/control-plane/backend/layer/lambda-web-adapter/Dockerfile
+++ b/src/control-plane/backend/layer/lambda-web-adapter/Dockerfile
@@ -1,0 +1,29 @@
+# ARG TARGET_PLATFORM=linux/amd64
+# FROM --platform=$TARGET_PLATFORM public.ecr.aws/amazonlinux/amazonlinux:2 as build-stage
+# ARG ARCH=x86_64
+# RUN rpm --rebuilddb && yum install -y yum-plugin-ovl jq
+# RUN yum groupinstall -y "Development tools"
+# RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+# RUN source $HOME/.cargo/env && rustup target add ${ARCH}-unknown-linux-musl
+# RUN curl -k -o /${ARCH}-linux-musl-cross.tgz https://musl.cc/${ARCH}-linux-musl-cross.tgz \
+#         && tar zxf /${ARCH}-linux-musl-cross.tgz \
+#         && ln -s /${ARCH}-linux-musl-cross/bin/${ARCH}-linux-musl-gcc /usr/local/bin/${ARCH}-unknown-linux-musl-gcc
+# WORKDIR /app
+# RUN git clone https://github.com/awslabs/aws-lambda-web-adapter.git &&\
+#     cd aws-lambda-web-adapter &&\
+#     source $HOME/.cargo/env &&\
+#     LAMBDA_RUNTIME_USER_AGENT=aws-lambda-rust/aws-lambda-adapter/$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].version') \
+#     CC=${ARCH}-unknown-linux-musl-gcc cargo build --release --target=${ARCH}-unknown-linux-musl
+ARG TARGET_PLATFORM=linux/amd64
+FROM --platform=$TARGET_PLATFORM public.ecr.aws/awsguru/rust-builder
+ARG ARCH=x86_64
+WORKDIR /app
+RUN git clone https://github.com/awslabs/aws-lambda-web-adapter.git &&\
+    cd aws-lambda-web-adapter &&\
+    source $HOME/.cargo/env &&\
+    LAMBDA_RUNTIME_USER_AGENT=aws-lambda-rust/aws-lambda-adapter/$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].version') \
+    CC=${ARCH}-unknown-linux-musl-gcc cargo build --release --target=${ARCH}-unknown-linux-musl
+
+RUN mkdir -p /asset/extensions
+RUN cp /app/aws-lambda-web-adapter/layer/* /asset/
+RUN cp /app/aws-lambda-web-adapter/target/${ARCH}-unknown-linux-musl/release/lambda-adapter /asset/extensions/lambda-adapter

--- a/src/control-plane/backend/layer/lambda-web-adapter/Dockerfile
+++ b/src/control-plane/backend/layer/lambda-web-adapter/Dockerfile
@@ -1,16 +1,21 @@
 ARG TARGET_PLATFORM=linux/amd64
 FROM --platform=$TARGET_PLATFORM public.ecr.aws/amazonlinux/amazonlinux:2 as build-stage
 ARG ARCH=x86_64
-RUN rpm --rebuilddb && yum install -y yum-plugin-ovl jq
-RUN yum groupinstall -y "Development tools"
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-RUN source $HOME/.cargo/env && rustup target add ${ARCH}-unknown-linux-musl
-RUN curl -k -o /${ARCH}-linux-musl-cross.tgz https://musl.cc/${ARCH}-linux-musl-cross.tgz \
+ARG ADAPTER_VERSION=latest
+RUN rpm --rebuilddb && yum install -y yum-plugin-ovl jq unzip &&\
+    yum groupinstall -y "Development tools" &&\
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y &&\
+    source $HOME/.cargo/env && rustup target add ${ARCH}-unknown-linux-musl &&\
+    curl -k -o /${ARCH}-linux-musl-cross.tgz https://musl.cc/${ARCH}-linux-musl-cross.tgz \
         && tar zxf /${ARCH}-linux-musl-cross.tgz \
         && ln -s /${ARCH}-linux-musl-cross/bin/${ARCH}-linux-musl-gcc /usr/local/bin/${ARCH}-unknown-linux-musl-gcc
 WORKDIR /app
 RUN git clone https://github.com/awslabs/aws-lambda-web-adapter.git &&\
     cd aws-lambda-web-adapter &&\
+    git fetch --tags &&\
+    checkoutTag=${ADAPTER_VERSION} &&\
+    if [ "x$ADAPTER_VERSION" == "xlatest" ] ; then checkoutTag=$(git describe --tags `git rev-list --tags --max-count=1`) ; else checkoutTag=${ADAPTER_VERSION} ; fi &&\
+    git checkout $checkoutTag &&\
     source $HOME/.cargo/env &&\
     LAMBDA_RUNTIME_USER_AGENT=aws-lambda-rust/aws-lambda-adapter/$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].version') \
     CC=${ARCH}-unknown-linux-musl-gcc cargo build --release --target=${ARCH}-unknown-linux-musl

--- a/src/control-plane/backend/layer/lambda-web-adapter/Dockerfile
+++ b/src/control-plane/backend/layer/lambda-web-adapter/Dockerfile
@@ -1,22 +1,13 @@
-# ARG TARGET_PLATFORM=linux/amd64
-# FROM --platform=$TARGET_PLATFORM public.ecr.aws/amazonlinux/amazonlinux:2 as build-stage
-# ARG ARCH=x86_64
-# RUN rpm --rebuilddb && yum install -y yum-plugin-ovl jq
-# RUN yum groupinstall -y "Development tools"
-# RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-# RUN source $HOME/.cargo/env && rustup target add ${ARCH}-unknown-linux-musl
-# RUN curl -k -o /${ARCH}-linux-musl-cross.tgz https://musl.cc/${ARCH}-linux-musl-cross.tgz \
-#         && tar zxf /${ARCH}-linux-musl-cross.tgz \
-#         && ln -s /${ARCH}-linux-musl-cross/bin/${ARCH}-linux-musl-gcc /usr/local/bin/${ARCH}-unknown-linux-musl-gcc
-# WORKDIR /app
-# RUN git clone https://github.com/awslabs/aws-lambda-web-adapter.git &&\
-#     cd aws-lambda-web-adapter &&\
-#     source $HOME/.cargo/env &&\
-#     LAMBDA_RUNTIME_USER_AGENT=aws-lambda-rust/aws-lambda-adapter/$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].version') \
-#     CC=${ARCH}-unknown-linux-musl-gcc cargo build --release --target=${ARCH}-unknown-linux-musl
 ARG TARGET_PLATFORM=linux/amd64
-FROM --platform=$TARGET_PLATFORM public.ecr.aws/awsguru/rust-builder
+FROM --platform=$TARGET_PLATFORM public.ecr.aws/amazonlinux/amazonlinux:2 as build-stage
 ARG ARCH=x86_64
+RUN rpm --rebuilddb && yum install -y yum-plugin-ovl jq
+RUN yum groupinstall -y "Development tools"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN source $HOME/.cargo/env && rustup target add ${ARCH}-unknown-linux-musl
+RUN curl -k -o /${ARCH}-linux-musl-cross.tgz https://musl.cc/${ARCH}-linux-musl-cross.tgz \
+        && tar zxf /${ARCH}-linux-musl-cross.tgz \
+        && ln -s /${ARCH}-linux-musl-cross/bin/${ARCH}-linux-musl-gcc /usr/local/bin/${ARCH}-unknown-linux-musl-gcc
 WORKDIR /app
 RUN git clone https://github.com/awslabs/aws-lambda-web-adapter.git &&\
     cd aws-lambda-web-adapter &&\
@@ -24,6 +15,8 @@ RUN git clone https://github.com/awslabs/aws-lambda-web-adapter.git &&\
     LAMBDA_RUNTIME_USER_AGENT=aws-lambda-rust/aws-lambda-adapter/$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].version') \
     CC=${ARCH}-unknown-linux-musl-gcc cargo build --release --target=${ARCH}-unknown-linux-musl
 
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 as  package-stage
+ARG ARCH=x86_64
 RUN mkdir -p /asset/extensions
-RUN cp /app/aws-lambda-web-adapter/layer/* /asset/
-RUN cp /app/aws-lambda-web-adapter/target/${ARCH}-unknown-linux-musl/release/lambda-adapter /asset/extensions/lambda-adapter
+COPY --from=build-stage /app/aws-lambda-web-adapter/target/${ARCH}-unknown-linux-musl/release/lambda-adapter /asset/extensions/lambda-adapter
+COPY --from=build-stage /app/aws-lambda-web-adapter/layer/* /asset/

--- a/src/control-plane/backend/layer/lambda-web-adapter/Dockerfile
+++ b/src/control-plane/backend/layer/lambda-web-adapter/Dockerfile
@@ -1,8 +1,8 @@
 ARG TARGET_PLATFORM=linux/amd64
 FROM --platform=$TARGET_PLATFORM public.ecr.aws/amazonlinux/amazonlinux:2 as build-stage
 ARG ARCH=x86_64
-ARG ADAPTER_VERSION=latest
-RUN rpm --rebuilddb && yum install -y yum-plugin-ovl jq unzip &&\
+ARG ADAPTER_VERSION=0.7.0
+RUN rpm --rebuilddb && yum install -y yum-plugin-ovl jq unzip wget &&\
     yum groupinstall -y "Development tools" &&\
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y &&\
     source $HOME/.cargo/env && rustup target add ${ARCH}-unknown-linux-musl &&\
@@ -10,12 +10,10 @@ RUN rpm --rebuilddb && yum install -y yum-plugin-ovl jq unzip &&\
         && tar zxf /${ARCH}-linux-musl-cross.tgz \
         && ln -s /${ARCH}-linux-musl-cross/bin/${ARCH}-linux-musl-gcc /usr/local/bin/${ARCH}-unknown-linux-musl-gcc
 WORKDIR /app
-RUN git clone https://github.com/awslabs/aws-lambda-web-adapter.git &&\
+RUN wget https://github.com/awslabs/aws-lambda-web-adapter/archive/refs/tags/v${ADAPTER_VERSION}.zip &&\
+    unzip v${ADAPTER_VERSION}.zip &&\
+    mv aws-lambda-web-adapter-${ADAPTER_VERSION} aws-lambda-web-adapter &&\
     cd aws-lambda-web-adapter &&\
-    git fetch --tags &&\
-    checkoutTag=${ADAPTER_VERSION} &&\
-    if [ "x$ADAPTER_VERSION" == "xlatest" ] ; then checkoutTag=$(git describe --tags `git rev-list --tags --max-count=1`) ; else checkoutTag=${ADAPTER_VERSION} ; fi &&\
-    git checkout $checkoutTag &&\
     source $HOME/.cargo/env &&\
     LAMBDA_RUNTIME_USER_AGENT=aws-lambda-rust/aws-lambda-adapter/$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].version') \
     CC=${ARCH}-unknown-linux-musl-gcc cargo build --release --target=${ARCH}-unknown-linux-musl

--- a/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
+++ b/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
@@ -1,0 +1,41 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import path from 'path';
+import { LayerVersion, Runtime, Code, Architecture } from 'aws-cdk-lib/aws-lambda';
+import { Construct } from 'constructs';
+
+export interface LambdaAdapterLayerProps {
+  readonly platform?: string;
+  readonly arch?: 'aarch64' | 'x86_64';
+}
+
+export class LambdaAdapterLayer extends LayerVersion {
+  constructor(scope: Construct, id: string, props?: LambdaAdapterLayerProps) {
+    const platform = props?.platform ?? 'linux/amd64';
+    const defaultArch = props?.arch === 'aarch64' ? 'aarch64' : 'x86_64';
+    const architecture = props?.arch === 'aarch64' ? Architecture.ARM_64 : Architecture.X86_64;
+
+    super(scope, id, {
+      code: Code.fromDockerBuild(path.join(__dirname, '.'), {
+        file: 'Dockerfile',
+        buildArgs: {
+          TARGET_PLATFORM: platform,
+          ARCH: defaultArch,
+        },
+      }),
+      compatibleRuntimes: [Runtime.NODEJS_16_X, Runtime.NODEJS_18_X],
+      compatibleArchitectures: [architecture],
+    });
+  }
+}

--- a/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
+++ b/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
@@ -16,14 +16,14 @@ import { LayerVersion, Runtime, Code, Architecture } from 'aws-cdk-lib/aws-lambd
 import { Construct } from 'constructs';
 
 export interface LambdaAdapterLayerProps {
-  readonly platform?: string;
+  readonly platform?: 'linux/arm64' | 'linux/amd64';
   readonly arch?: 'aarch64' | 'x86_64';
 }
 
 export class LambdaAdapterLayer extends LayerVersion {
   constructor(scope: Construct, id: string, props?: LambdaAdapterLayerProps) {
     const platform = props?.platform ?? 'linux/amd64';
-    const defaultArch = props?.arch === 'aarch64' ? 'aarch64' : 'x86_64';
+    const defaultArch = props?.arch ?? 'x86_64';
     const architecture = props?.arch === 'aarch64' ? Architecture.ARM_64 : Architecture.X86_64;
 
     super(scope, id, {

--- a/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
+++ b/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
@@ -23,7 +23,7 @@ export interface LambdaAdapterLayerProps {
 
 export class LambdaAdapterLayer extends LayerVersion {
   constructor(scope: Construct, id: string, props?: LambdaAdapterLayerProps) {
-    const defaultVersion = props?.arch ?? 'latest';
+    const defaultVersion = props?.arch ?? '0.7.0';
     const defaultPlatform = props?.platform ?? 'linux/amd64';
     const defaultArch = props?.arch ?? 'x86_64';
     const architecture = defaultArch === 'aarch64' ? Architecture.ARM_64 : Architecture.X86_64;

--- a/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
+++ b/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
@@ -16,22 +16,25 @@ import { LayerVersion, Runtime, Code, Architecture } from 'aws-cdk-lib/aws-lambd
 import { Construct } from 'constructs';
 
 export interface LambdaAdapterLayerProps {
+  readonly version?: string;
   readonly platform?: 'linux/arm64' | 'linux/amd64';
   readonly arch?: 'aarch64' | 'x86_64';
 }
 
 export class LambdaAdapterLayer extends LayerVersion {
   constructor(scope: Construct, id: string, props?: LambdaAdapterLayerProps) {
-    const platform = props?.platform ?? 'linux/amd64';
+    const defaultVersion = props?.arch ?? 'latest';
+    const defaultPlatform = props?.platform ?? 'linux/amd64';
     const defaultArch = props?.arch ?? 'x86_64';
-    const architecture = props?.arch === 'aarch64' ? Architecture.ARM_64 : Architecture.X86_64;
+    const architecture = defaultArch === 'aarch64' ? Architecture.ARM_64 : Architecture.X86_64;
 
     super(scope, id, {
       code: Code.fromDockerBuild(path.join(__dirname, '.'), {
         file: 'Dockerfile',
         buildArgs: {
-          TARGET_PLATFORM: platform,
+          TARGET_PLATFORM: defaultPlatform,
           ARCH: defaultArch,
+          ADAPTER_VERSION: defaultVersion,
         },
       }),
       compatibleRuntimes: [Runtime.NODEJS_16_X, Runtime.NODEJS_18_X],

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -14,17 +14,17 @@
 import { findResourcesName, TestEnv } from './test-utils';
 
 describe('Click Stream Api ALB deploy Construct Test', () => {
+  const newALBApiStackTemplate = TestEnv.newALBApiStack().template;
+  const newALBApiStackCNTemplate = TestEnv.newALBApiStack(true).template;
 
   test('DynamoDB table', () => {
-    const { template } = TestEnv.newALBApiStack();
-
-    expect(findResourcesName(template, 'AWS::DynamoDB::Table'))
+    expect(findResourcesName(newALBApiStackTemplate, 'AWS::DynamoDB::Table'))
       .toEqual([
         'testClickStreamALBApiClickstreamDictionary0A1156B6',
         'testClickStreamALBApiClickstreamMetadataA721B303',
       ]);
 
-    template.hasResourceProperties('AWS::DynamoDB::Table', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::DynamoDB::Table', {
       KeySchema: [
         {
           AttributeName: 'name',
@@ -45,7 +45,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
         SSEEnabled: true,
       },
     });
-    template.hasResourceProperties('AWS::DynamoDB::Table', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::DynamoDB::Table', {
       KeySchema: [
         {
           AttributeName: 'id',
@@ -107,9 +107,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
   });
 
   test('Api lambda Function', () => {
-    const { template } = TestEnv.newALBApiStack();
-
-    expect(findResourcesName(template, 'AWS::Lambda::Function'))
+    expect(findResourcesName(newALBApiStackTemplate, 'AWS::Lambda::Function'))
       .toEqual([
         'testClickStreamALBApiBatchInsertDDBCustomResourceDicInitCustomResourceFunction504311BF',
         'testClickStreamALBApiBatchInsertDDBCustomResourceDicInitCustomResourceProviderframeworkonEventFB731F8E',
@@ -119,7 +117,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
         'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A',
       ]);
 
-    template.hasResourceProperties('AWS::Lambda::Function', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
         'x86_64',
       ],
@@ -140,7 +138,6 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
         },
       },
       MemorySize: 512,
-      PackageType: 'Image',
       Timeout: 30,
       VpcConfig: {
         SecurityGroupIds: [
@@ -157,7 +154,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
         ],
       },
     });
-    template.hasResource('AWS::Lambda::Function', {
+    newALBApiStackTemplate.hasResource('AWS::Lambda::Function', {
       DependsOn: [
         'apifunceni59253B5A',
         'testClickStreamALBApiClickStreamApiFunctionRoleDefaultPolicyD977CF6D',
@@ -165,7 +162,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
       ],
     });
 
-    template.hasResourceProperties('AWS::Lambda::Function', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Environment: {
         Variables: {
           LOG_LEVEL: 'WARN',
@@ -174,14 +171,14 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
       },
     });
 
-    template.hasResourceProperties('AWS::Lambda::Function', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
         'x86_64',
       ],
       Description: 'Lambda function for dictionary init of solution Click Stream Analytics on AWS',
       Runtime: 'nodejs18.x',
     });
-    template.hasResourceProperties('AWS::Lambda::Function', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
         'x86_64',
       ],
@@ -202,7 +199,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
         Mode: 'Active',
       },
     });
-    template.hasResourceProperties('AWS::Lambda::Function', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
         'x86_64',
       ],
@@ -223,34 +220,31 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
         Mode: 'Active',
       },
     });
-    template.hasResourceProperties('AWS::Lambda::Function', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
         'x86_64',
       ],
-      PackageType: 'Image',
       Description: 'Lambda function for api of solution Click Stream Analytics on AWS',
     });
 
   });
 
   test('Api lambda Function in GCR', () => {
-    const { template } = TestEnv.newALBApiStack(true);
-
-    template.hasResourceProperties('AWS::Lambda::Function', {
+    newALBApiStackCNTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
         'x86_64',
       ],
       Description: 'Lambda function for dictionary init of solution Click Stream Analytics on AWS',
       Runtime: 'nodejs18.x',
     });
-    template.hasResourceProperties('AWS::Lambda::Function', {
+    newALBApiStackCNTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
         'x86_64',
       ],
       Description: 'Lambda function for state machine action of solution Clickstream Analytics on AWS',
       Runtime: 'nodejs18.x',
     });
-    template.hasResourceProperties('AWS::Lambda::Function', {
+    newALBApiStackCNTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
         'x86_64',
       ],
@@ -259,10 +253,8 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
   });
 
   test('IAM Resource for Api Lambda', () => {
-    const { template } = TestEnv.newALBApiStack();
-
     // Creates the function's execution role...
-    template.hasResourceProperties('AWS::IAM::Role', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::IAM::Role', {
       AssumeRolePolicyDocument: {
         Statement: [
           {
@@ -278,9 +270,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
   });
 
   test('Check SecurityGroup', () => {
-    const { template } = TestEnv.newALBApiStack();
-
-    template.hasResourceProperties('AWS::EC2::SecurityGroup', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::EC2::SecurityGroup', {
       GroupDescription: 'apiTestStack/testClickStreamALBApi/ClickStreamApiFunctionSG',
       SecurityGroupEgress: [
         {
@@ -292,7 +282,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
       VpcId: 'vpc-11111111111111111',
     });
 
-    template.hasResourceProperties('AWS::EC2::SecurityGroupIngress', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::EC2::SecurityGroupIngress', {
       IpProtocol: 'tcp',
       Description: 'allow all traffic from application load balancer',
       GroupId: {
@@ -308,14 +298,10 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
         ],
       },
     });
-
-
   });
 
   test('Policy', () => {
-    const { template } = TestEnv.newALBApiStack();
-
-    expect(findResourcesName(template, 'AWS::IAM::Policy'))
+    expect(findResourcesName(newALBApiStackTemplate, 'AWS::IAM::Policy'))
       .toEqual([
         'testClickStreamALBApiBatchInsertDDBCustomResourceDicInitCustomResourceRoleDefaultPolicy2DB98D9D',
         'testClickStreamALBApiBatchInsertDDBCustomResourceDicInitCustomResourceProviderframeworkonEventServiceRoleDefaultPolicy7EB8455A',
@@ -340,7 +326,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
       ]);
 
     // StateMachineActionFunctionRoleDefaultPolicy
-    template.hasResourceProperties('AWS::IAM::Policy', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::IAM::Policy', {
       PolicyDocument: {
         Statement: [
           {
@@ -363,7 +349,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
     });
 
     // StateMachineRoleDefaultPolicy
-    template.hasResourceProperties('AWS::IAM::Policy', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::IAM::Policy', {
       PolicyDocument: {
         Statement: [
           {
@@ -428,7 +414,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
     });
 
     // ApiFunctionRoleDefaultPolicy
-    template.hasResourceProperties('AWS::IAM::Policy', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::IAM::Policy', {
       PolicyDocument: {
         Statement: [
           {
@@ -505,7 +491,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
     });
 
     // ApiStepFunctionPolicy
-    template.hasResourceProperties('AWS::IAM::Policy', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::IAM::Policy', {
       PolicyDocument: {
         Statement: [
           {
@@ -527,7 +513,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
     });
 
     // ApiAWSSdkPolicy
-    template.hasResourceProperties('AWS::IAM::Policy', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::IAM::Policy', {
       PolicyDocument: {
         Statement: [
           {
@@ -589,7 +575,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
     });
 
     // ActionFunctionRolePolicy
-    template.hasResourceProperties('AWS::IAM::Policy', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::IAM::Policy', {
       PolicyDocument: {
         Statement: [
           {
@@ -671,15 +657,13 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
   });
 
   test('LogGroup', () => {
-    const { template } = TestEnv.newALBApiStack();
-
-    expect(findResourcesName(template, 'AWS::Logs::LogGroup'))
+    expect(findResourcesName(newALBApiStackTemplate, 'AWS::Logs::LogGroup'))
       .toEqual([
         'testClickStreamALBApiStackActionStateMachineLogGroupDE72356F',
         'testClickStreamALBApiStackWorkflowStateMachineLogGroupD7FD1922',
       ]);
 
-    template.hasResourceProperties('AWS::Logs::LogGroup', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::Logs::LogGroup', {
       LogGroupName: {
         'Fn::Join': [
           '',
@@ -716,14 +700,12 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
   });
 
   test('Custom Resource', () => {
-    const { template } = TestEnv.newALBApiStack();
-
-    expect(findResourcesName(template, 'AWS::CloudFormation::CustomResource'))
+    expect(findResourcesName(newALBApiStackTemplate, 'AWS::CloudFormation::CustomResource'))
       .toEqual([
         'testClickStreamALBApiBatchInsertDDBCustomResourceDicInitCustomResource5AE5EDD9',
       ]);
 
-    template.hasResourceProperties('AWS::CloudFormation::CustomResource', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::CloudFormation::CustomResource', {
       ServiceToken: {
         'Fn::GetAtt': [
           'testClickStreamALBApiBatchInsertDDBCustomResourceDicInitCustomResourceProviderframeworkonEventFB731F8E',
@@ -735,7 +717,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
       },
     });
 
-    template.hasResourceProperties('AWS::Lambda::Function', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
         'x86_64',
       ],
@@ -757,8 +739,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
   });
 
   test('State Machine', () => {
-    const { template } = TestEnv.newALBApiStack();
-    template.hasResourceProperties('AWS::StepFunctions::StateMachine', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::StepFunctions::StateMachine', {
       DefinitionString: {
         'Fn::Join': [
           '',
@@ -801,7 +782,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
         ],
       },
     });
-    template.hasResourceProperties('AWS::StepFunctions::StateMachine', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::StepFunctions::StateMachine', {
       DefinitionString: {
         'Fn::Join': [
           '',
@@ -915,11 +896,12 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
 });
 
 describe('Click Stream Api Cloudfront deploy Construct Test', () => {
+  const newALBApiStackTemplate = TestEnv.newALBApiStack().template;
+  const newALBApiStackCNTemplate = TestEnv.newALBApiStack(true).template;
+  const newCloudfrontApiStackTemplate = TestEnv.newCloudfrontApiStack().template;
 
   test('DynamoDB table', () => {
-    const { template } = TestEnv.newCloudfrontApiStack();
-
-    template.hasResourceProperties('AWS::DynamoDB::Table', {
+    newCloudfrontApiStackTemplate.hasResourceProperties('AWS::DynamoDB::Table', {
       KeySchema: [
         {
           AttributeName: 'name',
@@ -940,7 +922,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
         SSEEnabled: true,
       },
     });
-    template.hasResourceProperties('AWS::DynamoDB::Table', {
+    newCloudfrontApiStackTemplate.hasResourceProperties('AWS::DynamoDB::Table', {
       KeySchema: [
         {
           AttributeName: 'id',
@@ -1002,29 +984,75 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
   });
 
   test('Api lambda Function', () => {
-    const { template } = TestEnv.newCloudfrontApiStack();
-
-    template.hasResourceProperties('AWS::Lambda::Function', {
+    newCloudfrontApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
         'x86_64',
       ],
       Description: 'Lambda function for api of solution Click Stream Analytics on AWS',
       Environment: {
         Variables: {
+          AWS_LAMBDA_EXEC_WRAPPER: '/opt/bootstrap',
           CLICK_STREAM_TABLE_NAME: {
             Ref: 'testClickStreamCloudfrontApiClickstreamMetadata11A455BB',
           },
           DICTIONARY_TABLE_NAME: {
             Ref: 'testClickStreamCloudfrontApiClickstreamDictionaryB094D60B',
           },
-          QUICKSIGHT_CONTROL_PLANE_REGION: 'us-east-1',
+          STACK_ACTION_SATE_MACHINE: {
+            Ref: 'testClickStreamCloudfrontApiStackActionStateMachineF9686748',
+          },
+          STACK_WORKFLOW_SATE_MACHINE: {
+            Ref: 'testClickStreamCloudfrontApiStackWorkflowStateMachine74FBB0F0',
+          },
+          STACK_WORKFLOW_S3_BUCKET: {
+            Ref: 'stackWorkflowS3BucketF67B9562',
+          },
+          PREFIX_TIME_GSI_NAME: 'prefix-time-index',
+          AWS_ACCOUNT_ID: {
+            Ref: 'AWS::AccountId',
+          },
+          AWS_URL_SUFFIX: {
+            Ref: 'AWS::URLSuffix',
+          },
+          WITH_AUTH_MIDDLEWARE: 'false',
+          ISSUER: '',
+          AUTHORIZER_TABLE_NAME: '',
+          STS_UPLOAD_ROLE_ARN: {
+            'Fn::GetAtt': [
+              'testClickStreamCloudfrontApiUploadRole7D6ED157',
+              'Arn',
+            ],
+          },
+          API_ROLE_NAME: {
+            Ref: 'testClickStreamCloudfrontApiClickStreamApiFunctionRoleFDC21CDD',
+          },
+          HEALTH_CHECK_PATH: '/',
+          POWERTOOLS_SERVICE_NAME: 'ClickStreamAnalyticsOnAWS',
+          POWERTOOLS_LOGGER_SAMPLE_RATE: '1',
+          POWERTOOLS_LOGGER_LOG_EVENT: 'true',
+          LOG_LEVEL: 'WARN',
         },
       },
+      Handler: 'run.sh',
+      Layers: [
+        {
+          'Fn::Join': [
+            '',
+            [
+              'arn:aws:lambda:',
+              {
+                Ref: 'AWS::Region',
+              },
+              ':753240598075:layer:LambdaAdapterLayerX86:16',
+            ],
+          ],
+        },
+      ],
       MemorySize: 512,
-      PackageType: 'Image',
+      Runtime: 'nodejs18.x',
       Timeout: 30,
     });
-    template.hasResource('AWS::Lambda::Function', {
+    newCloudfrontApiStackTemplate.hasResource('AWS::Lambda::Function', {
       DependsOn: [
         'apifunceni59253B5A',
         'testClickStreamCloudfrontApiClickStreamApiFunctionRoleDefaultPolicy64431738',
@@ -1032,48 +1060,45 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
       ],
     });
 
-    template.hasResourceProperties('AWS::Lambda::Function', {
+    newCloudfrontApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
         'x86_64',
       ],
       Description: 'Lambda function for dictionary init of solution Click Stream Analytics on AWS',
       Runtime: 'nodejs18.x',
     });
-    template.hasResourceProperties('AWS::Lambda::Function', {
+    newCloudfrontApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
         'x86_64',
       ],
       Description: 'Lambda function for state machine action of solution Clickstream Analytics on AWS',
       Runtime: 'nodejs18.x',
     });
-    template.hasResourceProperties('AWS::Lambda::Function', {
+    newCloudfrontApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
         'x86_64',
       ],
-      PackageType: 'Image',
       Description: 'Lambda function for api of solution Click Stream Analytics on AWS',
     });
 
   });
 
   test('Api lambda Function in GCR', () => {
-    const { template } = TestEnv.newALBApiStack(true);
-
-    template.hasResourceProperties('AWS::Lambda::Function', {
+    newALBApiStackCNTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
         'x86_64',
       ],
       Description: 'Lambda function for dictionary init of solution Click Stream Analytics on AWS',
       Runtime: 'nodejs18.x',
     });
-    template.hasResourceProperties('AWS::Lambda::Function', {
+    newALBApiStackCNTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
         'x86_64',
       ],
       Description: 'Lambda function for state machine action of solution Clickstream Analytics on AWS',
       Runtime: 'nodejs18.x',
     });
-    template.hasResourceProperties('AWS::Lambda::Function', {
+    newALBApiStackCNTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
         'x86_64',
       ],
@@ -1088,10 +1113,8 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
   });
 
   test('IAM Resource for Api Lambda', () => {
-    const { template } = TestEnv.newCloudfrontApiStack();
-
     // Creates the function's execution role...
-    template.hasResourceProperties('AWS::IAM::Role', {
+    newCloudfrontApiStackTemplate.hasResourceProperties('AWS::IAM::Role', {
       AssumeRolePolicyDocument: {
         Statement: [
           {
@@ -1107,8 +1130,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
   });
 
   test('ApiGateway', () => {
-    const { template } = TestEnv.newCloudfrontApiStack();
-    template.hasResourceProperties('AWS::ApiGateway::Method', {
+    newCloudfrontApiStackTemplate.hasResourceProperties('AWS::ApiGateway::Method', {
       HttpMethod: 'ANY',
       ResourceId: {
         Ref: 'testClickStreamCloudfrontApiClickStreamApiproxyF7B82220',
@@ -1145,7 +1167,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
         },
       },
     });
-    template.hasResourceProperties('AWS::ApiGateway::Method', {
+    newCloudfrontApiStackTemplate.hasResourceProperties('AWS::ApiGateway::Method', {
       HttpMethod: 'ANY',
       ResourceId: {
         'Fn::GetAtt': [
@@ -1185,7 +1207,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
         },
       },
     });
-    template.hasResourceProperties('AWS::ApiGateway::RestApi', {
+    newCloudfrontApiStackTemplate.hasResourceProperties('AWS::ApiGateway::RestApi', {
       EndpointConfiguration: {
         Types: [
           'REGIONAL',
@@ -1193,20 +1215,20 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
       },
       Name: 'ClickStreamApi',
     });
-    template.hasResourceProperties('AWS::ApiGateway::Deployment', {
+    newCloudfrontApiStackTemplate.hasResourceProperties('AWS::ApiGateway::Deployment', {
       RestApiId: {
         Ref: 'testClickStreamCloudfrontApiClickStreamApi77242134',
       },
       Description: 'Automatically created by the RestApi construct',
     });
-    template.hasResource('AWS::ApiGateway::Deployment', {
+    newCloudfrontApiStackTemplate.hasResource('AWS::ApiGateway::Deployment', {
       DependsOn: [
         'testClickStreamCloudfrontApiClickStreamApiproxyANY2AD1F4B4',
         'testClickStreamCloudfrontApiClickStreamApiproxyF7B82220',
         'testClickStreamCloudfrontApiClickStreamApiANY34E982F9',
       ],
     });
-    template.hasResourceProperties('AWS::ApiGateway::Stage', {
+    newCloudfrontApiStackTemplate.hasResourceProperties('AWS::ApiGateway::Stage', {
       RestApiId: {
         Ref: 'testClickStreamCloudfrontApiClickStreamApi77242134',
       },
@@ -1234,7 +1256,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
       StageName: 'api',
       TracingEnabled: true,
     });
-    template.hasResourceProperties('AWS::ApiGateway::UsagePlan', {
+    newCloudfrontApiStackTemplate.hasResourceProperties('AWS::ApiGateway::UsagePlan', {
       ApiStages: [
         {
           ApiId: {
@@ -1254,9 +1276,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
   });
 
   test('LogGroup', () => {
-    const { template } = TestEnv.newALBApiStack();
-
-    template.hasResourceProperties('AWS::Logs::LogGroup', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::Logs::LogGroup', {
       LogGroupName: {
         'Fn::Join': [
           '',
@@ -1293,8 +1313,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
   });
 
   test('State Machine', () => {
-    const { template } = TestEnv.newALBApiStack();
-    template.hasResourceProperties('AWS::StepFunctions::StateMachine', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::StepFunctions::StateMachine', {
       DefinitionString: {
         'Fn::Join': [
           '',
@@ -1337,7 +1356,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
         ],
       },
     });
-    template.hasResourceProperties('AWS::StepFunctions::StateMachine', {
+    newALBApiStackTemplate.hasResourceProperties('AWS::StepFunctions::StateMachine', {
       DefinitionString: {
         'Fn::Join': [
           '',

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -984,6 +984,19 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
   });
 
   test('Api lambda Function', () => {
+    expect(findResourcesName(newCloudfrontApiStackTemplate, 'AWS::Lambda::LayerVersion'))
+      .toEqual([
+        'testClickStreamCloudfrontApiLambdaAdapterLayerX868468A9C4',
+      ]);
+    newCloudfrontApiStackTemplate.hasResourceProperties('AWS::Lambda::LayerVersion', {
+      CompatibleArchitectures: [
+        'x86_64',
+      ],
+      CompatibleRuntimes: [
+        'nodejs16.x',
+        'nodejs18.x',
+      ],
+    });
     newCloudfrontApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
         'x86_64',
@@ -1036,16 +1049,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
       Handler: 'run.sh',
       Layers: [
         {
-          'Fn::Join': [
-            '',
-            [
-              'arn:aws:lambda:',
-              {
-                Ref: 'AWS::Region',
-              },
-              ':753240598075:layer:LambdaAdapterLayerX86:16',
-            ],
-          ],
+          Ref: 'testClickStreamCloudfrontApiLambdaAdapterLayerX868468A9C4',
         },
       ],
       MemorySize: 512,

--- a/test/control-plane/cloudfront-control-plane-stack.test.ts
+++ b/test/control-plane/cloudfront-control-plane-stack.test.ts
@@ -29,7 +29,7 @@ describe('CloudFrontS3PotalStack', () => {
   test('Global region', () => {
     commonTemplate.resourceCountIs('AWS::CloudFront::CloudFrontOriginAccessIdentity', 1);
     commonTemplate.resourceCountIs('AWS::CloudFront::Distribution', 1);
-    commonTemplate.resourceCountIs('AWS::Lambda::LayerVersion', 1);
+    commonTemplate.resourceCountIs('AWS::Lambda::LayerVersion', 2);
     commonTemplate.resourceCountIs('Custom::CDKBucketDeployment', 1);
 
     commonTemplate.hasOutput(OUTPUT_CONTROL_PLANE_URL, {});
@@ -398,7 +398,7 @@ describe('CloudFrontS3PotalStack', () => {
     commonTemplate.resourceCountIs('AWS::S3::Bucket', 2);
     commonTemplate.resourceCountIs('AWS::CloudFront::CloudFrontOriginAccessIdentity', 1);
     commonTemplate.resourceCountIs('AWS::CloudFront::Distribution', 1);
-    commonTemplate.resourceCountIs('AWS::Lambda::LayerVersion', 1);
+    commonTemplate.resourceCountIs('AWS::Lambda::LayerVersion', 2);
     commonTemplate.resourceCountIs('Custom::CDKBucketDeployment', 1);
     expect(findResourcesName(commonTemplate, 'AWS::Lambda::Function').sort())
       .toEqual([
@@ -451,7 +451,7 @@ describe('CloudFrontS3PotalStack', () => {
     template.resourceCountIs('AWS::CloudFront::CloudFrontOriginAccessIdentity', 1);
     template.resourceCountIs('AWS::CloudFront::Distribution', 1);
     template.resourceCountIs('AWS::Route53::RecordSet', 1);
-    template.resourceCountIs('AWS::Lambda::LayerVersion', 1);
+    template.resourceCountIs('AWS::Lambda::LayerVersion', 2);
     template.resourceCountIs('Custom::CDKBucketDeployment', 1);
 
     template.hasOutput(OUTPUT_CONTROL_PLANE_URL, {});
@@ -518,7 +518,7 @@ describe('CloudFrontS3PotalStack', () => {
     template.resourceCountIs('AWS::CloudFront::CloudFrontOriginAccessIdentity', 1);
     template.resourceCountIs('AWS::CloudFront::Distribution', 1);
     template.resourceCountIs('AWS::Route53::RecordSet', 0);
-    template.resourceCountIs('AWS::Lambda::LayerVersion', 1);
+    template.resourceCountIs('AWS::Lambda::LayerVersion', 2);
     template.resourceCountIs('Custom::CDKBucketDeployment', 1);
 
     // Check Origin Request Policy


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. Create lambda adapter layer for backend lambda.
2. Docker build backend to Zip.

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module