### PR TITLE
fix: update password format to meet QuickSight connection's requirement

### DIFF
--- a/src/analytics/lambdas/custom-resource/create-schemas.ts
+++ b/src/analytics/lambdas/custom-resource/create-schemas.ts
@@ -394,7 +394,7 @@ const createDatabaseBIUser = async (redshiftClient: RedshiftDataClient, credenti
   props: CreateDatabaseAndSchemas) => {
   try {
     await executeStatementsWithWait(redshiftClient, [
-      `CREATE USER ${credential.username} PASSWORD 'sha256|${credential.password}'`,
+      `CREATE USER ${credential.username} PASSWORD '${credential.password}'`,
     ], props.serverlessRedshiftProps, props.provisionedRedshiftProps,
     props.serverlessRedshiftProps?.databaseName ?? props.provisionedRedshiftProps?.databaseName, false);
   } catch (err) {

--- a/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
@@ -358,7 +358,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
     lambdaMock.on(ListTagsCommand).resolves({
       Tags: { tag_key: 'tag_value' },
     });
-    const regex = new RegExp(`^CREATE USER ${biUserNamePrefix}[a-z0-9]{8} PASSWORD 'sha256|[a-zA-Z0-9!#$%^&-_=+|]{32}'$`);
+    const regex = new RegExp(`^CREATE USER ${biUserNamePrefix}[a-z0-9]{8} PASSWORD '[a-zA-Z0-9!#$%^&-_=+|]{32}'$`);
     redshiftDataMock.on(ExecuteStatementCommand).resolvesOnce({ Id: 'Id-1' })
       .callsFakeOnce(input => {
         if (input as ExecuteStatementCommandInput && regex.test(input.Sql)) {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

update redshift user password format to meet QuickSight connection's requirement

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module