### PR TITLE
feat: enable self-kafka and ignore invalid format message in kafka connector

### DIFF
--- a/frontend/src/ts/const.ts
+++ b/frontend/src/ts/const.ts
@@ -13,7 +13,7 @@ import { SelectProps } from '@cloudscape-design/components';
  *  and limitations under the License.
  */
 export const SUPPORT_USER_SELECT_REDSHIFT_SERVERLESS = false;
-export const SUPPORT_SELF_HOSTED_KAFKA = false;
+export const SUPPORT_SELF_HOSTED_KAFKA = true;
 
 export const PROJECT_CONFIG_JSON = 'ClickStreamOnAWSConfigId';
 export const CONFIG_URL = '/aws-exports.json';

--- a/src/ingestion-server/kafka-s3-connector/custom-resource/kafka-s3-sink-connector/index.ts
+++ b/src/ingestion-server/kafka-s3-connector/custom-resource/kafka-s3-sink-connector/index.ts
@@ -360,6 +360,7 @@ function getConnectorConfiguration(
     'flush.size': `${props.flushSize}`,
     'rotate.interval.ms': `${props.rotateIntervalMS}`,
     'rotate.schedule.interval.ms': `${props.rotateIntervalMS}`,
+    'errors.tolerance': 'all',
     's3.compression.type': 'gzip',
     'storage.class': 'io.confluent.connect.s3.storage.S3Storage',
     'format.class': 'io.confluent.connect.s3.format.json.JsonFormat',

--- a/test/ingestion-server/kafka-s3-connector/custom-resource/kafka-s3-sink-connector.test.ts
+++ b/test/ingestion-server/kafka-s3-connector/custom-resource/kafka-s3-sink-connector.test.ts
@@ -448,6 +448,7 @@ test('Check connector hardcode configurations are correct', async () => {
     expect(cmd.connectorConfiguration['partition.duration.ms']).toEqual('60000');
     expect(cmd.connectorConfiguration['rotate.interval.ms']).toEqual('60000');
     expect(cmd.connectorConfiguration['rotate.schedule.interval.ms']).toEqual('60000');
+    expect(cmd.connectorConfiguration['errors.tolerance']).toEqual('all');
     expect(cmd.connectorConfiguration.timezone).toEqual('UTC');
     expect(cmd.connectorConfiguration.locale).toEqual('en-US');
     expect(cmd.connectorConfiguration['key.converter']).toEqual('org.apache.kafka.connect.storage.StringConverter');


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Enable self-kafka and ignore invalid format message in kafka connector

## Implementation highlights

1. Enable control plane to support self-hosted kafka cluster
2. Add configuration to make kafka connector to ignore invalid format message.

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [x] end-to-end tests
  - [x] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [x] deploy ingestion server
    - [x] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module