### PR TITLE
fix: use stack parameter instead of fixed pattern as principal value …

### DIFF
--- a/frontend/src/pages/pipelines/create/CreatePipeline.tsx
+++ b/frontend/src/pages/pipelines/create/CreatePipeline.tsx
@@ -2063,6 +2063,7 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
               changeQuickSightSelectedUser={(user) => {
                 setQuickSightUserEmptyError(false);
                 setPipelineInfo((prev) => {
+                  const userObj = JSON.parse(user.value ?? '{}');
                   return {
                     ...prev,
                     selectedQuickSightUser: user,
@@ -2070,7 +2071,8 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
                       ...prev.reporting,
                       quickSight: {
                         ...prev.reporting.quickSight,
-                        user: user.value || '',
+                        user: userObj.userName,
+                        arn: userObj.arn
                       },
                     },
                   };
@@ -2517,7 +2519,7 @@ const CreatePipeline: React.FC<CreatePipelineProps> = (
         )[0];
         pipelineInfo.selectedQuickSightUser = {
           label: selectUser.userName,
-          value: selectUser.userName,
+          value: JSON.stringify(selectUser),
           description: selectUser.email,
           labelTag: selectUser.role,
         };

--- a/frontend/src/pages/pipelines/create/steps/Reporting.tsx
+++ b/frontend/src/pages/pipelines/create/steps/Reporting.tsx
@@ -127,13 +127,13 @@ const Reporting: React.FC<ReportingProps> = (props: ReportingProps) => {
       const { success, data }: ApiResponse<QuickSightUserResponse[]> =
         await getQuickSightUsers();
       if (success) {
-        const mskOptions: SelectProps.Options = data.map((element) => ({
+        const userOptions: SelectProps.Options = data.map((element) => ({
           label: element.userName,
-          value: element.userName,
+          value: JSON.stringify(element),
           description: element.email,
           labelTag: element.role,
         }));
-        setQuickSightRoleOptions(mskOptions);
+        setQuickSightRoleOptions(userOptions);
         setLoadingUsers(false);
       }
     } catch (error) {

--- a/frontend/src/ts/init.ts
+++ b/frontend/src/ts/init.ts
@@ -143,6 +143,7 @@ export const INIT_EXT_PIPELINE_DATA: IExtPipeline = {
     quickSight: {
       accountName: '',
       user: '',
+      arn: '',
     },
   },
 

--- a/frontend/src/types/pipeline.d.ts
+++ b/frontend/src/types/pipeline.d.ts
@@ -150,6 +150,7 @@ declare global {
       quickSight: {
         accountName: string;
         user: string;
+        arn: string;
       };
     };
     status?: {

--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -232,6 +232,7 @@ export const SCHEDULE_EXPRESSION_PATTERN =
 
 export const CORS_PATTERN = `^$|\\*$|^(${DOMAIN_NAME_PATTERN}(,\\s*${DOMAIN_NAME_PATTERN})*)$`;
 export const XSS_PATTERN = '<(?:"[^"]*"[\'"]*|\'[^\']*\'[\'"]*|[^\'">])+(?<!/\s*)>';
+export const REGION_PATTERN = '[a-z]{2}-[a-z0-9]{1,10}-[0-9]{1}';
 
 // cloudformation parameters
 export const PARAMETER_GROUP_LABEL_VPC = 'VPC Information';

--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -171,6 +171,7 @@ export interface Reporting {
   readonly quickSight?: {
     readonly accountName: string;
     readonly user: string;
+    readonly arn: string;
     readonly namespace?: string;
     readonly vpcConnection?: string;
   };

--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -1068,6 +1068,9 @@ export class CReportingStack extends JSONObject {
     QuickSightNamespaceParam?: string;
 
   @JSONObject.required
+    QuickSightPrincipalParam?: string;
+
+  @JSONObject.required
     RedshiftDBParam?: string;
 
   @JSONObject.required
@@ -1138,6 +1141,7 @@ export class CReportingStack extends JSONObject {
 
       QuickSightUserParam: pipeline.reporting?.quickSight?.user,
       QuickSightNamespaceParam: pipeline.reporting?.quickSight?.namespace,
+      QuickSightPrincipalParam: pipeline.reporting?.quickSight?.arn,
       RedshiftDBParam: pipeline.projectId,
       RedShiftDBSchemaParam: resources.appIds?.join(','),
       QuickSightVpcConnectionSubnetParam: resources.quickSightSubnetIds?.join(','),

--- a/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
@@ -601,6 +601,7 @@ export const KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_QUICKSIGHT_PIPELINE: I
     quickSight: {
       accountName: 'clickstream-acc-xxx',
       user: 'Admin/clickstream-user-xxx',
+      arn: 'arn:aws:quicksight:us-west-2:555555555555:user/default/clickstream-user-xxx',
     },
   },
 };
@@ -629,6 +630,7 @@ export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_QUICKSIGHT_PIPELINE: IPipeline
     quickSight: {
       accountName: 'clickstream-acc-xxx',
       user: 'clickstream-user-xxx@example.com',
+      arn: 'arn:aws:quicksight:us-west-2:555555555555:user/default/clickstream-user-xxx',
     },
   },
 };

--- a/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
@@ -776,6 +776,10 @@ const BASE_REPORTING_PARAMETERS = [
     ParameterValue: 'default',
   },
   {
+    ParameterKey: 'QuickSightPrincipalParam',
+    ParameterValue: 'arn:aws:quicksight:us-west-2:555555555555:user/default/clickstream-user-xxx',
+  },
+  {
     ParameterKey: 'RedshiftDBParam',
     ParameterValue: 'project_8888_8888',
   },
@@ -802,7 +806,7 @@ const BASE_REPORTING_PARAMETERS = [
 ];
 
 export const REPORTING_WITH_PROVISIONED_REDSHIFT_PARAMETERS = [
-  ...BASE_REPORTING_PARAMETERS.slice(0, 5),
+  ...BASE_REPORTING_PARAMETERS.slice(0, 6),
   {
     ParameterKey: 'RedshiftEndpointParam',
     ParameterValue: 'https://redshift/xxx/yyy',
@@ -811,7 +815,7 @@ export const REPORTING_WITH_PROVISIONED_REDSHIFT_PARAMETERS = [
     ParameterKey: 'RedshiftPortParam',
     ParameterValue: '5002',
   },
-  ...BASE_REPORTING_PARAMETERS.slice(5, BASE_REPORTING_PARAMETERS.length),
+  ...BASE_REPORTING_PARAMETERS.slice(6, BASE_REPORTING_PARAMETERS.length),
 ];
 
 export const REPORTING_WITH_NEW_REDSHIFT_PARAMETERS = [
@@ -822,6 +826,10 @@ export const REPORTING_WITH_NEW_REDSHIFT_PARAMETERS = [
   {
     ParameterKey: 'QuickSightNamespaceParam',
     ParameterValue: 'default',
+  },
+  {
+    ParameterKey: 'QuickSightPrincipalParam',
+    ParameterValue: 'arn:aws:quicksight:us-west-2:555555555555:user/default/clickstream-user-xxx',
   },
   {
     ParameterKey: 'RedshiftDBParam',

--- a/src/data-reporting-quicksight-stack.ts
+++ b/src/data-reporting-quicksight-stack.ts
@@ -80,11 +80,6 @@ export class DataReportingQuickSightStack extends Stack {
     vPCConnectionResource.node.addDependency(vpcConnectionCreateRole);
     const vpcConnectionArn = vPCConnectionResource.getAtt('Arn').toString();
 
-    const principalPrefix = `arn:${Aws.PARTITION}:quicksight:us-east-1:${Aws.ACCOUNT_ID}`;
-    const quickSightNamespace = stackParames.quickSightNamespaceParam.valueAsString;
-    const quickSightUser = stackParames.quickSightUserParam.valueAsString;
-    const principalArn = `${principalPrefix}:user/${quickSightNamespace}/${quickSightUser}`;
-
     const useTemplateArnCondition = new CfnCondition(
       this,
       'useTemplateArnCondition',
@@ -100,7 +95,7 @@ export class DataReportingQuickSightStack extends Stack {
       templateId,
       awsAccountId: Aws.ACCOUNT_ID,
       permissions: [{
-        principal: principalArn,
+        principal: stackParames.quickSightPrincipalParam.valueAsString,
         actions: [
           'quicksight:UpdateTemplatePermissions',
           'quicksight:DescribeTemplatePermissions',
@@ -145,7 +140,7 @@ export class DataReportingQuickSightStack extends Stack {
       },
       permissions: [
         {
-          principal: principalArn,
+          principal: stackParames.quickSightPrincipalParam.valueAsString,
           actions: [
             'quicksight:UpdateDataSourcePermissions',
             'quicksight:DescribeDataSourcePermissions',

--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -57,19 +57,13 @@ export type MustacheParamType = {
 export const handler = async (event: ResourceEvent, _context: Context): Promise<CdkCustomResourceResponse|void> => {
   const props = event.ResourceProperties as QuicksightCustomResourceLabmdaPropsType;
   const region = props.awsRegion;
-  const partition = props.awsPartition;
   const quickSight = new QuickSight({
     region,
     ...aws_sdk_client_common_config,
   });
 
   const awsAccountId = props.awsAccountId;
-  const namespace: string = props.quickSightNamespace;
-  const quickSightUser: string = props.quickSightUser;
-  let principalArn = `arn:${partition}:quicksight:us-east-1:${awsAccountId}:user/${namespace}/${quickSightUser}`;
-  if (props.quickSightPrincipalArn !== '') {
-    principalArn = props.quickSightPrincipalArn;
-  }
+  const principalArn = props.quickSightPrincipalArn;
 
   if (event.RequestType === 'Create') {
     return _onCreate(quickSight, awsAccountId, principalArn, event);

--- a/src/reporting/parameter.ts
+++ b/src/reporting/parameter.ts
@@ -72,7 +72,6 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
   const quickSightPrincipalParam = new CfnParameter(scope, 'QuickSightPrincipalParam', {
     description: 'Arn of the QuickSight principal, QuickSight resource will be owned by this pricipal.',
     type: 'String',
-    default: '',
   });
   labels[quickSightPrincipalParam.logicalId] = {
     default: 'QuickSight Principal Arn',

--- a/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
+++ b/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
@@ -627,27 +627,7 @@ describe('DataReportingQuickSightStack resource test', () => {
           'quicksight:UpdateTemplate',
         ],
         Principal: {
-          'Fn::Join': [
-            '',
-            [
-              'arn:',
-              {
-                Ref: 'AWS::Partition',
-              },
-              ':quicksight:us-east-1:',
-              {
-                Ref: 'AWS::AccountId',
-              },
-              ':user/',
-              {
-                Ref: 'QuickSightNamespaceParam',
-              },
-              '/',
-              {
-                Ref: 'QuickSightUserParam',
-              },
-            ],
-          ],
+          Ref: 'QuickSightPrincipalParam',
         },
       },
     ],
@@ -795,27 +775,7 @@ describe('DataReportingQuickSightStack resource test', () => {
           'quicksight:UpdateDataSource',
         ],
         Principal: {
-          'Fn::Join': [
-            '',
-            [
-              'arn:',
-              {
-                Ref: 'AWS::Partition',
-              },
-              ':quicksight:us-east-1:',
-              {
-                Ref: 'AWS::AccountId',
-              },
-              ':user/',
-              {
-                Ref: 'QuickSightNamespaceParam',
-              },
-              '/',
-              {
-                Ref: 'QuickSightUserParam',
-              },
-            ],
-          ],
+          Ref: 'QuickSightPrincipalParam',
         },
       },
     ],


### PR DESCRIPTION
…when create QuickSight report (#15)


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module