### PR TITLE
fix: apply time filter for the visuals of device report

### DIFF
--- a/src/reporting/private/template-def.json
+++ b/src/reporting/private/template-def.json
@@ -1,4 +1,3 @@
-
 {
     "DataSetConfigurations": [
         {
@@ -214,6 +213,10 @@
                         "DataType": "STRING"
                     },
                     {
+                        "Name": "ua_os_version",
+                        "DataType": "STRING"
+                    },
+                    {
                         "Name": "geo_locale",
                         "DataType": "STRING"
                     },
@@ -263,6 +266,10 @@
                     },
                     {
                         "Name": "event_id",
+                        "DataType": "STRING"
+                    },
+                    {
+                        "Name": "user_pseudo_id",
                         "DataType": "STRING"
                     },
                     {
@@ -454,7 +461,7 @@
     ],
     "Sheets": [
         {
-            "SheetId": "8f0ddf67-9443-4072-91b8-13658b385d88",
+            "SheetId": "45e2377a-4ca3-40db-9c20-5ec8e0a87eda",
             "Name": "Acquisition",
             "ParameterControls": [
                 {
@@ -600,7 +607,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -617,7 +628,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -634,7 +649,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -651,7 +670,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -668,7 +691,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -685,7 +712,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -695,7 +726,7 @@
             "Visuals": [
                 {
                     "KPIVisual": {
-                        "VisualId": "4c77838e-13ba-4153-8f67-174123f4b02e",
+                        "VisualId": "ac3c04d5-9aa4-4d27-a302-2d316540107b",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -729,7 +760,7 @@
                                                 "ColumnName": "first_visit_date"
                                             },
                                             "DateGranularity": "WEEK",
-                                            "HierarchyId": "2cdaa15e-cd7c-4458-a191-8f7500bd6eed",
+                                            "HierarchyId": "9cf4dd98-83cb-4459-a1cc-2c79b2aba18b",
                                             "FormatConfiguration": {
                                                 "DateTimeFormat": "MM-DD-YYYY"
                                             }
@@ -791,7 +822,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "2cdaa15e-cd7c-4458-a191-8f7500bd6eed",
+                                    "HierarchyId": "9cf4dd98-83cb-4459-a1cc-2c79b2aba18b",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -800,7 +831,7 @@
                 },
                 {
                     "PieChartVisual": {
-                        "VisualId": "1241fc92-1ccf-47d1-82be-4e8e4d153558",
+                        "VisualId": "863d6690-66a0-44a5-81e4-05ed3437beda",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -898,7 +929,7 @@
                 },
                 {
                     "GaugeChartVisual": {
-                        "VisualId": "c8bd9cd9-a549-443d-ad30-c625c29b0102",
+                        "VisualId": "51493c48-692f-477a-8984-5ca2fc8eab5d",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -944,7 +975,7 @@
                 },
                 {
                     "PieChartVisual": {
-                        "VisualId": "eb616dd7-5625-45ae-8380-c1f70bfa3319",
+                        "VisualId": "660c1d27-8a14-4ef0-8399-21f113039cac",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -1039,7 +1070,7 @@
                 },
                 {
                     "KPIVisual": {
-                        "VisualId": "c17ebc46-ac4b-476c-a48a-6b7fd2a9b37d",
+                        "VisualId": "3562b7aa-454f-4206-9f19-457c5731e409",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -1072,7 +1103,7 @@
                                                 "DataSetIdentifier": "clickstream_user_dim_view",
                                                 "ColumnName": "first_visit_date"
                                             },
-                                            "HierarchyId": "55f232de-9fe1-4202-b200-d109ee44f16b",
+                                            "HierarchyId": "c5674623-3ed6-4e37-8d9e-aafde04a61c2",
                                             "FormatConfiguration": {
                                                 "DateTimeFormat": "MM-DD-YYYY"
                                             }
@@ -1134,7 +1165,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "55f232de-9fe1-4202-b200-d109ee44f16b",
+                                    "HierarchyId": "c5674623-3ed6-4e37-8d9e-aafde04a61c2",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -1143,7 +1174,7 @@
                 },
                 {
                     "LineChartVisual": {
-                        "VisualId": "2ef7baaf-ed22-41e9-89a8-9c10b53e21c0",
+                        "VisualId": "9f865393-2c3d-4686-a339-a7e50cee30da",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -1164,7 +1195,7 @@
                                                     "DataSetIdentifier": "clickstream_user_dim_view",
                                                     "ColumnName": "first_visit_date"
                                                 },
-                                                "HierarchyId": "7caac55f-fd2e-4a83-bf94-d230e61df8e4",
+                                                "HierarchyId": "b591b4d5-91df-4278-84ea-a92cf9cae92a",
                                                 "FormatConfiguration": {
                                                     "DateTimeFormat": "MM-DD-YYYY"
                                                 }
@@ -1269,7 +1300,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "7caac55f-fd2e-4a83-bf94-d230e61df8e4",
+                                    "HierarchyId": "b591b4d5-91df-4278-84ea-a92cf9cae92a",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -1278,7 +1309,7 @@
                 },
                 {
                     "FilledMapVisual": {
-                        "VisualId": "68474985-25f6-4570-9c28-51faa577b5e1",
+                        "VisualId": "096ee61e-79e3-43eb-848a-953853429808",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -1358,7 +1389,7 @@
                 },
                 {
                     "TableVisual": {
-                        "VisualId": "cf1c62e1-069a-416d-bad8-f15c4cabde81",
+                        "VisualId": "7408af6c-116d-4d52-8d40-3ff8e3180ac1",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -1412,7 +1443,7 @@
                 },
                 {
                     "TreeMapVisual": {
-                        "VisualId": "edc79423-3ff8-4e7f-8545-21fd2bdc3f69",
+                        "VisualId": "fd64766c-a958-484f-9643-8afe2274a355",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -1502,7 +1533,7 @@
                 },
                 {
                     "BarChartVisual": {
-                        "VisualId": "23bbf605-3148-47ef-8b20-16f1210b26c2",
+                        "VisualId": "1545acd8-39e9-4952-a8f8-1aa9dcf012c2",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -1595,7 +1626,7 @@
                 },
                 {
                     "TableVisual": {
-                        "VisualId": "70781d6f-7ccf-4f9a-8f39-55c8b5b25c3f",
+                        "VisualId": "3b75c206-6012-4eff-a36d-06b743a54959",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -1751,7 +1782,7 @@
                                             "TargetVisualsConfiguration": {
                                                 "SameSheetTargetVisualConfiguration": {
                                                     "TargetVisuals": [
-                                                        "b2522804-a175-4b3a-b691-67f6636ae6da"
+                                                        "eb16e8fc-d0c5-4d16-88d9-9e6d5165920f"
                                                     ]
                                                 }
                                             }
@@ -1764,7 +1795,7 @@
                 },
                 {
                     "TableVisual": {
-                        "VisualId": "b2522804-a175-4b3a-b691-67f6636ae6da",
+                        "VisualId": "eb16e8fc-d0c5-4d16-88d9-9e6d5165920f",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -1862,7 +1893,7 @@
                                             "TargetVisualsConfiguration": {
                                                 "SameSheetTargetVisualConfiguration": {
                                                     "TargetVisuals": [
-                                                        "70781d6f-7ccf-4f9a-8f39-55c8b5b25c3f"
+                                                        "3b75c206-6012-4eff-a36d-06b743a54959"
                                                     ]
                                                 }
                                             }
@@ -1876,7 +1907,7 @@
             ],
             "TextBoxes": [
                 {
-                    "SheetTextBoxId": "c3bc563f-ea71-4ca7-b2fb-f4f6a1f815ba",
+                    "SheetTextBoxId": "b8a34a88-372b-4fe0-b238-ba0fccc8a00c",
                     "Content": "<text-box>\n  <inline color=\"#000000\" font-size=\"20px\">\n    <b>Acquisition report</b>\n  </inline>\n  <br/>\n  <inline color=\"#000000\" font-size=\"16px\">User acquisition report provides insights into how new users find your website or app for the first time, and help you understand the user profiles and user growth trends.</inline>\n  <br/>\n  <inline color=\"#000000\" font-size=\"16px\">This report mainly based on the user “_first_visit” event data in view of clickstream_user_dim.</inline>\n</text-box>"
                 }
             ],
@@ -1886,7 +1917,7 @@
                         "FreeFormLayout": {
                             "Elements": [
                                 {
-                                    "ElementId": "c3bc563f-ea71-4ca7-b2fb-f4f6a1f815ba",
+                                    "ElementId": "b8a34a88-372b-4fe0-b238-ba0fccc8a00c",
                                     "ElementType": "TEXT_BOX",
                                     "XAxisLocation": "16px",
                                     "YAxisLocation": "0px",
@@ -1895,7 +1926,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "1241fc92-1ccf-47d1-82be-4e8e4d153558",
+                                    "ElementId": "863d6690-66a0-44a5-81e4-05ed3437beda",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "8px",
                                     "YAxisLocation": "96px",
@@ -1904,7 +1935,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "c8bd9cd9-a549-443d-ad30-c625c29b0102",
+                                    "ElementId": "51493c48-692f-477a-8984-5ca2fc8eab5d",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "494px",
                                     "YAxisLocation": "96px",
@@ -1913,7 +1944,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "eb616dd7-5625-45ae-8380-c1f70bfa3319",
+                                    "ElementId": "660c1d27-8a14-4ef0-8399-21f113039cac",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "1025px",
                                     "YAxisLocation": "96px",
@@ -1922,7 +1953,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "c17ebc46-ac4b-476c-a48a-6b7fd2a9b37d",
+                                    "ElementId": "3562b7aa-454f-4206-9f19-457c5731e409",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "16px",
                                     "YAxisLocation": "448px",
@@ -1931,7 +1962,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "2ef7baaf-ed22-41e9-89a8-9c10b53e21c0",
+                                    "ElementId": "9f865393-2c3d-4686-a339-a7e50cee30da",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "320px",
                                     "YAxisLocation": "448px",
@@ -1940,7 +1971,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "4c77838e-13ba-4153-8f67-174123f4b02e",
+                                    "ElementId": "ac3c04d5-9aa4-4d27-a302-2d316540107b",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "16px",
                                     "YAxisLocation": "704px",
@@ -1985,7 +2016,7 @@
                                     }
                                 },
                                 {
-                                    "ElementId": "cf1c62e1-069a-416d-bad8-f15c4cabde81",
+                                    "ElementId": "7408af6c-116d-4d52-8d40-3ff8e3180ac1",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "1104px",
                                     "YAxisLocation": "928px",
@@ -1994,7 +2025,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "68474985-25f6-4570-9c28-51faa577b5e1",
+                                    "ElementId": "096ee61e-79e3-43eb-848a-953853429808",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "16px",
                                     "YAxisLocation": "944px",
@@ -2003,7 +2034,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "edc79423-3ff8-4e7f-8545-21fd2bdc3f69",
+                                    "ElementId": "fd64766c-a958-484f-9643-8afe2274a355",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "16px",
                                     "YAxisLocation": "1440px",
@@ -2012,7 +2043,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "23bbf605-3148-47ef-8b20-16f1210b26c2",
+                                    "ElementId": "1545acd8-39e9-4952-a8f8-1aa9dcf012c2",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "16px",
                                     "YAxisLocation": "1920px",
@@ -2030,7 +2061,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "b2522804-a175-4b3a-b691-67f6636ae6da",
+                                    "ElementId": "eb16e8fc-d0c5-4d16-88d9-9e6d5165920f",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "1136px",
                                     "YAxisLocation": "2512px",
@@ -2039,7 +2070,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "70781d6f-7ccf-4f9a-8f39-55c8b5b25c3f",
+                                    "ElementId": "3b75c206-6012-4eff-a36d-06b743a54959",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "16px",
                                     "YAxisLocation": "2512px",
@@ -2105,7 +2136,7 @@
             "ContentType": "INTERACTIVE"
         },
         {
-            "SheetId": "40d55f9e-966e-487d-9a8b-e10246cdcfd9",
+            "SheetId": "b08b0dfa-5395-4a6a-8974-78a9ee004399",
             "Name": "Engagement",
             "ParameterControls": [
                 {
@@ -2171,7 +2202,7 @@
             "Visuals": [
                 {
                     "BarChartVisual": {
-                        "VisualId": "efdd6b01-2454-425c-b54d-5a811a2fc441",
+                        "VisualId": "228ca447-266d-4bcc-a1ca-2a19e5c2e7ee",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -2273,7 +2304,7 @@
                 },
                 {
                     "KPIVisual": {
-                        "VisualId": "b1420f00-62ae-4cf2-8111-f295cc6a8aac",
+                        "VisualId": "84d11be9-57c7-4249-87a3-dbc7150ebfe3",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -2305,7 +2336,7 @@
                                                 "DataSetIdentifier": "clickstream_session_view",
                                                 "ColumnName": "session_date"
                                             },
-                                            "HierarchyId": "a4c98e28-68f4-40ff-b7c6-f5eb2829363b",
+                                            "HierarchyId": "d4ce01d7-bf6f-4dd7-a150-3e55586cbdf2",
                                             "FormatConfiguration": {
                                                 "DateTimeFormat": "MM-DD-YYYY"
                                             }
@@ -2352,7 +2383,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "a4c98e28-68f4-40ff-b7c6-f5eb2829363b",
+                                    "HierarchyId": "d4ce01d7-bf6f-4dd7-a150-3e55586cbdf2",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -2361,7 +2392,7 @@
                 },
                 {
                     "KPIVisual": {
-                        "VisualId": "9800f8b8-4c25-477a-bcaf-95624e8633a7",
+                        "VisualId": "e5531ae6-2033-4997-b8c1-aef548374cb6",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -2396,7 +2427,7 @@
                                                 "DataSetIdentifier": "clickstream_session_view",
                                                 "ColumnName": "session_date"
                                             },
-                                            "HierarchyId": "bf051ef3-d1d6-496a-829f-301f1e7df96d",
+                                            "HierarchyId": "090cc837-472b-4315-8d69-6154e9992b95",
                                             "FormatConfiguration": {
                                                 "DateTimeFormat": "MM-DD-YYYY"
                                             }
@@ -2443,7 +2474,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "bf051ef3-d1d6-496a-829f-301f1e7df96d",
+                                    "HierarchyId": "090cc837-472b-4315-8d69-6154e9992b95",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -2452,7 +2483,7 @@
                 },
                 {
                     "KPIVisual": {
-                        "VisualId": "cc39e064-7c56-4fa6-95c5-da13108110cb",
+                        "VisualId": "69e2b94d-1bff-4421-a43c-bec7a309cd3d",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -2487,7 +2518,7 @@
                                                 "DataSetIdentifier": "clickstream_session_view",
                                                 "ColumnName": "session_date"
                                             },
-                                            "HierarchyId": "89b05888-d44a-42f3-b5d4-a2da886dc09f",
+                                            "HierarchyId": "75d63dab-f43a-4b4b-ba07-3dc4006bc045",
                                             "FormatConfiguration": {
                                                 "DateTimeFormat": "MM-DD-YYYY"
                                             }
@@ -2534,7 +2565,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "89b05888-d44a-42f3-b5d4-a2da886dc09f",
+                                    "HierarchyId": "75d63dab-f43a-4b4b-ba07-3dc4006bc045",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -2543,7 +2574,7 @@
                 },
                 {
                     "KPIVisual": {
-                        "VisualId": "7b2a51ee-65a8-4b6b-b6f0-b7faa5cf680d",
+                        "VisualId": "50af85c3-9799-4906-a94e-912dbbefd5a6",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -2576,7 +2607,7 @@
                                                 "DataSetIdentifier": "clickstream_session_view",
                                                 "ColumnName": "session_date"
                                             },
-                                            "HierarchyId": "a6e8e958-50ea-4e74-9797-221d0cdc3412",
+                                            "HierarchyId": "7aa5f3e8-1c20-4bb8-bed7-53400d7e06da",
                                             "FormatConfiguration": {
                                                 "DateTimeFormat": "MM-DD-YYYY"
                                             }
@@ -2623,7 +2654,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "a6e8e958-50ea-4e74-9797-221d0cdc3412",
+                                    "HierarchyId": "7aa5f3e8-1c20-4bb8-bed7-53400d7e06da",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -2632,7 +2663,7 @@
                 },
                 {
                     "KPIVisual": {
-                        "VisualId": "6a6d6430-0120-4701-a419-8e8c0c390d73",
+                        "VisualId": "7e255483-26b9-4673-a179-97a0f3e0df74",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -2664,7 +2695,7 @@
                                                 "DataSetIdentifier": "clickstream_session_view",
                                                 "ColumnName": "session_date"
                                             },
-                                            "HierarchyId": "0208171f-b7ca-487c-9ee5-27996b88ba7f",
+                                            "HierarchyId": "21b10c04-d64e-4d91-bd80-a336dc910ab5",
                                             "FormatConfiguration": {
                                                 "DateTimeFormat": "MM-DD-YYYY"
                                             }
@@ -2716,7 +2747,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "0208171f-b7ca-487c-9ee5-27996b88ba7f",
+                                    "HierarchyId": "21b10c04-d64e-4d91-bd80-a336dc910ab5",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -2725,7 +2756,7 @@
                 },
                 {
                     "LineChartVisual": {
-                        "VisualId": "a1c56034-83fe-403e-8166-9db7a8a03e99",
+                        "VisualId": "34410864-11ff-46c0-b7f7-ba5a78f02ebf",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -2746,7 +2777,7 @@
                                                     "DataSetIdentifier": "clickstream_session_view",
                                                     "ColumnName": "session_date"
                                                 },
-                                                "HierarchyId": "9147e8dc-24d5-4aa5-819a-c481daeb681a",
+                                                "HierarchyId": "2799e4f7-b04d-429c-8a52-5635ed01313b",
                                                 "FormatConfiguration": {
                                                     "DateTimeFormat": "MM-DD-YYYY"
                                                 }
@@ -2884,7 +2915,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "9147e8dc-24d5-4aa5-819a-c481daeb681a",
+                                    "HierarchyId": "2799e4f7-b04d-429c-8a52-5635ed01313b",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -2893,7 +2924,7 @@
                 },
                 {
                     "KPIVisual": {
-                        "VisualId": "928f6067-41dd-4491-a070-01187cbf1b9f",
+                        "VisualId": "14c99630-b741-41e2-a166-7ff1ec0b090d",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -2925,7 +2956,7 @@
                                                 "DataSetIdentifier": "clickstream_session_view",
                                                 "ColumnName": "session_date"
                                             },
-                                            "HierarchyId": "fcd47186-d48b-4d69-9e91-7311c0a410e9",
+                                            "HierarchyId": "a8bf057c-10a5-4f01-a08b-9f0cc09b8079",
                                             "FormatConfiguration": {
                                                 "DateTimeFormat": "MM-DD-YYYY"
                                             }
@@ -2972,7 +3003,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "fcd47186-d48b-4d69-9e91-7311c0a410e9",
+                                    "HierarchyId": "a8bf057c-10a5-4f01-a08b-9f0cc09b8079",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -2981,7 +3012,7 @@
                 },
                 {
                     "KPIVisual": {
-                        "VisualId": "d0ec4ce8-627b-406e-96e0-1085509b9345",
+                        "VisualId": "4cc73c71-e436-4652-810a-73fbf6b6b0cc",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -3013,7 +3044,7 @@
                                                 "DataSetIdentifier": "clickstream_session_view",
                                                 "ColumnName": "session_date"
                                             },
-                                            "HierarchyId": "c6a8600e-7141-4b5c-8c77-842b0e15f659",
+                                            "HierarchyId": "f6c3a59f-f0a8-4452-9f10-52075fbc5406",
                                             "FormatConfiguration": {
                                                 "DateTimeFormat": "MM-DD-YYYY"
                                             }
@@ -3060,7 +3091,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "c6a8600e-7141-4b5c-8c77-842b0e15f659",
+                                    "HierarchyId": "f6c3a59f-f0a8-4452-9f10-52075fbc5406",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -3069,7 +3100,7 @@
                 },
                 {
                     "KPIVisual": {
-                        "VisualId": "deb2f736-2b7a-4127-b4a5-31ec732f0ff8",
+                        "VisualId": "cdb5b658-f8cb-4a34-9b4f-62dbc98e3f29",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -3101,7 +3132,7 @@
                                                 "DataSetIdentifier": "clickstream_session_view",
                                                 "ColumnName": "session_date"
                                             },
-                                            "HierarchyId": "aa0f2a9c-9e51-41a4-bdeb-2debe4d18602",
+                                            "HierarchyId": "46a41073-0218-43a1-84f7-8acb1806b4aa",
                                             "FormatConfiguration": {
                                                 "DateTimeFormat": "MM-DD-YYYY"
                                             }
@@ -3148,7 +3179,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "aa0f2a9c-9e51-41a4-bdeb-2debe4d18602",
+                                    "HierarchyId": "46a41073-0218-43a1-84f7-8acb1806b4aa",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -3157,7 +3188,7 @@
                 },
                 {
                     "LineChartVisual": {
-                        "VisualId": "20ae418c-fddd-4a0a-bb0a-e7f2bad110ea",
+                        "VisualId": "752a90fa-451e-4959-8b7f-03dd540e51f2",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -3178,7 +3209,7 @@
                                                     "DataSetIdentifier": "clickstream_session_view",
                                                     "ColumnName": "session_date"
                                                 },
-                                                "HierarchyId": "54d61695-e161-4161-9ae7-12af4ab62596",
+                                                "HierarchyId": "c174da1a-83dd-4ed6-af39-d62ffaef8c1d",
                                                 "FormatConfiguration": {
                                                     "DateTimeFormat": "MM-DD-YYYY"
                                                 }
@@ -3298,7 +3329,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "54d61695-e161-4161-9ae7-12af4ab62596",
+                                    "HierarchyId": "c174da1a-83dd-4ed6-af39-d62ffaef8c1d",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -3307,7 +3338,7 @@
                 },
                 {
                     "TableVisual": {
-                        "VisualId": "5cbc3fe7-5ede-4e4a-be2a-fc899289123d",
+                        "VisualId": "20660150-0681-4199-a9ad-4390867c527b",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -3439,7 +3470,7 @@
                 },
                 {
                     "InsightVisual": {
-                        "VisualId": "fcf4723c-b04d-4123-93e7-37bfaf0b3aae",
+                        "VisualId": "00b76bd2-c81c-4068-a1b6-a3ec372c04b1",
                         "Title": {
                             "Visibility": "VISIBLE"
                         },
@@ -3450,7 +3481,7 @@
                             "Computations": [
                                 {
                                     "MaximumMinimum": {
-                                        "ComputationId": "e3ae5079-599d-48fe-bb92-9a651a245d55",
+                                        "ComputationId": "1e7e475c-29e5-47a7-803b-5911d5a1efdd",
                                         "Name": "Maximum",
                                         "Time": {
                                             "DateDimensionField": {
@@ -3473,7 +3504,7 @@
                 },
                 {
                     "InsightVisual": {
-                        "VisualId": "3919cf76-68ce-48a6-a9b4-27e697954f73",
+                        "VisualId": "e894aecb-3e1e-4eaa-8319-f04cecebe896",
                         "Title": {
                             "Visibility": "VISIBLE"
                         },
@@ -3484,7 +3515,7 @@
                             "Computations": [
                                 {
                                     "PeriodOverPeriod": {
-                                        "ComputationId": "4554d26f-255a-4286-aac9-9356ffa947ad",
+                                        "ComputationId": "ed65ed8a-474a-47f6-b159-751281abfe55",
                                         "Name": "PeriodOverPeriod",
                                         "Time": {
                                             "DateDimensionField": {
@@ -3506,7 +3537,7 @@
                 },
                 {
                     "InsightVisual": {
-                        "VisualId": "3763db63-cb61-47b9-8fc6-ea08b07e004d",
+                        "VisualId": "7c63f4b7-8f96-4700-97d9-10abbca882f2",
                         "Title": {
                             "Visibility": "VISIBLE"
                         },
@@ -3517,7 +3548,7 @@
                             "Computations": [
                                 {
                                     "GrowthRate": {
-                                        "ComputationId": "5f846617-d87f-4853-8f9e-b833249ba65d",
+                                        "ComputationId": "088a0bbd-b2fc-45fb-a8e8-65e21c3276b6",
                                         "Name": "GrowthRate",
                                         "Time": {
                                             "DateDimensionField": {
@@ -3540,7 +3571,7 @@
                 },
                 {
                     "BarChartVisual": {
-                        "VisualId": "6930da4d-cc57-4849-9a18-3f04f0c52873",
+                        "VisualId": "93348126-c8fe-44dd-8e27-ec4133fc7fe9",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -3643,7 +3674,7 @@
             ],
             "TextBoxes": [
                 {
-                    "SheetTextBoxId": "8949f959-c002-4953-b570-67b705500c64",
+                    "SheetTextBoxId": "c05eb561-8858-41df-9d9a-d3bf6b831666",
                     "Content": "<text-box>\n  <inline font-size=\"20px\">\n    <b>Engagement report</b>\n  </inline>\n  <br/>\n  <inline font-size=\"16px\">User engagemetn report provides metrics based on sessions and views that your users trigger when they are using with your apps to help you understand their engagement level.</inline>\n  <br/>\n  <inline color=\"#000000\" font-size=\"16px\">This report mainly based on the the session data that aggregated at view of clickstream_session_view.</inline>\n  <br/>\n  <inline font-size=\"16px\">This report mainly based on the the session data that aggregated at view of clickstream_session_dim.This report mainly based on the the session data that aggregated at view of clickstream_session_dim.</inline>\n  <br/>\n  <inline font-size=\"16px\">This report mainly based on the the session data that aggregated at view of clickstream_session_dim.</inline>\n</text-box>"
                 }
             ],
@@ -3653,7 +3684,7 @@
                         "FreeFormLayout": {
                             "Elements": [
                                 {
-                                    "ElementId": "8949f959-c002-4953-b570-67b705500c64",
+                                    "ElementId": "c05eb561-8858-41df-9d9a-d3bf6b831666",
                                     "ElementType": "TEXT_BOX",
                                     "XAxisLocation": "0px",
                                     "YAxisLocation": "0px",
@@ -3662,7 +3693,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "7b2a51ee-65a8-4b6b-b6f0-b7faa5cf680d",
+                                    "ElementId": "50af85c3-9799-4906-a94e-912dbbefd5a6",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "0px",
                                     "YAxisLocation": "80px",
@@ -3671,7 +3702,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "cc39e064-7c56-4fa6-95c5-da13108110cb",
+                                    "ElementId": "69e2b94d-1bff-4421-a43c-bec7a309cd3d",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "352px",
                                     "YAxisLocation": "80px",
@@ -3680,7 +3711,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "9800f8b8-4c25-477a-bcaf-95624e8633a7",
+                                    "ElementId": "e5531ae6-2033-4997-b8c1-aef548374cb6",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "752px",
                                     "YAxisLocation": "80px",
@@ -3689,7 +3720,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "6a6d6430-0120-4701-a419-8e8c0c390d73",
+                                    "ElementId": "7e255483-26b9-4673-a179-97a0f3e0df74",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "1152px",
                                     "YAxisLocation": "80px",
@@ -3698,7 +3729,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "a1c56034-83fe-403e-8166-9db7a8a03e99",
+                                    "ElementId": "34410864-11ff-46c0-b7f7-ba5a78f02ebf",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "0px",
                                     "YAxisLocation": "288px",
@@ -3707,7 +3738,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "928f6067-41dd-4491-a070-01187cbf1b9f",
+                                    "ElementId": "14c99630-b741-41e2-a166-7ff1ec0b090d",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "0px",
                                     "YAxisLocation": "816px",
@@ -3716,7 +3747,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "d0ec4ce8-627b-406e-96e0-1085509b9345",
+                                    "ElementId": "4cc73c71-e436-4652-810a-73fbf6b6b0cc",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "352px",
                                     "YAxisLocation": "816px",
@@ -3725,7 +3756,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "b1420f00-62ae-4cf2-8111-f295cc6a8aac",
+                                    "ElementId": "84d11be9-57c7-4249-87a3-dbc7150ebfe3",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "752px",
                                     "YAxisLocation": "816px",
@@ -3734,7 +3765,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "deb2f736-2b7a-4127-b4a5-31ec732f0ff8",
+                                    "ElementId": "cdb5b658-f8cb-4a34-9b4f-62dbc98e3f29",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "1152px",
                                     "YAxisLocation": "816px",
@@ -3743,7 +3774,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "20ae418c-fddd-4a0a-bb0a-e7f2bad110ea",
+                                    "ElementId": "752a90fa-451e-4959-8b7f-03dd540e51f2",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "0px",
                                     "YAxisLocation": "1040px",
@@ -3752,7 +3783,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "5cbc3fe7-5ede-4e4a-be2a-fc899289123d",
+                                    "ElementId": "20660150-0681-4199-a9ad-4390867c527b",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "8px",
                                     "YAxisLocation": "1504px",
@@ -3761,7 +3792,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "6930da4d-cc57-4849-9a18-3f04f0c52873",
+                                    "ElementId": "93348126-c8fe-44dd-8e27-ec4133fc7fe9",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "16px",
                                     "YAxisLocation": "1984px",
@@ -3770,7 +3801,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "fcf4723c-b04d-4123-93e7-37bfaf0b3aae",
+                                    "ElementId": "00b76bd2-c81c-4068-a1b6-a3ec372c04b1",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "1024px",
                                     "YAxisLocation": "1536px",
@@ -3779,7 +3810,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "3919cf76-68ce-48a6-a9b4-27e697954f73",
+                                    "ElementId": "e894aecb-3e1e-4eaa-8319-f04cecebe896",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "1024px",
                                     "YAxisLocation": "1616px",
@@ -3788,7 +3819,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "3763db63-cb61-47b9-8fc6-ea08b07e004d",
+                                    "ElementId": "7c63f4b7-8f96-4700-97d9-10abbca882f2",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "1024px",
                                     "YAxisLocation": "1696px",
@@ -3797,7 +3828,7 @@
                                     "Visibility": "VISIBLE"
                                 },
                                 {
-                                    "ElementId": "efdd6b01-2454-425c-b54d-5a811a2fc441",
+                                    "ElementId": "228ca447-266d-4bcc-a1ca-2a19e5c2e7ee",
                                     "ElementType": "VISUAL",
                                     "XAxisLocation": "784px",
                                     "YAxisLocation": "1984px",
@@ -3852,7 +3883,7 @@
             "ContentType": "INTERACTIVE"
         },
         {
-            "SheetId": "b4b3cd9b-3306-4310-8c12-b260ffadda23",
+            "SheetId": "4a083137-a3c4-4952-b7a7-ca468d9533c1",
             "Name": "Activity",
             "ParameterControls": [
                 {
@@ -3904,7 +3935,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -3921,7 +3956,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -3938,7 +3977,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -3955,7 +3998,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -3972,7 +4019,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -3989,7 +4040,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -4006,7 +4061,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -4023,7 +4082,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -4040,7 +4103,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -4057,7 +4124,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -4074,7 +4145,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -4084,7 +4159,7 @@
             "Visuals": [
                 {
                     "KPIVisual": {
-                        "VisualId": "09f8f829-28ac-4bf0-b46a-9203430dbc83",
+                        "VisualId": "a585f518-2b0b-4aad-a143-38813d40dee7",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -4116,7 +4191,7 @@
                                                 "DataSetIdentifier": "clickstream_ods_events_view",
                                                 "ColumnName": "event_date"
                                             },
-                                            "HierarchyId": "8360495d-7222-42e6-b110-25a596cbe470",
+                                            "HierarchyId": "e2f71c3c-7693-4cfa-8137-70a381614dcb",
                                             "FormatConfiguration": {
                                                 "DateTimeFormat": "MM-DD-YYYY"
                                             }
@@ -4170,7 +4245,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "8360495d-7222-42e6-b110-25a596cbe470",
+                                    "HierarchyId": "e2f71c3c-7693-4cfa-8137-70a381614dcb",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -4179,7 +4254,7 @@
                 },
                 {
                     "LineChartVisual": {
-                        "VisualId": "a5fef043-e90f-4f86-bf4f-986261f65ac8",
+                        "VisualId": "59c523fa-baf9-4624-b082-c4470349905f",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -4200,7 +4275,7 @@
                                                     "DataSetIdentifier": "clickstream_ods_events_view",
                                                     "ColumnName": "event_date"
                                                 },
-                                                "HierarchyId": "324d1b5a-6265-4312-b91a-9c8e01eaa728",
+                                                "HierarchyId": "02a0239c-5fb6-40f5-8068-28ac1a85a0b5",
                                                 "FormatConfiguration": {
                                                     "DateTimeFormat": "MM-DD-YYYY"
                                                 }
@@ -4291,7 +4366,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "324d1b5a-6265-4312-b91a-9c8e01eaa728",
+                                    "HierarchyId": "02a0239c-5fb6-40f5-8068-28ac1a85a0b5",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -4300,7 +4375,7 @@
                 },
                 {
                     "KPIVisual": {
-                        "VisualId": "debbd3d9-4ae7-435e-ae77-6267b5ba5e0e",
+                        "VisualId": "fe24093d-cd04-4552-9355-d894fff751a6",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -4333,7 +4408,7 @@
                                                 "DataSetIdentifier": "clickstream_ods_events_view",
                                                 "ColumnName": "event_date"
                                             },
-                                            "HierarchyId": "a542b332-64b4-40fe-b384-181f2346bec4",
+                                            "HierarchyId": "d1df906a-35ab-432c-850d-6fcd80d05452",
                                             "FormatConfiguration": {
                                                 "DateTimeFormat": "MM-DD-YYYY"
                                             }
@@ -4387,7 +4462,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "a542b332-64b4-40fe-b384-181f2346bec4",
+                                    "HierarchyId": "d1df906a-35ab-432c-850d-6fcd80d05452",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -4396,7 +4471,7 @@
                 },
                 {
                     "BarChartVisual": {
-                        "VisualId": "de81ce02-fe9f-4a07-9c98-930a3061fc8e",
+                        "VisualId": "618de685-66f4-474a-8170-849e4a490b57",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -4516,7 +4591,7 @@
                 },
                 {
                     "BarChartVisual": {
-                        "VisualId": "603c8055-3619-4274-b0b2-6d75c8566f8c",
+                        "VisualId": "8cba4e78-1c98-43e2-aee6-fcdf13b64a48",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -4626,7 +4701,7 @@
                 },
                 {
                     "BarChartVisual": {
-                        "VisualId": "e4991716-30e1-4b82-95f9-9c4914fea825",
+                        "VisualId": "b783dae9-a562-49b8-ac8f-6ff708a032dd",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -4647,7 +4722,7 @@
                                                     "DataSetIdentifier": "clickstream_ods_events_view",
                                                     "ColumnName": "event_date"
                                                 },
-                                                "HierarchyId": "83c5de3a-89de-4676-acd0-e02df458f6d4",
+                                                "HierarchyId": "eb39b929-5d23-4775-bf2e-0d90379261b5",
                                                 "FormatConfiguration": {
                                                     "DateTimeFormat": "MM-DD-YYYY"
                                                 }
@@ -4757,7 +4832,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "83c5de3a-89de-4676-acd0-e02df458f6d4",
+                                    "HierarchyId": "eb39b929-5d23-4775-bf2e-0d90379261b5",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -4766,7 +4841,7 @@
                 },
                 {
                     "PieChartVisual": {
-                        "VisualId": "fd96da78-d4fe-44c4-aad2-d6857a9016f8",
+                        "VisualId": "e2ffb379-38df-46fc-a4d3-67b70d923129",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -4873,7 +4948,7 @@
                 },
                 {
                     "LineChartVisual": {
-                        "VisualId": "ff15adba-abc0-47d2-b3a9-a8ec7abf98b0",
+                        "VisualId": "88098d83-ab2f-4f08-ad27-f2484bd15c36",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -4894,7 +4969,7 @@
                                                     "DataSetIdentifier": "clickstream_ods_events_view",
                                                     "ColumnName": "event_date"
                                                 },
-                                                "HierarchyId": "38e67333-6b54-4998-8659-7d4af015238c",
+                                                "HierarchyId": "41e2b021-d3b8-450e-a0e2-1b356ea40c62",
                                                 "FormatConfiguration": {
                                                     "DateTimeFormat": "MM-DD-YYYY"
                                                 }
@@ -5000,7 +5075,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "38e67333-6b54-4998-8659-7d4af015238c",
+                                    "HierarchyId": "41e2b021-d3b8-450e-a0e2-1b356ea40c62",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -5009,7 +5084,7 @@
                 },
                 {
                     "TableVisual": {
-                        "VisualId": "df7ceb0d-8eb1-4c26-81d3-123da87f229d",
+                        "VisualId": "62cff7c9-c4b0-44cf-a43d-4251c7df97fe",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -5117,7 +5192,7 @@
                                             "TargetVisualsConfiguration": {
                                                 "SameSheetTargetVisualConfiguration": {
                                                     "TargetVisuals": [
-                                                        "9f8f0d34-e608-481e-94ca-550f9f54b9d3"
+                                                        "577b7fce-cba9-42cc-ac99-e6190006544a"
                                                     ]
                                                 }
                                             }
@@ -5130,7 +5205,7 @@
                 },
                 {
                     "TableVisual": {
-                        "VisualId": "9f8f0d34-e608-481e-94ca-550f9f54b9d3",
+                        "VisualId": "577b7fce-cba9-42cc-ac99-e6190006544a",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -5174,7 +5249,7 @@
             ],
             "TextBoxes": [
                 {
-                    "SheetTextBoxId": "c4097697-bad0-4a84-9843-6c6803693d5f",
+                    "SheetTextBoxId": "cb3806cd-9f92-4894-966b-7b7e8496613a",
                     "Content": "<text-box>\n  <inline font-size=\"20px\">Activity report</inline>\n  <br/>\n  Y\n  <inline font-size=\"16px\">ou can use the Activity report to get insights into the activities the users performed when using your websites and apps. This report measures user activity by the events that users triggered, and let you view the detail attributes of the events. This report mainly bases on data in clickstream_ods_events_view and clickstream_ods_events_parameters_view.</inline>\n</text-box>"
                 }
             ],
@@ -5184,7 +5259,7 @@
                         "GridLayout": {
                             "Elements": [
                                 {
-                                    "ElementId": "c4097697-bad0-4a84-9843-6c6803693d5f",
+                                    "ElementId": "cb3806cd-9f92-4894-966b-7b7e8496613a",
                                     "ElementType": "TEXT_BOX",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 34,
@@ -5192,7 +5267,7 @@
                                     "RowSpan": 1
                                 },
                                 {
-                                    "ElementId": "a5fef043-e90f-4f86-bf4f-986261f65ac8",
+                                    "ElementId": "59c523fa-baf9-4624-b082-c4470349905f",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 28,
@@ -5200,7 +5275,7 @@
                                     "RowSpan": 14
                                 },
                                 {
-                                    "ElementId": "debbd3d9-4ae7-435e-ae77-6267b5ba5e0e",
+                                    "ElementId": "fe24093d-cd04-4552-9355-d894fff751a6",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 28,
                                     "ColumnSpan": 6,
@@ -5208,7 +5283,7 @@
                                     "RowSpan": 7
                                 },
                                 {
-                                    "ElementId": "09f8f829-28ac-4bf0-b46a-9203430dbc83",
+                                    "ElementId": "a585f518-2b0b-4aad-a143-38813d40dee7",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 28,
                                     "ColumnSpan": 6,
@@ -5216,7 +5291,7 @@
                                     "RowSpan": 7
                                 },
                                 {
-                                    "ElementId": "de81ce02-fe9f-4a07-9c98-930a3061fc8e",
+                                    "ElementId": "618de685-66f4-474a-8170-849e4a490b57",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 17,
@@ -5224,7 +5299,7 @@
                                     "RowSpan": 10
                                 },
                                 {
-                                    "ElementId": "603c8055-3619-4274-b0b2-6d75c8566f8c",
+                                    "ElementId": "8cba4e78-1c98-43e2-aee6-fcdf13b64a48",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 17,
                                     "ColumnSpan": 17,
@@ -5232,7 +5307,7 @@
                                     "RowSpan": 10
                                 },
                                 {
-                                    "ElementId": "e4991716-30e1-4b82-95f9-9c4914fea825",
+                                    "ElementId": "b783dae9-a562-49b8-ac8f-6ff708a032dd",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 34,
@@ -5240,7 +5315,7 @@
                                     "RowSpan": 11
                                 },
                                 {
-                                    "ElementId": "fd96da78-d4fe-44c4-aad2-d6857a9016f8",
+                                    "ElementId": "e2ffb379-38df-46fc-a4d3-67b70d923129",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 17,
@@ -5248,7 +5323,7 @@
                                     "RowSpan": 10
                                 },
                                 {
-                                    "ElementId": "ff15adba-abc0-47d2-b3a9-a8ec7abf98b0",
+                                    "ElementId": "88098d83-ab2f-4f08-ad27-f2484bd15c36",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 17,
                                     "ColumnSpan": 17,
@@ -5336,7 +5411,7 @@
                                     "RowSpan": 2
                                 },
                                 {
-                                    "ElementId": "df7ceb0d-8eb1-4c26-81d3-123da87f229d",
+                                    "ElementId": "62cff7c9-c4b0-44cf-a43d-4251c7df97fe",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 24,
@@ -5344,7 +5419,7 @@
                                     "RowSpan": 11
                                 },
                                 {
-                                    "ElementId": "9f8f0d34-e608-481e-94ca-550f9f54b9d3",
+                                    "ElementId": "577b7fce-cba9-42cc-ac99-e6190006544a",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 24,
                                     "ColumnSpan": 10,
@@ -5365,7 +5440,7 @@
             "ContentType": "INTERACTIVE"
         },
         {
-            "SheetId": "46ff0142-9808-4e28-b4e6-dc4b4260e853",
+            "SheetId": "580757e4-13a6-49ee-9907-ddea75d86907",
             "Name": "Retention",
             "ParameterControls": [
                 {
@@ -5431,7 +5506,7 @@
             "Visuals": [
                 {
                     "KPIVisual": {
-                        "VisualId": "29b25f47-785e-4a8b-89b5-dc838343b527",
+                        "VisualId": "54d62bf2-a405-4586-a86a-5e2a4b503f8f",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -5465,7 +5540,7 @@
                                                 "ColumnName": "event_date"
                                             },
                                             "DateGranularity": "MONTH",
-                                            "HierarchyId": "2e8fc2bb-b4e9-43d1-9aba-c70b389cfbc5",
+                                            "HierarchyId": "89aaa859-6449-486a-82fc-122344a12ab2",
                                             "FormatConfiguration": {
                                                 "DateTimeFormat": "MM-DD-YYYY"
                                             }
@@ -5512,7 +5587,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "2e8fc2bb-b4e9-43d1-9aba-c70b389cfbc5",
+                                    "HierarchyId": "89aaa859-6449-486a-82fc-122344a12ab2",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -5521,7 +5596,7 @@
                 },
                 {
                     "KPIVisual": {
-                        "VisualId": "f1496953-66fa-4992-9444-8c4e9139f597",
+                        "VisualId": "579c0411-d82e-44e7-b820-f91a2acccda2",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -5555,7 +5630,7 @@
                                                 "ColumnName": "event_date"
                                             },
                                             "DateGranularity": "WEEK",
-                                            "HierarchyId": "4377db48-41c1-4445-8e33-c48254cac337",
+                                            "HierarchyId": "27a20d4c-1de3-40df-882f-348d05d4f068",
                                             "FormatConfiguration": {
                                                 "DateTimeFormat": "MM-DD-YYYY"
                                             }
@@ -5602,7 +5677,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "4377db48-41c1-4445-8e33-c48254cac337",
+                                    "HierarchyId": "27a20d4c-1de3-40df-882f-348d05d4f068",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -5611,7 +5686,7 @@
                 },
                 {
                     "KPIVisual": {
-                        "VisualId": "d12d55bc-456c-477a-b596-60b282a952b2",
+                        "VisualId": "7cac118f-54ab-4dd0-b265-b2eaeae32551",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -5644,7 +5719,7 @@
                                                 "DataSetIdentifier": "clickstream_ods_events_view",
                                                 "ColumnName": "event_date"
                                             },
-                                            "HierarchyId": "42b26f30-fcd8-46a3-a544-eb0bcc3b6579",
+                                            "HierarchyId": "f07da83c-d70f-46db-adf9-71ea8b1b2e9b",
                                             "FormatConfiguration": {
                                                 "DateTimeFormat": "MM-DD-YYYY"
                                             }
@@ -5691,7 +5766,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "42b26f30-fcd8-46a3-a544-eb0bcc3b6579",
+                                    "HierarchyId": "f07da83c-d70f-46db-adf9-71ea8b1b2e9b",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -5700,7 +5775,7 @@
                 },
                 {
                     "BarChartVisual": {
-                        "VisualId": "b79ef075-fa07-4b43-b936-77976c70fc55",
+                        "VisualId": "8cab4bd8-cfd8-4e65-9824-8f6a031b264f",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -5721,7 +5796,7 @@
                                                     "DataSetIdentifier": "clickstream_ods_events_view",
                                                     "ColumnName": "event_date"
                                                 },
-                                                "HierarchyId": "70671633-7e25-40af-af68-6de6380d9017",
+                                                "HierarchyId": "6e0e5c37-f057-4aeb-99c0-b5d3b61042e8",
                                                 "FormatConfiguration": {
                                                     "DateTimeFormat": "MM-DD-YYYY"
                                                 }
@@ -5811,7 +5886,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "70671633-7e25-40af-af68-6de6380d9017",
+                                    "HierarchyId": "6e0e5c37-f057-4aeb-99c0-b5d3b61042e8",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -5820,7 +5895,7 @@
                 },
                 {
                     "LineChartVisual": {
-                        "VisualId": "4c3930c2-52f9-4dc5-be89-53fdf8d5108f",
+                        "VisualId": "31bd9418-dfba-4f78-b055-d21c2485d680",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -5841,7 +5916,7 @@
                                                     "DataSetIdentifier": "clickstream_ods_events_view",
                                                     "ColumnName": "event_date"
                                                 },
-                                                "HierarchyId": "8fe85bf6-e8f2-44f4-a456-a23569fc0e7a",
+                                                "HierarchyId": "b60ee594-2d15-466e-bd55-b9b8559f5585",
                                                 "FormatConfiguration": {
                                                     "DateTimeFormat": "MM-DD-YYYY"
                                                 }
@@ -5997,7 +6072,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "8fe85bf6-e8f2-44f4-a456-a23569fc0e7a",
+                                    "HierarchyId": "b60ee594-2d15-466e-bd55-b9b8559f5585",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -6006,7 +6081,7 @@
                 },
                 {
                     "LineChartVisual": {
-                        "VisualId": "e0daa829-1824-4e10-890a-af5c683e6da9",
+                        "VisualId": "7df0adb9-699c-44bc-b92c-24bb62ca44a0",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -6027,7 +6102,7 @@
                                                     "DataSetIdentifier": "clickstream_ods_events_view",
                                                     "ColumnName": "event_date"
                                                 },
-                                                "HierarchyId": "8e9c11f2-7c51-4f32-b4cc-b595904d776f",
+                                                "HierarchyId": "77efce6f-3c39-4e9a-a519-de1b3c7e5b9a",
                                                 "FormatConfiguration": {
                                                     "DateTimeFormat": "MM-DD-YYYY"
                                                 }
@@ -6133,7 +6208,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "8e9c11f2-7c51-4f32-b4cc-b595904d776f",
+                                    "HierarchyId": "77efce6f-3c39-4e9a-a519-de1b3c7e5b9a",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -6142,7 +6217,7 @@
                 },
                 {
                     "PivotTableVisual": {
-                        "VisualId": "7013c70d-04fc-442a-8531-9c2c0baf968d",
+                        "VisualId": "eceabf6a-cf64-4b0b-93fe-6145a99e26ce",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -6231,7 +6306,8 @@
                                     "TextWrap": "NONE"
                                 },
                                 "CellStyle": {
-                                    "TextWrap": "NONE"
+                                    "TextWrap": "NONE",
+                                    "Height": 25
                                 }
                             },
                             "FieldOptions": {
@@ -6277,9 +6353,11 @@
                                                 }
                                             }
                                         },
-                                        "Scope": {
-                                            "Role": "FIELD"
-                                        }
+                                        "Scopes": [
+                                            {
+                                                "Role": "FIELD"
+                                            }
+                                        ]
                                     }
                                 }
                             ]
@@ -6289,7 +6367,7 @@
                 },
                 {
                     "LineChartVisual": {
-                        "VisualId": "121341c5-d319-490d-a8ee-0015cf41af3f",
+                        "VisualId": "2f0b1ddf-b192-4846-ac9e-92e1deff3955",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -6397,7 +6475,7 @@
                 },
                 {
                     "LineChartVisual": {
-                        "VisualId": "718d29d2-298c-420c-b72c-68ded9f98736",
+                        "VisualId": "1f6a27dc-166c-44e2-b227-1dbe1fe93b85",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -6418,7 +6496,7 @@
                                                     "DataSetIdentifier": "clickstream_retention_view",
                                                     "ColumnName": "first_date"
                                                 },
-                                                "HierarchyId": "0bb6192c-3aa4-4c2d-b9c9-c8e115793457",
+                                                "HierarchyId": "354bb2a0-7a9d-47fb-8cd8-b1074860c57b",
                                                 "FormatConfiguration": {
                                                     "DateTimeFormat": "MM-DD-YYYY"
                                                 }
@@ -6509,7 +6587,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "0bb6192c-3aa4-4c2d-b9c9-c8e115793457",
+                                    "HierarchyId": "354bb2a0-7a9d-47fb-8cd8-b1074860c57b",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -6518,7 +6596,7 @@
                 },
                 {
                     "BarChartVisual": {
-                        "VisualId": "436c5066-a74c-4561-acd2-d17409995eef",
+                        "VisualId": "5d8c95cd-c210-4d70-bcc9-f56848d69ae1",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -6539,7 +6617,7 @@
                                                     "DataSetIdentifier": "clickstream_lifecycle_weekly_view",
                                                     "ColumnName": "time_period"
                                                 },
-                                                "HierarchyId": "a5396d0c-15f7-4a49-a7f5-4f560c5d6a50"
+                                                "HierarchyId": "c44e13d3-74ae-43c2-9865-c43697b94b4b"
                                             }
                                         }
                                     ],
@@ -6645,7 +6723,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "a5396d0c-15f7-4a49-a7f5-4f560c5d6a50",
+                                    "HierarchyId": "c44e13d3-74ae-43c2-9865-c43697b94b4b",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -6654,7 +6732,7 @@
                 },
                 {
                     "BarChartVisual": {
-                        "VisualId": "c26a2e95-48fd-49c9-9300-2e9b7ca8aff8",
+                        "VisualId": "d6694db8-a8eb-43d0-84f0-d6636d50a84e",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -6675,7 +6753,7 @@
                                                     "DataSetIdentifier": "clickstream_lifecycle_daily_view",
                                                     "ColumnName": "time_period"
                                                 },
-                                                "HierarchyId": "cc8458ba-e9b9-402b-9100-ae7912c5228c"
+                                                "HierarchyId": "8ac488ef-a12f-4267-9719-acd607c7dd30"
                                             }
                                         }
                                     ],
@@ -6781,7 +6859,7 @@
                         "ColumnHierarchies": [
                             {
                                 "DateTimeHierarchy": {
-                                    "HierarchyId": "cc8458ba-e9b9-402b-9100-ae7912c5228c",
+                                    "HierarchyId": "8ac488ef-a12f-4267-9719-acd607c7dd30",
                                     "DrillDownFilters": []
                                 }
                             }
@@ -6795,7 +6873,7 @@
                         "GridLayout": {
                             "Elements": [
                                 {
-                                    "ElementId": "d12d55bc-456c-477a-b596-60b282a952b2",
+                                    "ElementId": "7cac118f-54ab-4dd0-b265-b2eaeae32551",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 12,
@@ -6803,7 +6881,7 @@
                                     "RowSpan": 9
                                 },
                                 {
-                                    "ElementId": "f1496953-66fa-4992-9444-8c4e9139f597",
+                                    "ElementId": "579c0411-d82e-44e7-b820-f91a2acccda2",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 12,
                                     "ColumnSpan": 12,
@@ -6811,7 +6889,7 @@
                                     "RowSpan": 9
                                 },
                                 {
-                                    "ElementId": "29b25f47-785e-4a8b-89b5-dc838343b527",
+                                    "ElementId": "54d62bf2-a405-4586-a86a-5e2a4b503f8f",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 24,
                                     "ColumnSpan": 12,
@@ -6819,7 +6897,7 @@
                                     "RowSpan": 9
                                 },
                                 {
-                                    "ElementId": "b79ef075-fa07-4b43-b936-77976c70fc55",
+                                    "ElementId": "8cab4bd8-cfd8-4e65-9824-8f6a031b264f",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 36,
@@ -6827,7 +6905,7 @@
                                     "RowSpan": 12
                                 },
                                 {
-                                    "ElementId": "4c3930c2-52f9-4dc5-be89-53fdf8d5108f",
+                                    "ElementId": "31bd9418-dfba-4f78-b055-d21c2485d680",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 18,
@@ -6835,7 +6913,7 @@
                                     "RowSpan": 12
                                 },
                                 {
-                                    "ElementId": "e0daa829-1824-4e10-890a-af5c683e6da9",
+                                    "ElementId": "7df0adb9-699c-44bc-b92c-24bb62ca44a0",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 18,
                                     "ColumnSpan": 18,
@@ -6843,7 +6921,7 @@
                                     "RowSpan": 12
                                 },
                                 {
-                                    "ElementId": "7013c70d-04fc-442a-8531-9c2c0baf968d",
+                                    "ElementId": "eceabf6a-cf64-4b0b-93fe-6145a99e26ce",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 36,
@@ -6851,7 +6929,7 @@
                                     "RowSpan": 12
                                 },
                                 {
-                                    "ElementId": "121341c5-d319-490d-a8ee-0015cf41af3f",
+                                    "ElementId": "2f0b1ddf-b192-4846-ac9e-92e1deff3955",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 18,
@@ -6859,7 +6937,7 @@
                                     "RowSpan": 12
                                 },
                                 {
-                                    "ElementId": "718d29d2-298c-420c-b72c-68ded9f98736",
+                                    "ElementId": "1f6a27dc-166c-44e2-b227-1dbe1fe93b85",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 18,
                                     "ColumnSpan": 18,
@@ -6867,7 +6945,7 @@
                                     "RowSpan": 12
                                 },
                                 {
-                                    "ElementId": "436c5066-a74c-4561-acd2-d17409995eef",
+                                    "ElementId": "5d8c95cd-c210-4d70-bcc9-f56848d69ae1",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 36,
@@ -6875,7 +6953,7 @@
                                     "RowSpan": 12
                                 },
                                 {
-                                    "ElementId": "c26a2e95-48fd-49c9-9300-2e9b7ca8aff8",
+                                    "ElementId": "d6694db8-a8eb-43d0-84f0-d6636d50a84e",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 36,
@@ -6924,7 +7002,7 @@
             "ContentType": "INTERACTIVE"
         },
         {
-            "SheetId": "0e60a439-fd81-4067-8922-e24047346b99",
+            "SheetId": "1ee494f5-bed8-4f8d-9570-b1ebd3026c3c",
             "Name": "Device",
             "ParameterControls": [
                 {
@@ -6976,7 +7054,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -6993,7 +7075,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -7010,7 +7096,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -7027,7 +7117,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -7058,7 +7152,7 @@
             "Visuals": [
                 {
                     "BarChartVisual": {
-                        "VisualId": "6d25dd30-0bc6-4c4e-bf6f-ce4ad44c9704",
+                        "VisualId": "13e1d43f-0fa4-453f-aa8e-9cafd682602d",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -7168,7 +7262,7 @@
                 },
                 {
                     "BarChartVisual": {
-                        "VisualId": "a3cf205d-249a-4d85-ad55-f6269443d792",
+                        "VisualId": "eb6dc8a4-59aa-4f2e-80b4-1f5a474baf4d",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -7290,7 +7384,7 @@
                 },
                 {
                     "BarChartVisual": {
-                        "VisualId": "bebe3e2d-c699-4f40-ae97-c37b75dc4ef9",
+                        "VisualId": "4cb96e95-0735-4daf-8f2d-6ff7190c949c",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -7400,7 +7494,7 @@
                 },
                 {
                     "BarChartVisual": {
-                        "VisualId": "973ba3cc-b335-4073-b1e7-d6eaf2c669b6",
+                        "VisualId": "59f4aa71-445e-418a-9546-c8da5722c0e5",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -7493,7 +7587,7 @@
                 },
                 {
                     "TreeMapVisual": {
-                        "VisualId": "6ce905ac-015b-4907-85aa-bcfcee250e69",
+                        "VisualId": "c987d76a-a252-4c41-957b-f36d9efc30dc",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -7578,7 +7672,7 @@
                 },
                 {
                     "PieChartVisual": {
-                        "VisualId": "609cf144-3f0b-416a-88ea-176e35d9d693",
+                        "VisualId": "4671cf06-906a-47f5-b081-490cfd58c686",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -7670,7 +7764,7 @@
                 },
                 {
                     "BarChartVisual": {
-                        "VisualId": "2dd8eba3-26b5-4380-b1cc-28c9203015ec",
+                        "VisualId": "535a90ed-cfec-49f3-b06a-b5f1f80fda3a",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -7779,7 +7873,7 @@
                 },
                 {
                     "BarChartVisual": {
-                        "VisualId": "49e83b0e-2e7e-422b-9256-a5437df7a00b",
+                        "VisualId": "c4968fde-16b3-41bc-84a2-64f53cd95259",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -7889,7 +7983,7 @@
                 },
                 {
                     "TableVisual": {
-                        "VisualId": "611e327b-07ac-4cc6-8632-447231c1c110",
+                        "VisualId": "cd7c9875-5639-4b4d-a2cc-98a4b6dccc89",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -8107,7 +8201,7 @@
                 },
                 {
                     "BarChartVisual": {
-                        "VisualId": "e927ec1e-005b-4912-bf86-e8c6da5c5b35",
+                        "VisualId": "92160673-c0f6-41d8-bc43-50a00e0baf62",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -8200,7 +8294,7 @@
                 },
                 {
                     "PieChartVisual": {
-                        "VisualId": "c4adf4c0-f7a9-44ac-8d77-b86016dcf483",
+                        "VisualId": "739b8920-afe7-41c9-8ad6-951265b37c8a",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -8292,7 +8386,7 @@
                 },
                 {
                     "PieChartVisual": {
-                        "VisualId": "b767f22b-6842-40eb-8317-6ec56c0cf8a7",
+                        "VisualId": "27a29a2b-18a2-41c5-9609-dd9c467d9c34",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -8384,7 +8478,7 @@
                 },
                 {
                     "PieChartVisual": {
-                        "VisualId": "cf1cfea3-881a-4ba8-994b-8d654e8e4e67",
+                        "VisualId": "7a28d161-4e78-4920-b5e0-5325b9585438",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -8477,7 +8571,7 @@
             ],
             "TextBoxes": [
                 {
-                    "SheetTextBoxId": "7cd53c15-f0ad-4669-ae05-23fcc91d829d",
+                    "SheetTextBoxId": "6329633f-cc97-43d4-94bb-bd1b9746fe0d",
                     "Content": "<text-box>\n  <inline font-size=\"20px\">\n    <b>Device report</b>\n  </inline>\n  <br/>\n  <inline font-size=\"16px\">Device report helps you understand what device your users user to access your apps.</inline>\n  <br/>\n  <inline font-size=\"16px\">This report mainly based on data from the view of clickstream_device_view.</inline>\n</text-box>"
                 }
             ],
@@ -8487,7 +8581,7 @@
                         "GridLayout": {
                             "Elements": [
                                 {
-                                    "ElementId": "7cd53c15-f0ad-4669-ae05-23fcc91d829d",
+                                    "ElementId": "6329633f-cc97-43d4-94bb-bd1b9746fe0d",
                                     "ElementType": "TEXT_BOX",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 36,
@@ -8495,7 +8589,7 @@
                                     "RowSpan": 3
                                 },
                                 {
-                                    "ElementId": "973ba3cc-b335-4073-b1e7-d6eaf2c669b6",
+                                    "ElementId": "59f4aa71-445e-418a-9546-c8da5722c0e5",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 36,
@@ -8503,7 +8597,7 @@
                                     "RowSpan": 12
                                 },
                                 {
-                                    "ElementId": "6ce905ac-015b-4907-85aa-bcfcee250e69",
+                                    "ElementId": "c987d76a-a252-4c41-957b-f36d9efc30dc",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 36,
@@ -8511,7 +8605,7 @@
                                     "RowSpan": 12
                                 },
                                 {
-                                    "ElementId": "609cf144-3f0b-416a-88ea-176e35d9d693",
+                                    "ElementId": "4671cf06-906a-47f5-b081-490cfd58c686",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 18,
@@ -8519,7 +8613,7 @@
                                     "RowSpan": 12
                                 },
                                 {
-                                    "ElementId": "2dd8eba3-26b5-4380-b1cc-28c9203015ec",
+                                    "ElementId": "535a90ed-cfec-49f3-b06a-b5f1f80fda3a",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 18,
                                     "ColumnSpan": 18,
@@ -8527,7 +8621,7 @@
                                     "RowSpan": 12
                                 },
                                 {
-                                    "ElementId": "e927ec1e-005b-4912-bf86-e8c6da5c5b35",
+                                    "ElementId": "92160673-c0f6-41d8-bc43-50a00e0baf62",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 18,
@@ -8535,7 +8629,7 @@
                                     "RowSpan": 12
                                 },
                                 {
-                                    "ElementId": "c4adf4c0-f7a9-44ac-8d77-b86016dcf483",
+                                    "ElementId": "739b8920-afe7-41c9-8ad6-951265b37c8a",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 18,
                                     "ColumnSpan": 18,
@@ -8543,7 +8637,7 @@
                                     "RowSpan": 12
                                 },
                                 {
-                                    "ElementId": "b767f22b-6842-40eb-8317-6ec56c0cf8a7",
+                                    "ElementId": "27a29a2b-18a2-41c5-9609-dd9c467d9c34",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 18,
@@ -8551,7 +8645,7 @@
                                     "RowSpan": 12
                                 },
                                 {
-                                    "ElementId": "cf1cfea3-881a-4ba8-994b-8d654e8e4e67",
+                                    "ElementId": "7a28d161-4e78-4920-b5e0-5325b9585438",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 18,
                                     "ColumnSpan": 18,
@@ -8559,7 +8653,7 @@
                                     "RowSpan": 12
                                 },
                                 {
-                                    "ElementId": "49e83b0e-2e7e-422b-9256-a5437df7a00b",
+                                    "ElementId": "c4968fde-16b3-41bc-84a2-64f53cd95259",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 9,
@@ -8567,7 +8661,7 @@
                                     "RowSpan": 10
                                 },
                                 {
-                                    "ElementId": "bebe3e2d-c699-4f40-ae97-c37b75dc4ef9",
+                                    "ElementId": "4cb96e95-0735-4daf-8f2d-6ff7190c949c",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 9,
                                     "ColumnSpan": 9,
@@ -8575,7 +8669,7 @@
                                     "RowSpan": 10
                                 },
                                 {
-                                    "ElementId": "6d25dd30-0bc6-4c4e-bf6f-ce4ad44c9704",
+                                    "ElementId": "13e1d43f-0fa4-453f-aa8e-9cafd682602d",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 18,
                                     "ColumnSpan": 9,
@@ -8583,7 +8677,7 @@
                                     "RowSpan": 10
                                 },
                                 {
-                                    "ElementId": "a3cf205d-249a-4d85-ad55-f6269443d792",
+                                    "ElementId": "eb6dc8a4-59aa-4f2e-80b4-1f5a474baf4d",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 27,
                                     "ColumnSpan": 9,
@@ -8623,7 +8717,7 @@
                                     "RowSpan": 3
                                 },
                                 {
-                                    "ElementId": "611e327b-07ac-4cc6-8632-447231c1c110",
+                                    "ElementId": "cd7c9875-5639-4b4d-a2cc-98a4b6dccc89",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 36,
@@ -8672,7 +8766,7 @@
             "ContentType": "INTERACTIVE"
         },
         {
-            "SheetId": "737019a2-83d0-49bd-a670-10bc0fad740d",
+            "SheetId": "0e5590b2-cc3b-4fd4-9578-a5f73441def0",
             "Name": "Path explorer",
             "ParameterControls": [
                 {
@@ -8724,7 +8818,11 @@
                             },
                             "TitleOptions": {
                                 "Visibility": "VISIBLE",
-                                "FontConfiguration": {}
+                                "FontConfiguration": {
+                                    "FontSize": {
+                                        "Relative": "MEDIUM"
+                                    }
+                                }
                             }
                         },
                         "Type": "MULTI_SELECT"
@@ -8734,7 +8832,7 @@
             "Visuals": [
                 {
                     "SankeyDiagramVisual": {
-                        "VisualId": "a034f06f-5611-4177-9489-ab18badf71c8",
+                        "VisualId": "084132ef-2529-4eec-b2df-1c891930cc80",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -8803,7 +8901,7 @@
                 },
                 {
                     "BarChartVisual": {
-                        "VisualId": "77bf130a-8db9-48c4-8d61-46d96e45c556",
+                        "VisualId": "e3b095d3-e44d-4705-b1e3-5bce7e0cb97d",
                         "Title": {
                             "Visibility": "VISIBLE",
                             "FormatText": {
@@ -8927,7 +9025,7 @@
                         "GridLayout": {
                             "Elements": [
                                 {
-                                    "ElementId": "a034f06f-5611-4177-9489-ab18badf71c8",
+                                    "ElementId": "084132ef-2529-4eec-b2df-1c891930cc80",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 36,
@@ -8935,7 +9033,7 @@
                                     "RowSpan": 12
                                 },
                                 {
-                                    "ElementId": "77bf130a-8db9-48c4-8d61-46d96e45c556",
+                                    "ElementId": "e3b095d3-e44d-4705-b1e3-5bce7e0cb97d",
                                     "ElementType": "VISUAL",
                                     "ColumnIndex": 0,
                                     "ColumnSpan": 36,
@@ -9196,7 +9294,7 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "8f0ddf67-9443-4072-91b8-13658b385d88",
+                            "SheetId": "45e2377a-4ca3-40db-9c20-5ec8e0a87eda",
                             "Scope": "ALL_VISUALS"
                         }
                     ]
@@ -9228,7 +9326,7 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "8f0ddf67-9443-4072-91b8-13658b385d88",
+                            "SheetId": "45e2377a-4ca3-40db-9c20-5ec8e0a87eda",
                             "Scope": "ALL_VISUALS"
                         }
                     ]
@@ -9260,7 +9358,7 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "8f0ddf67-9443-4072-91b8-13658b385d88",
+                            "SheetId": "45e2377a-4ca3-40db-9c20-5ec8e0a87eda",
                             "Scope": "ALL_VISUALS"
                         }
                     ]
@@ -9292,10 +9390,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "8f0ddf67-9443-4072-91b8-13658b385d88",
+                            "SheetId": "45e2377a-4ca3-40db-9c20-5ec8e0a87eda",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "70781d6f-7ccf-4f9a-8f39-55c8b5b25c3f"
+                                "3b75c206-6012-4eff-a36d-06b743a54959"
                             ]
                         }
                     ]
@@ -9327,10 +9425,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "8f0ddf67-9443-4072-91b8-13658b385d88",
+                            "SheetId": "45e2377a-4ca3-40db-9c20-5ec8e0a87eda",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "70781d6f-7ccf-4f9a-8f39-55c8b5b25c3f"
+                                "3b75c206-6012-4eff-a36d-06b743a54959"
                             ]
                         }
                     ]
@@ -9362,10 +9460,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "8f0ddf67-9443-4072-91b8-13658b385d88",
+                            "SheetId": "45e2377a-4ca3-40db-9c20-5ec8e0a87eda",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "70781d6f-7ccf-4f9a-8f39-55c8b5b25c3f"
+                                "3b75c206-6012-4eff-a36d-06b743a54959"
                             ]
                         }
                     ]
@@ -9397,10 +9495,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "8f0ddf67-9443-4072-91b8-13658b385d88",
+                            "SheetId": "45e2377a-4ca3-40db-9c20-5ec8e0a87eda",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "b2522804-a175-4b3a-b691-67f6636ae6da"
+                                "eb16e8fc-d0c5-4d16-88d9-9e6d5165920f"
                             ]
                         }
                     ]
@@ -9432,10 +9530,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "8f0ddf67-9443-4072-91b8-13658b385d88",
+                            "SheetId": "45e2377a-4ca3-40db-9c20-5ec8e0a87eda",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "b2522804-a175-4b3a-b691-67f6636ae6da"
+                                "eb16e8fc-d0c5-4d16-88d9-9e6d5165920f"
                             ]
                         }
                     ]
@@ -9467,10 +9565,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "8f0ddf67-9443-4072-91b8-13658b385d88",
+                            "SheetId": "45e2377a-4ca3-40db-9c20-5ec8e0a87eda",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "70781d6f-7ccf-4f9a-8f39-55c8b5b25c3f"
+                                "3b75c206-6012-4eff-a36d-06b743a54959"
                             ]
                         }
                     ]
@@ -9502,10 +9600,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "8f0ddf67-9443-4072-91b8-13658b385d88",
+                            "SheetId": "45e2377a-4ca3-40db-9c20-5ec8e0a87eda",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "70781d6f-7ccf-4f9a-8f39-55c8b5b25c3f"
+                                "3b75c206-6012-4eff-a36d-06b743a54959"
                             ]
                         }
                     ]
@@ -9541,7 +9639,7 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "40d55f9e-966e-487d-9a8b-e10246cdcfd9",
+                            "SheetId": "b08b0dfa-5395-4a6a-8974-78a9ee004399",
                             "Scope": "ALL_VISUALS"
                         }
                     ]
@@ -9573,7 +9671,7 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "40d55f9e-966e-487d-9a8b-e10246cdcfd9",
+                            "SheetId": "b08b0dfa-5395-4a6a-8974-78a9ee004399",
                             "Scope": "ALL_VISUALS"
                         }
                     ]
@@ -9609,7 +9707,7 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "b4b3cd9b-3306-4310-8c12-b260ffadda23",
+                            "SheetId": "4a083137-a3c4-4952-b7a7-ca468d9533c1",
                             "Scope": "ALL_VISUALS"
                         }
                     ]
@@ -9641,7 +9739,7 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "b4b3cd9b-3306-4310-8c12-b260ffadda23",
+                            "SheetId": "4a083137-a3c4-4952-b7a7-ca468d9533c1",
                             "Scope": "ALL_VISUALS"
                         }
                     ]
@@ -9675,10 +9773,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "b4b3cd9b-3306-4310-8c12-b260ffadda23",
+                            "SheetId": "4a083137-a3c4-4952-b7a7-ca468d9533c1",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "603c8055-3619-4274-b0b2-6d75c8566f8c"
+                                "8cba4e78-1c98-43e2-aee6-fcdf13b64a48"
                             ]
                         }
                     ]
@@ -9712,10 +9810,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "b4b3cd9b-3306-4310-8c12-b260ffadda23",
+                            "SheetId": "4a083137-a3c4-4952-b7a7-ca468d9533c1",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "603c8055-3619-4274-b0b2-6d75c8566f8c"
+                                "8cba4e78-1c98-43e2-aee6-fcdf13b64a48"
                             ]
                         }
                     ]
@@ -9747,10 +9845,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "b4b3cd9b-3306-4310-8c12-b260ffadda23",
+                            "SheetId": "4a083137-a3c4-4952-b7a7-ca468d9533c1",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "df7ceb0d-8eb1-4c26-81d3-123da87f229d"
+                                "62cff7c9-c4b0-44cf-a43d-4251c7df97fe"
                             ]
                         }
                     ]
@@ -9782,10 +9880,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "b4b3cd9b-3306-4310-8c12-b260ffadda23",
+                            "SheetId": "4a083137-a3c4-4952-b7a7-ca468d9533c1",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "df7ceb0d-8eb1-4c26-81d3-123da87f229d"
+                                "62cff7c9-c4b0-44cf-a43d-4251c7df97fe"
                             ]
                         }
                     ]
@@ -9817,10 +9915,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "b4b3cd9b-3306-4310-8c12-b260ffadda23",
+                            "SheetId": "4a083137-a3c4-4952-b7a7-ca468d9533c1",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "df7ceb0d-8eb1-4c26-81d3-123da87f229d"
+                                "62cff7c9-c4b0-44cf-a43d-4251c7df97fe"
                             ]
                         }
                     ]
@@ -9852,10 +9950,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "b4b3cd9b-3306-4310-8c12-b260ffadda23",
+                            "SheetId": "4a083137-a3c4-4952-b7a7-ca468d9533c1",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "df7ceb0d-8eb1-4c26-81d3-123da87f229d"
+                                "62cff7c9-c4b0-44cf-a43d-4251c7df97fe"
                             ]
                         }
                     ]
@@ -9887,10 +9985,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "b4b3cd9b-3306-4310-8c12-b260ffadda23",
+                            "SheetId": "4a083137-a3c4-4952-b7a7-ca468d9533c1",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "df7ceb0d-8eb1-4c26-81d3-123da87f229d"
+                                "62cff7c9-c4b0-44cf-a43d-4251c7df97fe"
                             ]
                         }
                     ]
@@ -9922,10 +10020,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "b4b3cd9b-3306-4310-8c12-b260ffadda23",
+                            "SheetId": "4a083137-a3c4-4952-b7a7-ca468d9533c1",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "df7ceb0d-8eb1-4c26-81d3-123da87f229d"
+                                "62cff7c9-c4b0-44cf-a43d-4251c7df97fe"
                             ]
                         }
                     ]
@@ -9957,10 +10055,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "b4b3cd9b-3306-4310-8c12-b260ffadda23",
+                            "SheetId": "4a083137-a3c4-4952-b7a7-ca468d9533c1",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "df7ceb0d-8eb1-4c26-81d3-123da87f229d"
+                                "62cff7c9-c4b0-44cf-a43d-4251c7df97fe"
                             ]
                         }
                     ]
@@ -9992,10 +10090,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "b4b3cd9b-3306-4310-8c12-b260ffadda23",
+                            "SheetId": "4a083137-a3c4-4952-b7a7-ca468d9533c1",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "df7ceb0d-8eb1-4c26-81d3-123da87f229d"
+                                "62cff7c9-c4b0-44cf-a43d-4251c7df97fe"
                             ]
                         }
                     ]
@@ -10023,10 +10121,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "b4b3cd9b-3306-4310-8c12-b260ffadda23",
+                            "SheetId": "4a083137-a3c4-4952-b7a7-ca468d9533c1",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "df7ceb0d-8eb1-4c26-81d3-123da87f229d"
+                                "62cff7c9-c4b0-44cf-a43d-4251c7df97fe"
                             ]
                         }
                     ]
@@ -10058,10 +10156,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "b4b3cd9b-3306-4310-8c12-b260ffadda23",
+                            "SheetId": "4a083137-a3c4-4952-b7a7-ca468d9533c1",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "9f8f0d34-e608-481e-94ca-550f9f54b9d3"
+                                "577b7fce-cba9-42cc-ac99-e6190006544a"
                             ]
                         }
                     ]
@@ -10093,10 +10191,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "b4b3cd9b-3306-4310-8c12-b260ffadda23",
+                            "SheetId": "4a083137-a3c4-4952-b7a7-ca468d9533c1",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "9f8f0d34-e608-481e-94ca-550f9f54b9d3"
+                                "577b7fce-cba9-42cc-ac99-e6190006544a"
                             ]
                         }
                     ]
@@ -10149,10 +10247,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "46ff0142-9808-4e28-b4e6-dc4b4260e853",
+                            "SheetId": "580757e4-13a6-49ee-9907-ddea75d86907",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "718d29d2-298c-420c-b72c-68ded9f98736"
+                                "1f6a27dc-166c-44e2-b227-1dbe1fe93b85"
                             ]
                         }
                     ]
@@ -10184,10 +10282,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "46ff0142-9808-4e28-b4e6-dc4b4260e853",
+                            "SheetId": "580757e4-13a6-49ee-9907-ddea75d86907",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "718d29d2-298c-420c-b72c-68ded9f98736"
+                                "1f6a27dc-166c-44e2-b227-1dbe1fe93b85"
                             ]
                         }
                     ]
