### PR TITLE
fix: delete CompatibleArchitectures for lambda layer

### DIFF
--- a/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
+++ b/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
@@ -12,7 +12,7 @@
  */
 
 import path from 'path';
-import { LayerVersion, Runtime, Code, Architecture } from 'aws-cdk-lib/aws-lambda';
+import { LayerVersion, Runtime, Code } from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
 
 export interface LambdaAdapterLayerProps {
@@ -26,7 +26,6 @@ export class LambdaAdapterLayer extends LayerVersion {
     const defaultVersion = props?.arch ?? '0.7.0';
     const defaultPlatform = props?.platform ?? 'linux/amd64';
     const defaultArch = props?.arch ?? 'x86_64';
-    const architecture = defaultArch === 'aarch64' ? Architecture.ARM_64 : Architecture.X86_64;
 
     super(scope, id, {
       code: Code.fromDockerBuild(path.join(__dirname, '.'), {
@@ -38,7 +37,6 @@ export class LambdaAdapterLayer extends LayerVersion {
         },
       }),
       compatibleRuntimes: [Runtime.NODEJS_16_X, Runtime.NODEJS_18_X],
-      compatibleArchitectures: [architecture],
     });
   }
 }

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -1071,9 +1071,6 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
         'testClickStreamCloudfrontApiLambdaAdapterLayerX868468A9C4',
       ]);
     newCloudfrontApiStackTemplate.hasResourceProperties('AWS::Lambda::LayerVersion', {
-      CompatibleArchitectures: [
-        'x86_64',
-      ],
       CompatibleRuntimes: [
         'nodejs16.x',
         'nodejs18.x',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

closes: #48 

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [x] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module