### PR TITLE
chore: copy extensions asset from lambda-adapter image

### DIFF
--- a/src/control-plane/backend/layer/lambda-web-adapter/Dockerfile
+++ b/src/control-plane/backend/layer/lambda-web-adapter/Dockerfile
@@ -1,25 +1,8 @@
 ARG TARGET_PLATFORM=linux/amd64
-FROM --platform=$TARGET_PLATFORM public.ecr.aws/amazonlinux/amazonlinux:2 as build-stage
-ARG ARCH=x86_64
 ARG ADAPTER_VERSION=0.7.0
-RUN rpm --rebuilddb && yum install -y yum-plugin-ovl jq unzip wget &&\
-    yum groupinstall -y "Development tools" &&\
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y &&\
-    source $HOME/.cargo/env && rustup target add ${ARCH}-unknown-linux-musl &&\
-    curl -k -o /${ARCH}-linux-musl-cross.tgz https://musl.cc/${ARCH}-linux-musl-cross.tgz \
-        && tar zxf /${ARCH}-linux-musl-cross.tgz \
-        && ln -s /${ARCH}-linux-musl-cross/bin/${ARCH}-linux-musl-gcc /usr/local/bin/${ARCH}-unknown-linux-musl-gcc
-WORKDIR /app
-RUN wget https://github.com/awslabs/aws-lambda-web-adapter/archive/refs/tags/v${ADAPTER_VERSION}.zip &&\
-    unzip v${ADAPTER_VERSION}.zip &&\
-    mv aws-lambda-web-adapter-${ADAPTER_VERSION} aws-lambda-web-adapter &&\
-    cd aws-lambda-web-adapter &&\
-    source $HOME/.cargo/env &&\
-    LAMBDA_RUNTIME_USER_AGENT=aws-lambda-rust/aws-lambda-adapter/$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].version') \
-    CC=${ARCH}-unknown-linux-musl-gcc cargo build --release --target=${ARCH}-unknown-linux-musl
+FROM --platform=$TARGET_PLATFORM public.ecr.aws/awsguru/aws-lambda-adapter:$ADAPTER_VERSION as build-stage
 
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 as  package-stage
-ARG ARCH=x86_64
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 as package-stage
 RUN mkdir -p /asset/extensions
-COPY --from=build-stage /app/aws-lambda-web-adapter/target/${ARCH}-unknown-linux-musl/release/lambda-adapter /asset/extensions/lambda-adapter
-COPY --from=build-stage /app/aws-lambda-web-adapter/layer/* /asset/
+COPY --from=build-stage /lambda-adapter /asset/extensions/lambda-adapter
+COPY ./bootstrap /asset/bootstrap

--- a/src/control-plane/backend/layer/lambda-web-adapter/bootstrap
+++ b/src/control-plane/backend/layer/lambda-web-adapter/bootstrap
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec -- "${LAMBDA_TASK_ROOT}/${_HANDLER}"


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

closes: #95 

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [x] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [x] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [x] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module