@@ -10223,7 +10321,7 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "46ff0142-9808-4e28-b4e6-dc4b4260e853",
+                            "SheetId": "580757e4-13a6-49ee-9907-ddea75d86907",
                             "Scope": "ALL_VISUALS"
                         }
                     ]
@@ -10255,7 +10353,7 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "46ff0142-9808-4e28-b4e6-dc4b4260e853",
+                            "SheetId": "580757e4-13a6-49ee-9907-ddea75d86907",
                             "Scope": "ALL_VISUALS"
                         }
                     ]
@@ -10291,10 +10389,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "46ff0142-9808-4e28-b4e6-dc4b4260e853",
+                            "SheetId": "580757e4-13a6-49ee-9907-ddea75d86907",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "436c5066-a74c-4561-acd2-d17409995eef"
+                                "5d8c95cd-c210-4d70-bcc9-f56848d69ae1"
                             ]
                         }
                     ]
@@ -10330,10 +10428,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "46ff0142-9808-4e28-b4e6-dc4b4260e853",
+                            "SheetId": "580757e4-13a6-49ee-9907-ddea75d86907",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "c26a2e95-48fd-49c9-9300-2e9b7ca8aff8"
+                                "d6694db8-a8eb-43d0-84f0-d6636d50a84e"
                             ]
                         }
                     ]
