### PR TITLE
feat(api): add file type validation for uploading plug-ins

### DIFF
--- a/src/control-plane/backend/lambda/api/common/constants.ts
+++ b/src/control-plane/backend/lambda/api/common/constants.ts
@@ -25,6 +25,7 @@ const awsUrlSuffix = process.env.AWS_URL_SUFFIX;
 const STSUploadRole = process.env.STS_UPLOAD_ROLE_ARN;
 const APIRoleName = process.env.API_ROLE_NAME;
 const amznRequestContextHeader = 'x-amzn-request-context';
+const ALLOW_UPLOADED_FILE_TYPES = process.env.ALLOW_UPLOADED_FILE_TYPES || 'jar,mmdb';
 const QUICKSIGHT_CONTROL_PLANE_REGION = process.env.QUICKSIGHT_CONTROL_PLANE_REGION || 'us-east-1';
 const SDK_MAVEN_VERSION_API_LINK =
   'https://search.maven.org/solrsearch/select?q=g:%22software.aws.solution%22+AND+a:%22clickstream%22&wt=json';
@@ -74,4 +75,5 @@ export {
   QUICKSIGHT_CONTROL_PLANE_REGION,
   SDK_MAVEN_VERSION_API_LINK,
   PIPELINE_SUPPORTED_REGIONS,
+  ALLOW_UPLOADED_FILE_TYPES,
 };

--- a/src/control-plane/backend/lambda/api/common/request-valid.ts
+++ b/src/control-plane/backend/lambda/api/common/request-valid.ts
@@ -13,7 +13,7 @@
 
 import express from 'express';
 import { validationResult, ValidationChain, CustomValidator } from 'express-validator';
-import { awsRegion } from './constants';
+import { ALLOW_UPLOADED_FILE_TYPES, awsRegion } from './constants';
 import { APP_ID_PATTERN, MUTIL_EMAIL_PATTERN, PROJECT_ID_PATTERN } from './constants-ln';
 import { validateXSS } from './stack-params-valid';
 import { ApiFail, AssumeRoleType } from './types';
@@ -229,6 +229,28 @@ export const isXSSRequest = (data: any) => {
   const str = JSON.stringify(data);
   if (validateXSS(str)) {
     return Promise.reject('Bad request. Please check and try again.');
+  }
+  return true;
+};
+
+export const isAllowFilesSuffix = (data: any) => {
+  if (isEmpty(data)) {
+    return true;
+  }
+  if (Array.prototype.isPrototypeOf(data)) {
+    for (let filename of data as string[]) {
+      const index = filename.lastIndexOf('.') + 1;
+      const suffix = filename.substring(index);
+      if (!ALLOW_UPLOADED_FILE_TYPES.split(',').includes(suffix)) {
+        return Promise.reject('Bad request. The file type not allow upload.');
+      }
+    }
+  } else {
+    const index = (data as string).lastIndexOf('.') + 1;
+    const suffix = (data as string).substring(index);
+    if (!ALLOW_UPLOADED_FILE_TYPES.split(',').includes(suffix)) {
+      return Promise.reject('Bad request. The file type not allow upload.');
+    }
   }
   return true;
 };

--- a/src/control-plane/backend/lambda/api/router/plugin.ts
+++ b/src/control-plane/backend/lambda/api/router/plugin.ts
@@ -13,7 +13,7 @@
 
 import express from 'express';
 import { body, header, query, param } from 'express-validator';
-import { defaultOrderValueValid, defaultPageValueValid, isPluginIdValid, isRequestIdExisted, isValidEmpty, isXSSRequest, validMatchParamId, validate } from '../common/request-valid';
+import { defaultOrderValueValid, defaultPageValueValid, isAllowFilesSuffix, isPluginIdValid, isRequestIdExisted, isValidEmpty, isXSSRequest, validMatchParamId, validate } from '../common/request-valid';
 import { PluginServ } from '../service/plugin';
 
 const router_plugin = express.Router();
