### PR TITLE
chore: update CloudFront price class level

### DIFF
--- a/src/control-plane/cloudfront-s3-portal.ts
+++ b/src/control-plane/cloudfront-s3-portal.ts
@@ -324,7 +324,7 @@ export class CloudFrontS3Portal extends Construct {
           responseHeadersPolicy: responseHeadersPolicy,
         },
         defaultRootObject: 'index.html',
-        priceClass: PriceClass.PRICE_CLASS_100,
+        priceClass: PriceClass.PRICE_CLASS_200,
         enableIpv6: props.distributionProps?.enableIpv6 ?? false,
         comment: distributionDescription,
       });

--- a/src/control-plane/cloudfront-s3-portal.ts
+++ b/src/control-plane/cloudfront-s3-portal.ts
@@ -185,7 +185,7 @@ export class CloudFrontS3Portal extends Construct {
 
       this.distribution = new CloudFrontWebDistribution(this, 'PortalDistribution', {
         enableIpV6: false,
-        priceClass: PriceClass.PRICE_CLASS_ALL,
+        priceClass: PriceClass.PRICE_CLASS_100,
         defaultRootObject: 'index.html',
         viewerProtocolPolicy: ViewerProtocolPolicy.HTTPS_ONLY,
         originConfigs: [
@@ -324,7 +324,7 @@ export class CloudFrontS3Portal extends Construct {
           responseHeadersPolicy: responseHeadersPolicy,
         },
         defaultRootObject: 'index.html',
-        priceClass: PriceClass.PRICE_CLASS_ALL,
+        priceClass: PriceClass.PRICE_CLASS_100,
         enableIpv6: props.distributionProps?.enableIpv6 ?? false,
         comment: distributionDescription,
       });

--- a/src/control-plane/cloudfront-s3-portal.ts
+++ b/src/control-plane/cloudfront-s3-portal.ts
@@ -185,7 +185,7 @@ export class CloudFrontS3Portal extends Construct {
 
       this.distribution = new CloudFrontWebDistribution(this, 'PortalDistribution', {
         enableIpV6: false,
-        priceClass: PriceClass.PRICE_CLASS_100,
+        priceClass: PriceClass.PRICE_CLASS_ALL,
         defaultRootObject: 'index.html',
         viewerProtocolPolicy: ViewerProtocolPolicy.HTTPS_ONLY,
         originConfigs: [

--- a/test/control-plane/cloudfront-s3-portal.test.ts
+++ b/test/control-plane/cloudfront-s3-portal.test.ts
@@ -139,7 +139,7 @@ describe('CloudFrontS3Portal', () => {
             },
           },
         ],
-        PriceClass: 'PriceClass_100',
+        PriceClass: 'PriceClass_200',
       },
     });
 
@@ -397,7 +397,7 @@ describe('CloudFrontS3Portal', () => {
             OriginPath: '/prod',
           },
         ],
-        PriceClass: 'PriceClass_100',
+        PriceClass: 'PriceClass_200',
       },
     });
     template.hasResourceProperties('AWS::CloudFront::OriginRequestPolicy', {

--- a/test/control-plane/cloudfront-s3-portal.test.ts
+++ b/test/control-plane/cloudfront-s3-portal.test.ts
@@ -139,7 +139,7 @@ describe('CloudFrontS3Portal', () => {
             },
           },
         ],
-        PriceClass: 'PriceClass_All',
+        PriceClass: 'PriceClass_100',
       },
     });
 
@@ -397,7 +397,7 @@ describe('CloudFrontS3Portal', () => {
             OriginPath: '/prod',
           },
         ],
-        PriceClass: 'PriceClass_All',
+        PriceClass: 'PriceClass_100',
       },
     });
     template.hasResourceProperties('AWS::CloudFront::OriginRequestPolicy', {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

- update CloudFront Price class to 100 level 
- test deploy in global region
- test deploy in China region

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [x] deploy in China region

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module