@@ -10365,10 +10463,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "0e60a439-fd81-4067-8922-e24047346b99",
+                            "SheetId": "1ee494f5-bed8-4f8d-9570-b1ebd3026c3c",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "611e327b-07ac-4cc6-8632-447231c1c110"
+                                "cd7c9875-5639-4b4d-a2cc-98a4b6dccc89"
                             ]
                         }
                     ]
@@ -10400,10 +10498,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "0e60a439-fd81-4067-8922-e24047346b99",
+                            "SheetId": "1ee494f5-bed8-4f8d-9570-b1ebd3026c3c",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "611e327b-07ac-4cc6-8632-447231c1c110"
+                                "cd7c9875-5639-4b4d-a2cc-98a4b6dccc89"
                             ]
                         }
                     ]
@@ -10435,10 +10533,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "0e60a439-fd81-4067-8922-e24047346b99",
+                            "SheetId": "1ee494f5-bed8-4f8d-9570-b1ebd3026c3c",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "611e327b-07ac-4cc6-8632-447231c1c110"
+                                "cd7c9875-5639-4b4d-a2cc-98a4b6dccc89"
                             ]
                         }
                     ]
@@ -10470,10 +10568,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "0e60a439-fd81-4067-8922-e24047346b99",
+                            "SheetId": "1ee494f5-bed8-4f8d-9570-b1ebd3026c3c",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "611e327b-07ac-4cc6-8632-447231c1c110"
+                                "cd7c9875-5639-4b4d-a2cc-98a4b6dccc89"
                             ]
                         }
                     ]
