### PR TITLE
fix: retry the failed stacks

### DIFF
--- a/test/control-plane/lambda/sfn-action.test.ts
+++ b/test/control-plane/lambda/sfn-action.test.ts
@@ -13,7 +13,8 @@
 
 import {
   CloudFormationClient,
-  DescribeStacksCommand, StackStatus, UpdateTerminationProtectionCommand,
+  CreateStackCommand,
+  DescribeStacksCommand, StackStatus, UpdateStackCommand, UpdateTerminationProtectionCommand,
 } from '@aws-sdk/client-cloudformation';
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { CdkCustomResourceResponse } from 'aws-lambda';
@@ -69,6 +70,88 @@ describe('SFN Action Lambda Function', () => {
   beforeEach(() => {
     s3Mock.reset();
     cloudFormationMock.reset();
+  });
+
+  test('Create stack', async () => {
+    const event: SfnStackEvent = {
+      ...baseStackActionEvent,
+      Action: StackAction.CREATE,
+    };
+    cloudFormationMock.on(CreateStackCommand).resolves({
+      StackId: 'arn:aws:cloudformation:ap-southeast-1:555555555555:stack/Clickstream-ETL-6972c135cb864885b25c5b7ebe584fdf/5b6971e0-f261-11ed-a7e3-02a848659f60',
+    });
+    const resp = await handler(event, context) as CdkCustomResourceResponse;
+    expect(resp.Action).toEqual(StackAction.DESCRIBE);
+    expect(resp.Result.StackId).toEqual('arn:aws:cloudformation:ap-southeast-1:555555555555:stack/Clickstream-ETL-6972c135cb864885b25c5b7ebe584fdf/5b6971e0-f261-11ed-a7e3-02a848659f60');
+    expect(resp.Result.StackName).toEqual('Clickstream-ETL-6972c135cb864885b25c5b7ebe584fdf');
+    expect(resp.Result.StackStatus).toEqual(StackStatus.CREATE_IN_PROGRESS);
+    expect(cloudFormationMock).toHaveReceivedCommandTimes(CreateStackCommand, 1);
+    expect(s3Mock).toHaveReceivedCommandTimes(PutObjectCommand, 0);
+  });
+
+  test('Update stack', async () => {
+    const event: SfnStackEvent = {
+      ...baseStackActionEvent,
+      Action: StackAction.UPDATE,
+    };
+    cloudFormationMock.on(UpdateStackCommand).resolves({
+      StackId: 'arn:aws:cloudformation:ap-southeast-1:555555555555:stack/Clickstream-ETL-6972c135cb864885b25c5b7ebe584fdf/5b6971e0-f261-11ed-a7e3-02a848659f60',
+    });
+    const resp = await handler(event, context) as CdkCustomResourceResponse;
+    expect(resp.Action).toEqual(StackAction.DESCRIBE);
+    expect(resp.Result.StackId).toEqual('arn:aws:cloudformation:ap-southeast-1:555555555555:stack/Clickstream-ETL-6972c135cb864885b25c5b7ebe584fdf/5b6971e0-f261-11ed-a7e3-02a848659f60');
+    expect(resp.Result.StackName).toEqual('Clickstream-ETL-6972c135cb864885b25c5b7ebe584fdf');
+    expect(resp.Result.StackStatus).toEqual(StackStatus.UPDATE_IN_PROGRESS);
+    expect(cloudFormationMock).toHaveReceivedCommandTimes(UpdateStackCommand, 1);
+    expect(s3Mock).toHaveReceivedCommandTimes(PutObjectCommand, 0);
+  });
+
+  test('Upgrade stack', async () => {
+    const event: SfnStackEvent = {
+      ...baseStackActionEvent,
+      Action: StackAction.UPGRADE,
+    };
+    cloudFormationMock.on(UpdateStackCommand).resolves({
+      StackId: 'arn:aws:cloudformation:ap-southeast-1:555555555555:stack/Clickstream-ETL-6972c135cb864885b25c5b7ebe584fdf/5b6971e0-f261-11ed-a7e3-02a848659f60',
+    });
+    const resp = await handler(event, context) as CdkCustomResourceResponse;
+    expect(resp.Action).toEqual(StackAction.DESCRIBE);
+    expect(resp.Result.StackId).toEqual('arn:aws:cloudformation:ap-southeast-1:555555555555:stack/Clickstream-ETL-6972c135cb864885b25c5b7ebe584fdf/5b6971e0-f261-11ed-a7e3-02a848659f60');
+    expect(resp.Result.StackName).toEqual('Clickstream-ETL-6972c135cb864885b25c5b7ebe584fdf');
+    expect(resp.Result.StackStatus).toEqual(StackStatus.UPDATE_IN_PROGRESS);
+    expect(cloudFormationMock).toHaveReceivedCommandTimes(UpdateStackCommand, 1);
+    expect(s3Mock).toHaveReceivedCommandTimes(PutObjectCommand, 0);
+  });
+
+  test('Callback', async () => {
+    const event: SfnStackEvent = {
+      ...baseStackActionEvent,
+      Action: StackAction.CALLBACK,
+      Result: stackResult,
+    };
+    s3Mock.on(PutObjectCommand).resolves({});
+    const resp = await handler(event, context) as CdkCustomResourceResponse;
+    expect(resp).toEqual(event);
+    expect(s3Mock).toHaveReceivedCommandTimes(PutObjectCommand, 1);
+  });
+
+  test('Callback with stack failed', async () => {
+    const event: SfnStackEvent = {
+      ...baseStackActionEvent,
+      Action: StackAction.CALLBACK,
+      Result: {
+        ...stackResult,
+        StackStatus: StackStatus.DELETE_FAILED,
+        StackStatusReason: 'mock failed reason',
+      },
+    };
+    s3Mock.on(PutObjectCommand).resolves({});
+    try {
+      await handler(event, context) as CdkCustomResourceResponse;
+    } catch (err) {
+      expect((err as Error).message).toEqual('mock failed reason');
+    }
+    expect(s3Mock).toHaveReceivedCommandTimes(PutObjectCommand, 1);
   });
 
   test('Describe stack with delete_in_progress', async () => {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

closes: #49 

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [x] retry failed pipeline
  - [x] update the existing pipeline 
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module