### PR TITLE
fix: replace api function resource id

### DIFF
--- a/src/control-plane/backend/click-stream-api.ts
+++ b/src/control-plane/backend/click-stream-api.ts
@@ -274,8 +274,8 @@ export class ClickStreamApiConstruct extends Construct {
     });
     props.stackWorkflowS3Bucket.grantPut(uploadRole, `${props.pluginPrefix}*`);
 
-    this.clickStreamApiFunction = new Function(this, 'ClickStreamApiFunction', {
-      description: 'Lambda function for api of solution Click Stream Analytics on AWS',
+    this.clickStreamApiFunction = new Function(this, 'ApiFunction', {
+      description: 'Lambda function for api of solution Clickstream Analytics on AWS',
       code: Code.fromDockerBuild(path.join(__dirname, '../../../'), {
         file: 'Dockerfile.backend.build',
       }),

--- a/test/control-plane/alb-control-plane-stack.test.ts
+++ b/test/control-plane/alb-control-plane-stack.test.ts
@@ -240,7 +240,7 @@ describe('ALBPotalStack - exist VPC - private - no custom domain', () => {
         'ClickStreamApiBatchInsertDDBCustomResourceDicInitCustomResourceProviderframeworkonEventCEE52DB5',
         'ClickStreamApiStackActionStateMachineActionFunction8314F7B4',
         'ClickStreamApiStackWorkflowStateMachineWorkflowFunctionD5F091A8',
-        'ClickStreamApiClickStreamApiFunction8C843168',
+        'ClickStreamApiApiFunction684A4D61',
         'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A',
       ]);
     template.hasResourceProperties('AWS::Lambda::Function', {

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -113,7 +113,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
         'testClickStreamALBApiBatchInsertDDBCustomResourceDicInitCustomResourceProviderframeworkonEventFB731F8E',
         'testClickStreamALBApiStackActionStateMachineActionFunction9CC75763',
         'testClickStreamALBApiStackWorkflowStateMachineWorkflowFunctionE7DBCFDE',
-        'testClickStreamALBApiClickStreamApiFunction4A01DB3A',
+        'testClickStreamALBApiApiFunction9890103B',
         'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A',
       ]);
 
@@ -121,7 +121,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
       Architectures: [
         'x86_64',
       ],
-      Description: 'Lambda function for api of solution Click Stream Analytics on AWS',
+      Description: 'Lambda function for api of solution Clickstream Analytics on AWS',
       Environment: {
         Variables: {
           CLICK_STREAM_TABLE_NAME: {
@@ -224,7 +224,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
       Architectures: [
         'x86_64',
       ],
-      Description: 'Lambda function for api of solution Click Stream Analytics on AWS',
+      Description: 'Lambda function for api of solution Clickstream Analytics on AWS',
     });
 
   });
@@ -248,7 +248,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
       Architectures: [
         'x86_64',
       ],
-      Description: 'Lambda function for api of solution Click Stream Analytics on AWS',
+      Description: 'Lambda function for api of solution Clickstream Analytics on AWS',
     });
   });
 
@@ -1001,7 +1001,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
       Architectures: [
         'x86_64',
       ],
-      Description: 'Lambda function for api of solution Click Stream Analytics on AWS',
+      Description: 'Lambda function for api of solution Clickstream Analytics on AWS',
       Environment: {
         Variables: {
           AWS_LAMBDA_EXEC_WRAPPER: '/opt/bootstrap',
@@ -1082,7 +1082,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
       Architectures: [
         'x86_64',
       ],
-      Description: 'Lambda function for api of solution Click Stream Analytics on AWS',
+      Description: 'Lambda function for api of solution Clickstream Analytics on AWS',
     });
 
   });
@@ -1111,7 +1111,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
           QUICKSIGHT_CONTROL_PLANE_REGION: 'cn-north-1',
         },
       },
