### PR TITLE
chore(deps): upgrade nginx to stable 1.24

### DIFF
--- a/src/ingestion-server/server/images/nginx/Dockerfile
+++ b/src/ingestion-server/server/images/nginx/Dockerfile
@@ -1,5 +1,5 @@
 ARG PLATFORM_ARG
-FROM --platform=$PLATFORM_ARG public.ecr.aws/docker/library/nginx:1.22
+FROM --platform=$PLATFORM_ARG public.ecr.aws/docker/library/nginx:1.24
 
 # default nginx path
 ENV SERVER_ENDPOINT_PATH='/collect'


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Upgrade nginx from 1.22 to 1.25

closes #9 

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [x] deploy ingestion server
    - [x] with MSK sink
    - [x] with KDS sink
    - [x] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module