### PR TITLE
fix: edit pipeline not allow data processing cron or rate expression

### DIFF
--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -753,6 +753,7 @@ export class CDataModelingStack extends JSONObject {
       'MaxFilesLimit',
       'ProcessingFilesLimit',
       'UpsertUsersScheduleExpression',
+      'DataProcessingCronOrRateExpression',
       'ClearExpiredEventsScheduleExpression',
       'ClearExpiredEventsRetentionRangeDays',
       'RedshiftServerlessRPU',

--- a/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
@@ -785,7 +785,155 @@ export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW: IPipel
                   Region: 'ap-southeast-1',
                   TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-analytics-redshift-stack.template.json',
                   Action: 'Create',
+                  Parameters: [
+                    {
+                      ParameterKey: 'DataProcessingCronOrRateExpression',
+                      ParameterValue: 'rate(16 minutes)',
+                    },
+                  ],
+                  StackName: `Clickstream-DataModelingRedshift-${MOCK_PIPELINE_ID}`,
+                },
+                Callback: {
+                  BucketPrefix: `clickstream/workflow/${MOCK_EXECUTION_ID_OLD}`,
+                  BucketName: 'EXAMPLE_BUCKET',
+                },
+              },
+              Next: 'Reporting',
+            },
+          },
+          StartAt: 'DataModeling',
+        },
+        {
+          StartAt: 'Metrics',
+          States: {
+            Metrics: {
+              Data: {
+                Callback: {
+                  BucketName: 'EXAMPLE_BUCKET',
+                  BucketPrefix: `clickstream/workflow/${MOCK_EXECUTION_ID_OLD}`,
+                },
+                Input: {
+                  Action: 'Create',
+                  Region: 'ap-southeast-1',
+                  Parameters: BASE_METRICS_PARAMETERS,
+                  StackName: 'Clickstream-Metrics-6666-6666',
+                  TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/v1.0.0/default/metrics-stack.template.json',
+                },
+              },
+              End: true,
+              Type: WorkflowStateType.STACK,
+            },
+          },
+        },
+      ],
+    },
+  },
+};
+
+export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW_AND_EXPRESSION_UPDATE: IPipeline = {
+  ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE,
+  status: {
+    ...BASE_STATUS,
+  },
+  workflow: {
+    Version: '2022-03-15',
+    Workflow: {
+      Type: WorkflowStateType.PARALLEL,
+      End: true,
+      Branches: [
+        {
+          States: {
+            KafkaConnector: {
+              Type: WorkflowStateType.STACK,
+              Data: {
+                Input: {
+                  Region: 'ap-southeast-1',
+                  TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/kafka-s3-sink-stack.template.json',
+                  Action: 'Create',
                   Parameters: [],
+                  StackName: `Clickstream-KafkaConnector-${MOCK_PIPELINE_ID}`,
+                },
+                Callback: {
+                  BucketPrefix: `clickstream/workflow/${MOCK_EXECUTION_ID_OLD}`,
+                  BucketName: 'EXAMPLE_BUCKET',
+                },
+              },
+              End: true,
+            },
+            Ingestion: {
+              Type: WorkflowStateType.STACK,
+              Data: {
+                Input: {
+                  Region: 'ap-southeast-1',
+                  TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/ingestion-server-kafka-stack.template.json',
+                  Action: 'Create',
+                  Parameters: [],
+                  StackName: `Clickstream-Ingestion-kafka-${MOCK_PIPELINE_ID}`,
+                },
+                Callback: {
+                  BucketPrefix: `clickstream/workflow/${MOCK_EXECUTION_ID_OLD}`,
+                  BucketName: 'EXAMPLE_BUCKET',
+                },
+              },
+              Next: 'KafkaConnector',
+            },
+          },
+          StartAt: 'Ingestion',
+        },
+        {
+          States: {
+            DataProcessing: {
+              Type: WorkflowStateType.STACK,
+              Data: {
+                Input: {
+                  Region: 'ap-southeast-1',
+                  TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-pipeline-stack.template.json',
+                  Action: 'Create',
+                  Parameters: [],
+                  StackName: `Clickstream-DataProcessing-${MOCK_PIPELINE_ID}`,
+                },
+                Callback: {
+                  BucketPrefix: `clickstream/workflow/${MOCK_EXECUTION_ID_OLD}`,
+                  BucketName: 'EXAMPLE_BUCKET',
+                },
+              },
+              End: true,
+            },
+          },
+          StartAt: 'DataProcessing',
+        },
+        {
+          States: {
+            Reporting: {
+              Type: WorkflowStateType.STACK,
+              Data: {
+                Input: {
+                  Region: 'ap-southeast-1',
+                  TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-reporting-quicksight-stack.template.json',
+                  Action: 'Create',
+                  Parameters: [],
+                  StackName: `Clickstream-Reporting-${MOCK_PIPELINE_ID}`,
+                },
+                Callback: {
+                  BucketPrefix: `clickstream/workflow/${MOCK_EXECUTION_ID_OLD}`,
+                  BucketName: 'EXAMPLE_BUCKET',
+                },
+              },
+              End: true,
+            },
+            DataModeling: {
+              Type: WorkflowStateType.STACK,
+              Data: {
+                Input: {
+                  Region: 'ap-southeast-1',
+                  TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-analytics-redshift-stack.template.json',
+                  Action: 'Create',
+                  Parameters: [
+                    {
+                      ParameterKey: 'DataProcessingCronOrRateExpression',
+                      ParameterValue: 'rate(6 minutes)',
+                    },
+                  ],
                   StackName: `Clickstream-DataModelingRedshift-${MOCK_PIPELINE_ID}`,
                 },
                 Callback: {

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -63,6 +63,7 @@ import {
   S3_INGESTION_HTTP_AUTHENTICATION_PIPELINE,
   KINESIS_DATA_PROCESSING_NEW_REDSHIFT_WITH_ERROR_RPU_PIPELINE,
   S3_DATA_PROCESSING_WITH_ERROR_PREFIX_PIPELINE,
+  KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW_AND_EXPRESSION_UPDATE,
 } from './pipeline-mock';
 import { clickStreamTableName, dictionaryTableName } from '../../common/constants';
 import { app, server } from '../../index';
@@ -2523,6 +2524,61 @@ describe('Pipeline test', () => {
       success: false,
       message: 'Unexpected error occurred at server.',
       error: 'Error',
+    });
+  });
+  it('Update pipeline with data procession expression changed', async () => {
+    tokenMock(ddbMock, false);
+    projectExistedMock(ddbMock, true);
+    dictionaryMock(ddbMock);
+    createPipelineMock(ddbMock, kafkaMock, redshiftServerlessMock, redshiftMock,
+      ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
+        publicAZContainPrivateAZ: true,
+        subnetsCross3AZ: true,
+        subnetsIsolated: true,
+        update: true,
+        updatePipeline: KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW_AND_EXPRESSION_UPDATE,
+      });
+    cloudFormationMock.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackName: 'xxx',
+          Outputs: [
+            {
+              OutputKey: 'IngestionServerC000IngestionServerURL',
+              OutputValue: 'http://xxx/xxx',
+            },
+            {
+              OutputKey: 'IngestionServerC000IngestionServerDNS',
+              OutputValue: 'http://yyy/yyy',
+            },
+            {
+              OutputKey: 'Dashboards',
+              OutputValue: '[{"appId":"app1","dashboardId":"clickstream_dashboard_v1_notepad_mtzfsocy_app1"},{"appId":"app2","dashboardId":"clickstream_dashboard_v1_notepad_mtzfsocy_app2"}]',
+            },
+            {
+              OutputKey: 'ObservabilityDashboardName',
+              OutputValue: 'clickstream_dashboard_notepad_mtzfsocy',
+            },
+          ],
+          StackStatus: StackStatus.CREATE_COMPLETE,
+          CreationTime: new Date(),
+        },
+      ],
+    });
+
+    ddbMock.on(TransactWriteItemsCommand).resolves({});
+    const res = await request(app)
+      .put(`/api/pipeline/${MOCK_PIPELINE_ID}`)
+      .send(KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW_AND_EXPRESSION_UPDATE);
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 6);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toEqual({
+      data: {
+        id: MOCK_PIPELINE_ID,
+      },
+      success: true,
+      message: 'Pipeline updated.',
     });
   });
   it('Update pipeline with emails changed', async () => {

--- a/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
@@ -1632,7 +1632,12 @@ describe('Workflow test', () => {
                   Input: {
                     Action: 'Create',
                     Region: 'ap-southeast-1',
-                    Parameters: [],
+                    Parameters: [
+                      {
+                        ParameterKey: 'DataProcessingCronOrRateExpression',
+                        ParameterValue: 'rate(16 minutes)',
+                      },
+                    ],
                     StackName: 'Clickstream-DataModelingRedshift-6666-6666',
                     TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-analytics-redshift-stack.template.json',
                   },
@@ -2219,7 +2224,12 @@ describe('Workflow test', () => {
                   Input: {
                     Action: 'Delete',
                     Region: 'ap-southeast-1',
-                    Parameters: [],
+                    Parameters: [
+                      {
+                        ParameterKey: 'DataProcessingCronOrRateExpression',
+                        ParameterValue: 'rate(16 minutes)',
+                      },
+                    ],
                     StackName: 'Clickstream-DataModelingRedshift-6666-6666',
                     TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-analytics-redshift-stack.template.json',
                   },


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module