### PR TITLE
chore: configure weekly dependencies update

### DIFF
--- a/.github/workflows/build-sub-projects.yml
+++ b/.github/workflows/build-sub-projects.yml
@@ -64,6 +64,7 @@ jobs:
           include_passed: true
       - name: Add coverage to PR
         id: jacoco
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
         uses: madrapps/jacoco-report@v1.4
         with:
           paths: ./src/data-pipeline/spark-etl/build/reports/jacoco/jacocoAggregatedReport/jacocoAggregatedReport.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           output: both
           thresholds: 60 80
       - name: Add Coverage PR Comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           recreate: true

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -4,7 +4,7 @@ name: upgrade
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 * * 1
 jobs:
   upgrade:
     name: Upgrade
@@ -24,6 +24,10 @@ jobs:
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
         run: npx projen upgrade
+      - name: Upgrade API dependencies
+        run: cd src/control-plane/backend/lambda/api/ && npx projen upgrade && cd ../../../../../
+      - name: Upgrade frontend dependencies
+        run: yarn upgrade --cwd frontend
       - name: Find mutations
         id: create_patch
         run: |-


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

there is some additional repo setting,

- [x] add an action secret named `PROJEN_GITHUB_TOKEN` with below fine-grained permissions of personal access token
  -  read/write content
  - read/write pull request
  - read/write workflow

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] manully trigger the workflow run in forked repo without errors
- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module