-      Description: 'Lambda function for api of solution Click Stream Analytics on AWS',
+      Description: 'Lambda function for api of solution Clickstream Analytics on AWS',
     });
 
   });
@@ -1161,7 +1161,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
               ':lambda:path/2015-03-31/functions/',
               {
                 'Fn::GetAtt': [
-                  'testClickStreamCloudfrontApiClickStreamApiFunction25FEE34E',
+                  'testClickStreamCloudfrontApiApiFunctionD30AC413',
                   'Arn',
                 ],
               },
@@ -1201,7 +1201,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
               ':lambda:path/2015-03-31/functions/',
               {
                 'Fn::GetAtt': [
-                  'testClickStreamCloudfrontApiClickStreamApiFunction25FEE34E',
+                  'testClickStreamCloudfrontApiApiFunctionD30AC413',
                   'Arn',
                 ],
               },
@@ -1246,7 +1246,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
         Format: '$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId',
       },
       DeploymentId: {
-        Ref: 'testClickStreamCloudfrontApiClickStreamApiDeploymentD81E884Adde54841819a5cb2bcfcf208847bd745',
+        Ref: 'testClickStreamCloudfrontApiClickStreamApiDeploymentD81E884A50b4b46e84c4d3354fa978ebcd6c1d08',
       },
       MethodSettings: [
         {

--- a/test/control-plane/cloudfront-control-plane-stack.test.ts
+++ b/test/control-plane/cloudfront-control-plane-stack.test.ts
@@ -403,9 +403,9 @@ describe('CloudFrontS3PotalStack', () => {
     expect(findResourcesName(commonTemplate, 'AWS::Lambda::Function').sort())
       .toEqual([
         'AuthorizerFunctionB4DBAA43',
+        'ClickStreamApiApiFunction684A4D61',
         'ClickStreamApiBatchInsertDDBCustomResourceDicInitCustomResourceFunction50F646E7',
         'ClickStreamApiBatchInsertDDBCustomResourceDicInitCustomResourceProviderframeworkonEventCEE52DB5',
-        'ClickStreamApiClickStreamApiFunction8C843168',
         'ClickStreamApiStackActionStateMachineActionFunction8314F7B4',
         'ClickStreamApiStackWorkflowStateMachineWorkflowFunctionD5F091A8',
         'CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536',
@@ -432,9 +432,9 @@ describe('CloudFrontS3PotalStack', () => {
     expect(findResourcesName(template, 'AWS::Lambda::Function').sort())
       .toEqual([
         'AuthorizerFunctionB4DBAA43',
+        'ClickStreamApiApiFunction684A4D61',
         'ClickStreamApiBatchInsertDDBCustomResourceDicInitCustomResourceFunction50F646E7',
         'ClickStreamApiBatchInsertDDBCustomResourceDicInitCustomResourceProviderframeworkonEventCEE52DB5',
-        'ClickStreamApiClickStreamApiFunction8C843168',
         'ClickStreamApiStackActionStateMachineActionFunction8314F7B4',
         'ClickStreamApiStackWorkflowStateMachineWorkflowFunctionD5F091A8',
         'CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536',
@@ -504,9 +504,9 @@ describe('CloudFrontS3PotalStack', () => {
     expect(findResourcesName(template, 'AWS::Lambda::Function').sort())
       .toEqual([
         'AuthorizerFunctionB4DBAA43',
+        'ClickStreamApiApiFunction684A4D61',
         'ClickStreamApiBatchInsertDDBCustomResourceDicInitCustomResourceFunction50F646E7',
         'ClickStreamApiBatchInsertDDBCustomResourceDicInitCustomResourceProviderframeworkonEventCEE52DB5',
-        'ClickStreamApiClickStreamApiFunction8C843168',
         'ClickStreamApiStackActionStateMachineActionFunction8314F7B4',
         'ClickStreamApiStackWorkflowStateMachineWorkflowFunctionD5F091A8',
         'CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module