@@ -41,7 +41,8 @@ router_plugin.post(
   '',
   validate([
     body().custom(isValidEmpty).custom(isXSSRequest),
-    body('jarFile').custom(isValidEmpty),
+    body('jarFile').custom(isValidEmpty).custom(isAllowFilesSuffix),
+    body('dependencyFiles').custom(isAllowFilesSuffix),
     body('mainFunction').custom(isValidEmpty),
     header('X-Click-Stream-Request-Id').custom(isRequestIdExisted),
   ]),

--- a/src/control-plane/backend/lambda/api/test/api/plugin.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/plugin.test.ts
@@ -39,8 +39,8 @@ describe('Plugin test', () => {
       .send({
         name: 'Plugin-01',
         description: 'Description of Plugin-01',
-        jarFile: 'jarFile',
-        dependencyFiles: ['dependencyFiles1', 'dependencyFiles2'],
+        jarFile: 'jarFile.jar',
+        dependencyFiles: ['dependencyFiles1.jar', 'dependencyFiles2.mmdb'],
         mainFunction: 'com.cn.sre.main',
         pluginType: 'Transform',
       });
@@ -49,6 +49,41 @@ describe('Plugin test', () => {
     expect(res.body.message).toEqual('Plugin created.');
     expect(res.body.success).toEqual(true);
     expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 2);
+  });
+  it('Create plugin with not allow file type', async () => {
+    tokenMock(ddbMock, false);
+    ddbMock.on(PutCommand).resolvesOnce({});
+    const res = await request(app)
+      .post('/api/plugin')
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        name: 'Plugin-01',
+        description: 'Description of Plugin-01',
+        jarFile: 'jarFile.sh',
+        dependencyFiles: ['dependencyFiles1.exe', 'dependencyFiles2.mmdb'],
+        mainFunction: 'com.cn.sre.main',
+        pluginType: 'Transform',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Parameter verification failed.',
+      error: [
+        {
+          location: 'body',
+          msg: 'Bad request. The file type not allow upload.',
+          param: 'dependencyFiles',
+          value: ['dependencyFiles1.exe', 'dependencyFiles2.mmdb'],
+        },
+        {
+          location: 'body',
+          msg: 'Bad request. The file type not allow upload.',
+          param: 'jarFile',
+          value: 'jarFile.sh',
+        },
+      ],
+    });
   });
   it('Create plugin with XSS', async () => {
     tokenMock(ddbMock, false);
@@ -59,8 +94,8 @@ describe('Plugin test', () => {
       .send({
         name: '<IMG SRC=javascript:alert(\'XSS\')><script>alert(234)</script>',
         description: 'Description of Plugin-01',
-        jarFile: 'jarFile',
-        dependencyFiles: ['dependencyFiles1', 'dependencyFiles2'],
+        jarFile: 'jarFile.jar',
+        dependencyFiles: ['dependencyFiles1.jar', 'dependencyFiles2.mmdb'],
         mainFunction: 'com.cn.sre.main',
         pluginType: 'Transform',
       });
@@ -77,8 +112,8 @@ describe('Plugin test', () => {
           value: {
             name: '<IMG SRC=javascript:alert(\'XSS\')><script>alert(234)</script>',
             description: 'Description of Plugin-01',
-            jarFile: 'jarFile',
-            dependencyFiles: ['dependencyFiles1', 'dependencyFiles2'],
+            jarFile: 'jarFile.jar',
+            dependencyFiles: ['dependencyFiles1.jar', 'dependencyFiles2.mmdb'],
             mainFunction: 'com.cn.sre.main',
             pluginType: 'Transform',
           },
@@ -96,8 +131,8 @@ describe('Plugin test', () => {
       .send({
         name: 'Plugin-01',
         description: 'Description of Plugin-01',
-        jarFile: 'jarFile',
-        dependencyFiles: ['dependencyFiles1', 'dependencyFiles2'],
+        jarFile: 'jarFile.jar',
+        dependencyFiles: ['dependencyFiles1.jar', 'dependencyFiles2.mmdb'],
         mainFunction: 'com.cn.sre.main',
         pluginType: 'Transform',
       });
@@ -123,11 +158,6 @@ describe('Plugin test', () => {
         {
           location: 'body',
           msg: 'Value is empty.',
-          param: 'jarFile',
-        },
-        {
-          location: 'body',
-          msg: 'Value is empty.',
           param: 'mainFunction',
         },
         {
@@ -141,6 +171,11 @@ describe('Plugin test', () => {
           param: '',
           value: {},
         },
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: 'jarFile',
+        },
       ],
     });
     expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
@@ -153,8 +188,8 @@ describe('Plugin test', () => {
       .send({
         name: 'Plugin-01',
         description: 'Description of Plugin-01',
-        jarFile: 'jarFile',
-        dependencyFiles: ['dependencyFiles1', 'dependencyFiles2'],
+        jarFile: 'jarFile.jar',
+        dependencyFiles: ['dependencyFiles1.jar', 'dependencyFiles2.mmdb'],
         mainFunction: 'com.cn.sre.main',
         pluginType: 'Transform',
       });
@@ -183,7 +218,7 @@ describe('Plugin test', () => {
       .send({
         name: 'Plugin-01',
         description: 'Description of Plugin-01',
-        dependencyFiles: ['dependencyFiles1', 'dependencyFiles2'],
+        dependencyFiles: ['dependencyFiles1.jar', 'dependencyFiles2.mmdb'],
         pluginType: 'Transform',
       });
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
@@ -195,12 +230,12 @@ describe('Plugin test', () => {
         {
           location: 'body',
           msg: 'Value is empty.',
-          param: 'jarFile',
+          param: 'mainFunction',
         },
         {
           location: 'body',
           msg: 'Value is empty.',
-          param: 'mainFunction',
+          param: 'jarFile',
         },
       ],
     });


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

For security reasons, restrict the suffix of uploaded files (`jar, mmdb`)

Allow file suffix could edit by lambda environment variable: **ALLOW_UPLOADED_FILE_TYPES**

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module