### PR TITLE
chore: mitigate toomany requests when pulling from public ecr in github actions

### DIFF
--- a/.github/workflows/build-sub-projects.yml
+++ b/.github/workflows/build-sub-projects.yml
@@ -34,6 +34,8 @@ jobs:
   build-data-pipeline:
     name: build data pipeline
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,12 @@ jobs:
       contents: write
       checks: write
       pull-requests: write
+      id-token: write
     outputs:
       self_mutation_happened: ${{ steps.self_mutation.outputs.self_mutation_happened }}
     env:
       CI: "true"
+      iam_role_to_assume: ${{ secrets.ROLE_ARN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -27,6 +29,17 @@ jobs:
           node-version: 16.18.0
       - name: Install dependencies
         run: yarn install --check-files
+      - name: Configure AWS Credentials
+        if: ${{ env.iam_role_to_assume != '' }}
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.iam_role_to_assume }}
+          aws-region: us-east-1
+      - name: Login to Amazon ECR Public
+        if: ${{ env.iam_role_to_assume != '' }}
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: public
       - name: build
         run: npx projen build
       - name: Publish Test Report

--- a/.github/workflows/dist-scan.yml
+++ b/.github/workflows/dist-scan.yml
@@ -5,12 +5,28 @@ on:
 jobs:
   build-dist:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      iam_role_to_assume: ${{ secrets.ROLE_ARN }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 16
+      - name: Configure AWS Credentials
+        if: ${{ env.iam_role_to_assume != '' }}
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.iam_role_to_assume }}
+          aws-region: us-east-1
+      - name: Login to Amazon ECR Public
+        if: ${{ env.iam_role_to_assume != '' }}
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: public
       - name: Test build dist
         run: |-
           chmod +x ./deployment/test-build-dist-1.sh

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -275,6 +275,31 @@ project.buildWorkflow.workflow.file?.addOverride(
   'jobs.build.permissions.pull-requests',
   'write',
 );
+project.buildWorkflow.workflow.file?.addOverride(
+  'jobs.build.permissions.id-token',
+  'write',
+);
+project.buildWorkflow.workflow.file?.addOverride(
+  'jobs.build.env.iam_role_to_assume',
+  '${{ secrets.ROLE_ARN }}',
+);
+project.buildWorkflow.preBuildSteps.push({
+  name: 'Configure AWS Credentials',
+  if: '${{ env.iam_role_to_assume != \'\' }}',
+  uses: 'aws-actions/configure-aws-credentials@v2',
+  with: {
+    'role-to-assume': '${{ env.iam_role_to_assume }}',
+    'aws-region': 'us-east-1',
+  },
+});
+project.buildWorkflow.preBuildSteps.push({
+  name: 'Login to Amazon ECR Public',
+  if: '${{ env.iam_role_to_assume != \'\' }}',
+  uses: 'aws-actions/amazon-ecr-login@v1',
+  with: {
+    'registry-type': 'public',
+  },
+});
 project.buildWorkflow.addPostBuildSteps({
   name: 'Publish Test Report',
   uses: 'mikepenz/action-junit-report@v3',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Login public ecr when the secret `ROLE_ARN` if it exists

## Implementation highlights

Below are the procedures to generate the role to meet the requirements with least privilege,

1. use [the template](https://github.com/aws-actions/configure-aws-credentials#sample-iam-oidc-cloudformation-template) to create the identity provider of Github and IAM role
2. grant the role with [permission to login public ecr](https://github.com/aws-actions/configure-aws-credentials#sample-iam-oidc-cloudformation-template)
3. create an action secret `ROLE_ARN` in repo with the value of role arn created by step 1

**Note**: it only helps the committers to submit PR in this repo. Due to we store the role arn in secret which is not available when the pull request is from forked repository.

## Test checklist

- [x] tested in forked repository
- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module