### PR TITLE
chore: add unit test to auth lambda

### DIFF
--- a/src/control-plane/auth/authorizer.ts
+++ b/src/control-plane/auth/authorizer.ts
@@ -95,7 +95,6 @@ export class JWTAuthorizer {
     if (!openidConfiguration) {
       throw Error(ERR_OPENID_CONFIGURATION);
     }
-
     const client = jwksClient({
       jwksUri: openidConfiguration.jwks_uri,
       cache: true,
@@ -136,7 +135,7 @@ export class JWTAuthorizer {
     };
   }
 
-  public async getOpenidConfiguration(): Promise<OpenidConfiguration | undefined> {
+  private async getOpenidConfiguration(): Promise<OpenidConfiguration | undefined> {
     try {
       const localCache = nodeCache.get(this.openidConfigurationKey);
       if (localCache) {
@@ -166,7 +165,7 @@ export class JWTAuthorizer {
     }
   }
 
-  public async getOpenidConfigurationFromDDB(): Promise<OpenidConfiguration | undefined> {
+  private async getOpenidConfigurationFromDDB(): Promise<OpenidConfiguration | undefined> {
     try {
       const params: GetCommand = new GetCommand({
         TableName: this.dynamodbTableName,
@@ -185,7 +184,7 @@ export class JWTAuthorizer {
     }
   }
 
-  public async setOpenidConfigurationToDDB(key: string, data: OpenidConfiguration, ttl: number): Promise<void> {
+  private async setOpenidConfigurationToDDB(key: string, data: OpenidConfiguration, ttl: number): Promise<void> {
     try {
       const params: PutCommand = new PutCommand({
         TableName: this.dynamodbTableName,

--- a/src/control-plane/auth/authorizer.ts
+++ b/src/control-plane/auth/authorizer.ts
@@ -136,7 +136,7 @@ export class JWTAuthorizer {
     };
   }
 
-  private async getOpenidConfiguration(): Promise<OpenidConfiguration | undefined> {
+  public async getOpenidConfiguration(): Promise<OpenidConfiguration | undefined> {
     try {
       const localCache = nodeCache.get(this.openidConfigurationKey);
       if (localCache) {
@@ -166,7 +166,7 @@ export class JWTAuthorizer {
     }
   }
 
-  private async getOpenidConfigurationFromDDB(): Promise<OpenidConfiguration | undefined> {
+  public async getOpenidConfigurationFromDDB(): Promise<OpenidConfiguration | undefined> {
     try {
       const params: GetCommand = new GetCommand({
         TableName: this.dynamodbTableName,
@@ -185,7 +185,7 @@ export class JWTAuthorizer {
     }
   }
 
-  private async setOpenidConfigurationToDDB(key: string, data: OpenidConfiguration, ttl: number): Promise<void> {
+  public async setOpenidConfigurationToDDB(key: string, data: OpenidConfiguration, ttl: number): Promise<void> {
     try {
       const params: PutCommand = new PutCommand({
         TableName: this.dynamodbTableName,

--- a/src/control-plane/backend/lambda/api/middle-ware/auth-oidc.ts
+++ b/src/control-plane/backend/lambda/api/middle-ware/auth-oidc.ts
@@ -18,9 +18,6 @@ import { amznRequestContextHeader } from '../common/constants';
 import { logger } from '../common/powertools';
 import { getEmailFromRequestContext, isEmpty } from '../common/utils';
 
-const issuerInput = process.env.ISSUER ?? '';
-const authorizerTable = process.env.AUTHORIZER_TABLE ?? '';
-
 // Implement access log middleware function
 export async function authOIDC(req: express.Request, res: express.Response, next: express.NextFunction) {
   let operator = '';
@@ -36,6 +33,8 @@ export async function authOIDC(req: express.Request, res: express.Response, next
       });
     } else {
       try {
+        const issuerInput = process.env.ISSUER ?? '';
+        const authorizerTable = process.env.AUTHORIZER_TABLE ?? '';
         const authorizer = new JWTAuthorizer({
           issuer: issuerInput,
           dynamodbTableName: authorizerTable,

--- a/src/control-plane/backend/lambda/api/test/api/app.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/app.test.ts
@@ -14,10 +14,10 @@
 import request from 'supertest';
 import { getEmailFromRequestContext } from '../../common/utils';
 import { app, server } from '../../index';
+import 'aws-sdk-client-mock-jest';
 
 describe('App test', () => {
 
-  process.env.WITH_AUTH_MIDDLEWARE = 'true';
   process.env.HEALTH_CHECK_PATH='/';
   it('healthcheck', async () => {
     const res = await request(app)
@@ -37,14 +37,8 @@ describe('App test', () => {
     expect(getEmailFromRequestContext(context)).toEqual('abc@example.com');
     expect(getEmailFromRequestContext(context_unknown)).toEqual('');
   });
-
-  it('status 401 when no auth token provided.', async () => {
-    const res = await request(app)
-      .get('/projects');
-    expect(res.statusCode).toBe(401);
-  });
-
   it('content length check', async () => {
+    process.env.WITH_AUTH_MIDDLEWARE = 'true';
     const res1 = await request(app)
       .post('/api/plugin')
       .send({ name: Array(1024 * 300).join('a') });
@@ -67,5 +61,4 @@ describe('App test', () => {
     server.close();
     done();
   });
-
 });

--- a/src/control-plane/backend/lambda/api/test/api/auth.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/auth.test.ts
@@ -11,31 +11,11 @@
  *  and limitations under the License.
  */
 
-import fetch, { Response } from 'node-fetch';
 import request from 'supertest';
 import { app, server } from '../../index';
-import { JWTAuthorizer } from '../../middle-ware/authorizer';
-
-
-jest.mock('node-fetch');
-
-process.env.ISSUER = 'https://mock-server';
-process.env.AUTHORIZER_TABLE = 'AUTHORIZER_TABLE';
-process.env.WITH_AUTH_MIDDLEWARE = 'true';
 
 describe('Auth test', () => {
-  const mockFetch = fetch as jest.MockedFunction<typeof fetch>;
-
-  beforeAll(() => {
-    jest.spyOn(JWTAuthorizer.prototype, 'getOpenidConfigurationFromDDB')
-      .mockImplementation(() => Promise.resolve(undefined));
-    jest.spyOn(JWTAuthorizer.prototype, 'setOpenidConfigurationToDDB')
-      .mockImplementation(() => Promise.resolve());
-  });
-
-  afterAll(() => {
-    jest.restoreAllMocks();
-  });
+  process.env.WITH_AUTH_MIDDLEWARE = 'true';
 
   it('status 401 when no auth token provided.', async () => {
     const res = await request(app)
@@ -48,28 +28,6 @@ describe('Auth test', () => {
       .get('/api/dictionary')
       .set('Authorization', 'Bearer xxx');
     expect(res.statusCode).toBe(403);
-  });
-
-  it('auth success', async () => {
-    const TOKEN = 'eyJraWQiOiJQWFh0eGxCaXlISTJSZ3ZQUFY1VGxnTERqNkc0bHkxT0hnSitRZ2xvbnBnPSIsImFsZyI6IlJTMjU2In0.eyJhdF9oYXNoIjoiamhRTFU4c1FRMXgyWGFkdWhIWE5xdyIsInN1YiI6IjcxNmJlNTMwLTkwYzEtNzBkMi03NzUyLWYyMzM2OWMxOTg5NSIsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC51cy1lYXN0LTIuYW1hem9uYXdzLmNvbVwvdXMtZWFzdC0yX3FNcmZIUlRhaCIsImNvZ25pdG86dXNlcm5hbWUiOiI3MTZiZTUzMC05MGMxLTcwZDItNzc1Mi1mMjMzNjljMTk4OTUiLCJvcmlnaW5fanRpIjoiZDA5NjU2ZTEtNzI1NC00ODNlLWI0ZGQtZGIzYmQ1YzJhOGIyIiwiYXVkIjoiMXNhZXRjcDhwbDlsdTlrNTVmN2NyNTF0OGYiLCJldmVudF9pZCI6IjAwNGVhNDQ1LWU0YjctNDY5ZS1hMDk4LTQwYTU4Mjc5MDRlMiIsInRva2VuX3VzZSI6ImlkIiwiYXV0aF90aW1lIjoxNjg5MTQ4MzI5LCJleHAiOjE2ODkxNTU0NzYsImlhdCI6MTY4OTE1MTg3NiwianRpIjoiNzQ3MGQyOGQtMTgzZC00ZjdjLTgzMTMtZTZiMTk1NTQzNjJkIiwiZW1haWwiOiJtaW5nZmVpcUBhbWF6b24uY29tIn0.JZiSa52FhVd_dAVucOWpwRSwBKV4NQp1UpxuGfaeJwoepYhLkv89g0Pnr5tZdizLUNsdZwUyULvnlsHditXhYWfcs7nPRvgAJfU3HsCJkITxc31kfZbj3CETXujdfU7eX0_HFlfxEwzc9AuYbj3qL5oNpasLUNdKsZRQzMNt8hlcn5gLCtnudFsoseHbtw1hRkviIwgdhDItHB3xh2UO26F3NIaTPfpiM98-1NThWDAHlsJL5hz3MXCbyvIz5qfQETwryTBVnTPXShJRA8hALO0aSDWMKqBbAFctflssEFG1Cp12NhElqZ5s16Ut8JUaF6AwGC1oQROAQidhFIx1VQ';
-    const authorizer = new JWTAuthorizer({
-      issuer: 'https://mock-server',
-      dynamodbTableName: 'AUTHORIZER_TABLE',
-    });
-    mockFetch.mockReturnValue(
-      Promise.resolve({
-        ok: true,
-        status: 200,
-        json: () =>
-          Promise.resolve({
-            jwks_uri: 'https://mock-server/.well-known/jwks.json',
-          }),
-      } as Response),
-    );
-    const authResult = await authorizer.auth(TOKEN);
-    expect(mockFetch.mock.calls.length).toBe(1);
-    expect(mockFetch.mock.calls[0]).toEqual(['http://xxx/xxx', { method: 'GET' }]);
-    expect(authResult).toEqual(1);
   });
 
   afterAll((done) => {

--- a/src/control-plane/backend/lambda/api/test/api/auth.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/auth.test.ts
@@ -1,0 +1,79 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import fetch, { Response } from 'node-fetch';
+import request from 'supertest';
+import { app, server } from '../../index';
+import { JWTAuthorizer } from '../../middle-ware/authorizer';
+
+
+jest.mock('node-fetch');
+
+process.env.ISSUER = 'https://mock-server';
+process.env.AUTHORIZER_TABLE = 'AUTHORIZER_TABLE';
+process.env.WITH_AUTH_MIDDLEWARE = 'true';
+
+describe('Auth test', () => {
+  const mockFetch = fetch as jest.MockedFunction<typeof fetch>;
+
+  beforeAll(() => {
+    jest.spyOn(JWTAuthorizer.prototype, 'getOpenidConfigurationFromDDB')
+      .mockImplementation(() => Promise.resolve(undefined));
+    jest.spyOn(JWTAuthorizer.prototype, 'setOpenidConfigurationToDDB')
+      .mockImplementation(() => Promise.resolve());
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('status 401 when no auth token provided.', async () => {
+    const res = await request(app)
+      .get('/api/dictionary');
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('status 403 when error auth token.', async () => {
+    const res = await request(app)
+      .get('/api/dictionary')
+      .set('Authorization', 'Bearer xxx');
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('auth success', async () => {
+    const TOKEN = 'eyJraWQiOiJQWFh0eGxCaXlISTJSZ3ZQUFY1VGxnTERqNkc0bHkxT0hnSitRZ2xvbnBnPSIsImFsZyI6IlJTMjU2In0.eyJhdF9oYXNoIjoiamhRTFU4c1FRMXgyWGFkdWhIWE5xdyIsInN1YiI6IjcxNmJlNTMwLTkwYzEtNzBkMi03NzUyLWYyMzM2OWMxOTg5NSIsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC51cy1lYXN0LTIuYW1hem9uYXdzLmNvbVwvdXMtZWFzdC0yX3FNcmZIUlRhaCIsImNvZ25pdG86dXNlcm5hbWUiOiI3MTZiZTUzMC05MGMxLTcwZDItNzc1Mi1mMjMzNjljMTk4OTUiLCJvcmlnaW5fanRpIjoiZDA5NjU2ZTEtNzI1NC00ODNlLWI0ZGQtZGIzYmQ1YzJhOGIyIiwiYXVkIjoiMXNhZXRjcDhwbDlsdTlrNTVmN2NyNTF0OGYiLCJldmVudF9pZCI6IjAwNGVhNDQ1LWU0YjctNDY5ZS1hMDk4LTQwYTU4Mjc5MDRlMiIsInRva2VuX3VzZSI6ImlkIiwiYXV0aF90aW1lIjoxNjg5MTQ4MzI5LCJleHAiOjE2ODkxNTU0NzYsImlhdCI6MTY4OTE1MTg3NiwianRpIjoiNzQ3MGQyOGQtMTgzZC00ZjdjLTgzMTMtZTZiMTk1NTQzNjJkIiwiZW1haWwiOiJtaW5nZmVpcUBhbWF6b24uY29tIn0.JZiSa52FhVd_dAVucOWpwRSwBKV4NQp1UpxuGfaeJwoepYhLkv89g0Pnr5tZdizLUNsdZwUyULvnlsHditXhYWfcs7nPRvgAJfU3HsCJkITxc31kfZbj3CETXujdfU7eX0_HFlfxEwzc9AuYbj3qL5oNpasLUNdKsZRQzMNt8hlcn5gLCtnudFsoseHbtw1hRkviIwgdhDItHB3xh2UO26F3NIaTPfpiM98-1NThWDAHlsJL5hz3MXCbyvIz5qfQETwryTBVnTPXShJRA8hALO0aSDWMKqBbAFctflssEFG1Cp12NhElqZ5s16Ut8JUaF6AwGC1oQROAQidhFIx1VQ';
+    const authorizer = new JWTAuthorizer({
+      issuer: 'https://mock-server',
+      dynamodbTableName: 'AUTHORIZER_TABLE',
+    });
+    mockFetch.mockReturnValue(
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            jwks_uri: 'https://mock-server/.well-known/jwks.json',
+          }),
+      } as Response),
+    );
+    const authResult = await authorizer.auth(TOKEN);
+    expect(mockFetch.mock.calls.length).toBe(1);
+    expect(mockFetch.mock.calls[0]).toEqual(['http://xxx/xxx', { method: 'GET' }]);
+    expect(authResult).toEqual(1);
+  });
+
+  afterAll((done) => {
+    server.close();
+    done();
+  });
+});

--- a/test/control-plane/lambda/auth.test.ts
+++ b/test/control-plane/lambda/auth.test.ts
@@ -1,0 +1,124 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  GetCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { mockClient } from 'aws-sdk-client-mock';
+import jwt from 'jsonwebtoken';
+import { JwksClient, RsaSigningKey } from 'jwks-rsa';
+import fetch, { Response } from 'node-fetch';
+import { JWTAuthorizer } from '../../../src/control-plane/auth/authorizer';
+import 'aws-sdk-client-mock-jest';
+
+jest.mock('jsonwebtoken');
+jest.mock('node-fetch');
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+describe('Auth test', () => {
+  const mockFetch = fetch as jest.MockedFunction<typeof fetch>;
+
+  beforeEach(() => {
+    ddbMock.reset();
+    mockFetch.mockClear();
+  });
+
+  it('auth success', async () => {
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(GetCommand).resolves({});
+
+    const TOKEN = 'Bearer eyJraWQiOiJQWFh0eGxCaXlISTJSZ3ZQUFY1VGxnTERqNkc0bHkxT0hnSitRZ2xvbnBnPSIsImFsZyI6IlJTMjU2In0.eyJhdF9oYXNoIjoiamhRTFU4c1FRMXgyWGFkdWhIWE5xdyIsInN1YiI6IjcxNmJlNTMwLTkwYzEtNzBkMi03NzUyLWYyMzM2OWMxOTg5NSIsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC51cy1lYXN0LTIuYW1hem9uYXdzLmNvbVwvdXMtZWFzdC0yX3FNcmZIUlRhaCIsImNvZ25pdG86dXNlcm5hbWUiOiI3MTZiZTUzMC05MGMxLTcwZDItNzc1Mi1mMjMzNjljMTk4OTUiLCJvcmlnaW5fanRpIjoiZDA5NjU2ZTEtNzI1NC00ODNlLWI0ZGQtZGIzYmQ1YzJhOGIyIiwiYXVkIjoiMXNhZXRjcDhwbDlsdTlrNTVmN2NyNTF0OGYiLCJldmVudF9pZCI6IjAwNGVhNDQ1LWU0YjctNDY5ZS1hMDk4LTQwYTU4Mjc5MDRlMiIsInRva2VuX3VzZSI6ImlkIiwiYXV0aF90aW1lIjoxNjg5MTQ4MzI5LCJleHAiOjE2ODkxNTU0NzYsImlhdCI6MTY4OTE1MTg3NiwianRpIjoiNzQ3MGQyOGQtMTgzZC00ZjdjLTgzMTMtZTZiMTk1NTQzNjJkIiwiZW1haWwiOiJtaW5nZmVpcUBhbWF6b24uY29tIn0.JZiSa52FhVd_dAVucOWpwRSwBKV4NQp1UpxuGfaeJwoepYhLkv89g0Pnr5tZdizLUNsdZwUyULvnlsHditXhYWfcs7nPRvgAJfU3HsCJkITxc31kfZbj3CETXujdfU7eX0_HFlfxEwzc9AuYbj3qL5oNpasLUNdKsZRQzMNt8hlcn5gLCtnudFsoseHbtw1hRkviIwgdhDItHB3xh2UO26F3NIaTPfpiM98-1NThWDAHlsJL5hz3MXCbyvIz5qfQETwryTBVnTPXShJRA8hALO0aSDWMKqBbAFctflssEFG1Cp12NhElqZ5s16Ut8JUaF6AwGC1oQROAQidhFIx1VQ';
+    const authorizer = new JWTAuthorizer({
+      issuer: 'https://cognito-idp.us-east-2.amazonaws.com/us-east-2_xxx',
+      dynamodbTableName: 'AUTHORIZER_TABLE',
+    });
+
+    // Mock fetch jwks uri
+    const jwks_uri = jest.fn() as jest.MockedFunction<any>;
+    jwks_uri.mockResolvedValue({
+      issuer: 'https://cognito-idp.us-east-2.amazonaws.com/us-east-2_xxx',
+      jwks_uri: 'https://cognito-idp.us-east-2.amazonaws.com/us-east-2_xxx/.well-known/jwks.json',
+    });
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: jwks_uri } as Response);
+
+    // Mock fetch SigningKey
+    jest.spyOn(JwksClient.prototype, 'getSigningKey').mockImplementation(() => {
+      return new MockRsaSigningKey('KID', 'RS256', 'rsaPublicKey');
+    });
+
+    // Mock jwt
+    const decode = jest.spyOn(jwt, 'decode');
+    decode.mockImplementation(() => ({
+      header: { kid: 'PXXtxlBiyHI2RgvPPV5TlgLDj6G4ly1OHgJ+Qglonpg=', alg: 'RS256' },
+      payload: {
+        at_hash: 'jhQLU8sQQ1x2XaduhHXNqw',
+        sub: '716be530-90c1-70d2-7752-f23369c19895',
+        iss: 'https://cognito-idp.us-east-2.amazonaws.com/us-east-2_xxx',
+        origin_jti: 'd09656e1-7254-483e-b4dd-db3bd5c2a8b2',
+        aud: '1saetcp8pl9lu9k55f7cr51t8f',
+        event_id: '004ea445-e4b7-469e-a098-40a5827904e2',
+        token_use: 'id',
+        auth_time: 1689148329,
+        exp: 1689155476,
+        iat: 1689151876,
+        jti: '7470d28d-183d-4f7c-8313-e6b19554362d',
+        email: 'test@fake.com',
+      },
+      signature: 'JZiSa52FhVd_dAVucOWpwRSwBKV4NQp1UpxuGfaeJwoepYhLkv89g0Pnr5tZdizLUNsdZwUyULvnlsHditXhYWfcs7nPRvgAJfU3HsCJkITxc31kfZbj3CETXujdfU7eX0_HFlfxEwzc9AuYbj3qL5oNpasLUNdKsZRQzMNt8hlcn5gLCtnudFsoseHbtw1hRkviIwgdhDItHB3xh2UO26F3NIaTPfpiM98-1NThWDAHlsJL5hz3MXCbyvIz5qfQETwryTBVnTPXShJRA8hALO0aSDWMKqBbAFctflssEFG1Cp12NhElqZ5s16Ut8JUaF6AwGC1oQROAQidhFIx1VQ',
+    }));
+    const verify = jest.spyOn(jwt, 'verify');
+    verify.mockImplementation(() => ({
+      iss: 'iss',
+      sub: 'sub',
+      aud: 'aud',
+      exp: 0,
+      nbf: 0,
+      iat: 0,
+      jti: 'jti',
+    }));
+
+    const authResult = await authorizer.auth(TOKEN);
+    expect(mockFetch.mock.calls.length).toBe(1);
+    expect(mockFetch.mock.calls[0]).toEqual(['https://cognito-idp.us-east-2.amazonaws.com/us-east-2_xxx/.well-known/openid-configuration', { method: 'GET' }]);
+    expect(authResult).toEqual({
+      jwtPayload: {
+        aud: 'aud',
+        exp: 0,
+        iat: 0,
+        iss: 'iss',
+        jti: 'jti',
+        nbf: 0,
+        sub: 'sub',
+      },
+      success: true,
+    });
+  });
+
+  class MockRsaSigningKey implements RsaSigningKey {
+    kid: string;
+    alg: string;
+    rsaPublicKey: string;
+
+    constructor(kid: string, alg: string, rsaPublicKey: string) {
+      this.kid = kid;
+      this.alg = alg;
+      this.rsaPublicKey = rsaPublicKey;
+    }
+    getPublicKey() {
+      return 'JZiSa52FhVd_dAVucOWpwRSwBKV4NQp1UpxuGfaeJwoepYhLkv89g0Pnr5tZdizLUNsdZwUyULvnlsHditXhYWfcs7nPRvgAJfU3HsCJkITxc31kfZbj3CETXujdfU7eX0_HFlfxEwzc9AuYbj3qL5oNpasLUNdKsZRQzMNt8hlcn5gLCtnudFsoseHbtw1hRkviIwgdhDItHB3xh2UO26F3NIaTPfpiM98-1NThWDAHlsJL5hz3MXCbyvIz5qfQETwryTBVnTPXShJRA8hALO0aSDWMKqBbAFctflssEFG1Cp12NhElqZ5s16Ut8JUaF6AwGC1oQROAQidhFIx1VQ';
+    }
+  }
+});

--- a/test/control-plane/lambda/auth.test.ts
+++ b/test/control-plane/lambda/auth.test.ts
@@ -75,7 +75,7 @@ describe('Auth test', () => {
         exp: 1689155476,
         iat: 1689151876,
         jti: '7470d28d-183d-4f7c-8313-e6b19554362d',
-        email: 'test@fake.com',
+        email: 'fake@example.com',
       },
       signature: 'JZiSa52FhVd_dAVucOWpwRSwBKV4NQp1UpxuGfaeJwoepYhLkv89g0Pnr5tZdizLUNsdZwUyULvnlsHditXhYWfcs7nPRvgAJfU3HsCJkITxc31kfZbj3CETXujdfU7eX0_HFlfxEwzc9AuYbj3qL5oNpasLUNdKsZRQzMNt8hlcn5gLCtnudFsoseHbtw1hRkviIwgdhDItHB3xh2UO26F3NIaTPfpiM98-1NThWDAHlsJL5hz3MXCbyvIz5qfQETwryTBVnTPXShJRA8hALO0aSDWMKqBbAFctflssEFG1Cp12NhElqZ5s16Ut8JUaF6AwGC1oQROAQidhFIx1VQ',
     }));


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module