### PR TITLE
fix: enable retry for KDS

### DIFF
--- a/src/ingestion-server/server/images/vector/Dockerfile
+++ b/src/ingestion-server/server/images/vector/Dockerfile
@@ -1,5 +1,5 @@
 ARG PLATFORM_ARG
-FROM --platform=$PLATFORM_ARG timberio/vector:0.29.1-debian
+FROM --platform=$PLATFORM_ARG timberio/vector:0.31.0-debian
 
 ENV AWS_REGION='__NOT_SET__'
 ENV AWS_MSK_BROKERS='__NOT_SET__'

--- a/src/ingestion-server/server/images/vector/config/vector-kinesis-ack.toml
+++ b/src/ingestion-server/server/images/vector/config/vector-kinesis-ack.toml
@@ -8,5 +8,9 @@ region = "%%AWS_REGION%%"
 stream_name = "%%AWS_KINESIS_STREAM_NAME%%"
 
 acknowledgements.enabled = true
+request_retry_partial = true
+request.retry_attempts = 4
+request.retry_max_duration_secs = 3
+
   [sinks.kinesis_sink.encoding]
   codec = "json"


### PR DESCRIPTION
----

## Summary

upgrade vector to 0.31.0 version and enable retry for KDS

relate to #9 

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module