@@ -10505,7 +10603,7 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "0e60a439-fd81-4067-8922-e24047346b99",
+                            "SheetId": "1ee494f5-bed8-4f8d-9570-b1ebd3026c3c",
                             "Scope": "ALL_VISUALS"
                         }
                     ]
@@ -10513,6 +10611,42 @@
             },
             "Status": "ENABLED",
             "CrossDataset": "SINGLE_DATASET"
+        },
+        {
+            "FilterGroupId": "bcc338b3-aa5c-426e-ae25-1f0a166278f5",
+            "Filters": [
+                {
+                    "TimeRangeFilter": {
+                        "FilterId": "437a88ec-9934-4217-b29b-208478b180fb",
+                        "Column": {
+                            "DataSetIdentifier": "clickstream_device_view",
+                            "ColumnName": "event_date"
+                        },
+                        "IncludeMinimum": true,
+                        "IncludeMaximum": true,
+                        "RangeMinimumValue": {
+                            "Parameter": "EventStartDate"
+                        },
+                        "RangeMaximumValue": {
+                            "Parameter": "EventEndDate"
+                        },
+                        "NullOption": "NON_NULLS_ONLY",
+                        "TimeGranularity": "DAY"
+                    }
+                }
+            ],
+            "ScopeConfiguration": {
+                "SelectedSheets": {
+                    "SheetVisualScopingConfigurations": [
+                        {
+                            "SheetId": "1ee494f5-bed8-4f8d-9570-b1ebd3026c3c",
+                            "Scope": "ALL_VISUALS"
+                        }
+                    ]
+                }
+            },
+            "Status": "ENABLED",
+            "CrossDataset": "ALL_DATASETS"
         },
         {
             "FilterGroupId": "c579aa2c-87fa-46d4-8184-6a0cb36cce43",
@@ -10539,10 +10673,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "737019a2-83d0-49bd-a670-10bc0fad740d",
+                            "SheetId": "0e5590b2-cc3b-4fd4-9578-a5f73441def0",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "a034f06f-5611-4177-9489-ab18badf71c8"
+                                "084132ef-2529-4eec-b2df-1c891930cc80"
                             ]
                         }
                     ]
