### PR TITLE
chore: change md5 hash to sha256

### DIFF
--- a/src/analytics/lambdas/custom-resource/create-schemas.ts
+++ b/src/analytics/lambdas/custom-resource/create-schemas.ts
@@ -11,7 +11,6 @@
  *  and limitations under the License.
  */
 
-import crypto from 'crypto';
 import { RedshiftDataClient } from '@aws-sdk/client-redshift-data';
 import {
   CreateSecretCommand,
@@ -395,7 +394,7 @@ const createDatabaseBIUser = async (redshiftClient: RedshiftDataClient, credenti
   props: CreateDatabaseAndSchemas) => {
   try {
     await executeStatementsWithWait(redshiftClient, [
-      `CREATE USER ${credential.username} PASSWORD 'md5${md5Hash(credential.password+credential.username)}'`,
+      `CREATE USER ${credential.username} PASSWORD 'sha256|${credential.password}'`,
     ], props.serverlessRedshiftProps, props.provisionedRedshiftProps,
     props.serverlessRedshiftProps?.databaseName ?? props.provisionedRedshiftProps?.databaseName, false);
   } catch (err) {
@@ -404,11 +403,6 @@ const createDatabaseBIUser = async (redshiftClient: RedshiftDataClient, credenti
     }
     throw err;
   }
-};
-
-// write a function to cacluate md5 hash of string
-const md5Hash = (str: string) => {
-  return crypto.createHash('md5').update(str).digest('hex');
 };
 
 const createSchemasInRedshift = async (redshiftClient: RedshiftDataClient, sqlStatements: string[], props: CreateDatabaseAndSchemas) => {
@@ -489,5 +483,3 @@ function getAppUpdateProps(props: ResourcePropertiesType, oldProps: ResourceProp
     oldSchemaSqlArray: oldSchemaSqlArray,
   };
 }
-
-

--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -752,7 +752,7 @@ const updateDashboard = async (quickSight: QuickSight, awsAccountId: string, dat
 const buildDashBoardId = function (databaseName: string, schema: string): Identifer {
   const schemaIdentifer = truncateString(schema, 40);
   const databaseIdentifer = truncateString(databaseName, 40);
-  const suffix = crypto.createHash('md5').update(`${databaseName}${schema}`).digest('hex').substring(0, 8);
+  const suffix = crypto.createHash('sha256').update(`${databaseName}${schema}`).digest('hex').substring(0, 8);
   return {
     id: `clickstream_dashboard_${databaseIdentifer}_${schemaIdentifer}_${suffix}`,
     idSuffix: suffix,
@@ -764,7 +764,7 @@ const buildDashBoardId = function (databaseName: string, schema: string): Identi
 const buildAnalysisId = function (databaseName: string, schema: string): Identifer {
   const schemaIdentifer = truncateString(schema, 40);
   const databaseIdentifer = truncateString(databaseName, 40);
-  const suffix = crypto.createHash('md5').update(`${databaseName}${schema}`).digest('hex').substring(0, 8);
+  const suffix = crypto.createHash('sha256').update(`${databaseName}${schema}`).digest('hex').substring(0, 8);
   return {
     id: `clickstream_analysis_${databaseIdentifer}_${schemaIdentifer}_${suffix}`,
     idSuffix: suffix,
@@ -777,7 +777,7 @@ const buildDataSetId = function (databaseName: string, schema: string, tableName
   const tableNameIdentifer = truncateString(tableName.replace(/clickstream_/g, ''), 40);
   const schemaIdentifer = truncateString(schema, 15);
   const databaseIdentifer = truncateString(databaseName, 15);
-  const suffix = crypto.createHash('md5').update(`${databaseName}${schema}${tableName}`).digest('hex').substring(0, 8);
+  const suffix = crypto.createHash('sha256').update(`${databaseName}${schema}${tableName}`).digest('hex').substring(0, 8);
   return {
     id: `clickstream_dataset_${databaseIdentifer}_${schemaIdentifer}_${tableNameIdentifer}_${suffix}`,
     idSuffix: suffix,

--- a/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
@@ -358,7 +358,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
     lambdaMock.on(ListTagsCommand).resolves({
       Tags: { tag_key: 'tag_value' },
     });
-    const regex = new RegExp(`^CREATE USER ${biUserNamePrefix}[a-z0-9]{8} PASSWORD 'md5[a-f0-9]{32}'$`);
+    const regex = new RegExp(`^CREATE USER ${biUserNamePrefix}[a-z0-9]{8} PASSWORD 'sha256|[a-zA-Z0-9!#$%^&-_=+|]{32}'$`);
     redshiftDataMock.on(ExecuteStatementCommand).resolvesOnce({ Id: 'Id-1' })
       .callsFakeOnce(input => {
         if (input as ExecuteStatementCommandInput && regex.test(input.Sql)) {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

change all md5 hash fun to sha256 to improve security level

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module