@@ -10580,10 +10714,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "737019a2-83d0-49bd-a670-10bc0fad740d",
+                            "SheetId": "0e5590b2-cc3b-4fd4-9578-a5f73441def0",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "77bf130a-8db9-48c4-8d61-46d96e45c556"
+                                "e3b095d3-e44d-4705-b1e3-5bce7e0cb97d"
                             ]
                         }
                     ]
@@ -10615,7 +10749,7 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "737019a2-83d0-49bd-a670-10bc0fad740d",
+                            "SheetId": "0e5590b2-cc3b-4fd4-9578-a5f73441def0",
                             "Scope": "ALL_VISUALS"
                         }
                     ]
@@ -10651,10 +10785,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "737019a2-83d0-49bd-a670-10bc0fad740d",
+                            "SheetId": "0e5590b2-cc3b-4fd4-9578-a5f73441def0",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "a034f06f-5611-4177-9489-ab18badf71c8"
+                                "084132ef-2529-4eec-b2df-1c891930cc80"
                             ]
                         }
                     ]
@@ -10690,10 +10824,10 @@
                 "SelectedSheets": {
                     "SheetVisualScopingConfigurations": [
                         {
-                            "SheetId": "737019a2-83d0-49bd-a670-10bc0fad740d",
+                            "SheetId": "0e5590b2-cc3b-4fd4-9578-a5f73441def0",
                             "Scope": "SELECTED_VISUALS",
                             "VisualIds": [
-                                "77bf130a-8db9-48c4-8d61-46d96e45c556"
+                                "e3b095d3-e44d-4705-b1e3-5bce7e0cb97d"
                             ]
                         }
                     ]


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

update QuickSight dashboard - device sheet
make timeStart and timeEnd filter take effect

fix #61 

## Implementation highlights

update device report and regenerate analysis template definition

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [x] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module