### PR TITLE
fix: check Redshift DB user in both frontend and backend

### DIFF
--- a/frontend/public/locales/en/pipeline.json
+++ b/frontend/public/locales/en/pipeline.json
@@ -45,6 +45,7 @@
     "redshiftServerlessSubnetInvalidError": "Please select at least 3 subnets locates in at least 2 different AZ",
     "redshiftProvisionedCulsterEmptyError": "Please select a culster",
     "redshiftProvisionedDBUserEmptyError": "Please input the database user.",
+    "redshiftProvisionedDBUserFormatError": "Database user format error",
     "quickSightUserEmptyError": "Please select a QuickSight user.",
     "emailInvalid": "Email invalid."
   },

--- a/frontend/public/locales/zh/pipeline.json
+++ b/frontend/public/locales/zh/pipeline.json
@@ -45,6 +45,7 @@
     "redshiftServerlessSubnetInvalidError": "请选择位于至少 2 个不同可用区的至少 3 个子网",
     "redshiftProvisionedCulsterEmptyError": "请选择群集",
     "redshiftProvisionedDBUserEmptyError": "请输入数据库用户。",
+    "redshiftProvisionedDBUserFormatError": "数据库用户格式错误",
     "quickSightUserEmptyError": "请选择 QuickSight 用户。",
     "emailInvalid": "电子邮件无效。"
   },

--- a/frontend/src/pages/pipelines/create/CreatePipeline.tsx
+++ b/frontend/src/pages/pipelines/create/CreatePipeline.tsx
@@ -67,6 +67,7 @@ import {
   DOMAIN_NAME_PATTERN,
   KAFKA_BROKERS_PATTERN,
   KAFKA_TOPIC_PATTERN,
+  REDSHIFT_DB_USER_NAME_PATTERN,
 } from 'ts/constant-ln';
 import { INIT_EXT_PIPELINE_DATA } from 'ts/init';
 import {
@@ -172,6 +173,11 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
     redshiftProvisionedDBUserEmptyError,
     setRedshiftProvisionedDBUserEmptyError,
   ] = useState(false);
+  const [
+    redshiftProvisionedDBUserFormatError,
+    setRedshiftProvisionedDBUserFormatError,
+  ] = useState(false);
+  
 
   const [quickSightUserEmptyError, setQuickSightUserEmptyError] =
     useState(false);
@@ -533,6 +539,15 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
             !pipelineInfo.dataModeling?.redshift?.provisioned?.dbUser.trim()
           ) {
             setRedshiftProvisionedDBUserEmptyError(true);
+            return false;
+          }
+          if (
+            !checkStringValidRegex(
+              pipelineInfo.dataModeling?.redshift?.provisioned?.dbUser,
+              new RegExp(REDSHIFT_DB_USER_NAME_PATTERN)
+            )
+          ) {
+            setRedshiftProvisionedDBUserFormatError(true);
             return false;
           }
         }
@@ -1706,6 +1721,9 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
               }
               redshiftProvisionedDBUserEmptyError={
                 redshiftProvisionedDBUserEmptyError
+              }
+              redshiftProvisionedDBUserFormatError={
+                redshiftProvisionedDBUserFormatError
               }
               changeEnableDataProcessing={(enable) => {
                 if (enable) {

--- a/frontend/src/pages/pipelines/create/steps/DataProcessing.tsx
+++ b/frontend/src/pages/pipelines/create/steps/DataProcessing.tsx
@@ -102,6 +102,7 @@ interface DataProcessingProps {
   redshiftServerlessSubnetInvalidError: boolean;
   redshiftProvisionedCulsterEmptyError: boolean;
   redshiftProvisionedDBUserEmptyError: boolean;
+  redshiftProvisionedDBUserFormatError: boolean;
 }
 
 const DataProcessing: React.FC<DataProcessingProps> = (
@@ -143,6 +144,7 @@ const DataProcessing: React.FC<DataProcessingProps> = (
     redshiftServerlessSubnetInvalidError,
     redshiftProvisionedCulsterEmptyError,
     redshiftProvisionedDBUserEmptyError,
+    redshiftProvisionedDBUserFormatError,
   } = props;
 
   const [selectedExecution, setSelectedExecution] = useState(
@@ -934,6 +936,10 @@ const DataProcessing: React.FC<DataProcessingProps> = (
                           redshiftProvisionedDBUserEmptyError
                             ? t(
                                 'pipeline:valid.redshiftProvisionedDBUserEmptyError'
+                              )
+                            : redshiftProvisionedDBUserFormatError
+                            ? t(
+                                'pipeline:valid.redshiftProvisionedDBUserFormatError'
                               )
                             : ''
                         }

--- a/src/analytics/parameter.ts
+++ b/src/analytics/parameter.ts
@@ -17,6 +17,8 @@ import { Bucket, IBucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 import {
   PARAMETER_GROUP_LABEL_VPC, PARAMETER_LABEL_PRIVATE_SUBNETS, PARAMETER_LABEL_VPCID,
+  REDSHIFT_CLUSTER_IDENTIFIER_PATTERN,
+  REDSHIFT_DB_USER_NAME_PATTERN,
   S3_BUCKET_NAME_PATTERN, SCHEDULE_EXPRESSION_PATTERN, SUBNETS_THREE_AZ_PATTERN, VPC_ID_PATTERN,
 } from '../common/constant';
 import { REDSHIFT_MODE } from '../common/model';
@@ -407,14 +409,14 @@ export function createStackParameters(scope: Construct): {
   const redshiftClusterIdentifierParam = new CfnParameter(scope, 'RedshiftClusterIdentifier', {
     description: 'The cluster identifier of Redshift.',
     type: 'String',
-    allowedPattern: '^([a-z0-9-]{1,63})?$',
+    allowedPattern: REDSHIFT_CLUSTER_IDENTIFIER_PATTERN,
     default: '',
   });
 
   const redshiftDbUserParam = new CfnParameter(scope, 'RedshiftDbUser', {
     description: 'The name of Redshift database user.',
     type: 'String',
-    allowedPattern: '^([a-z0-9-]{1,63})?$',
+    allowedPattern: REDSHIFT_DB_USER_NAME_PATTERN,
     default: '',
   });
 

--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -225,8 +225,8 @@ export const QUICKSIGHT_USER_NAME_PATTERN =
   '^[A-Za-z0-9][A-Za-z0-9/_@.\\-]+[A-Za-z0-9]$';
 export const QUICKSIGHT_NAMESPACE_PATTERN = '^([A-Za-z])[A-Za-z0-9]{4,63}$';
 export const REDSHIFT_DB_NAME_PATTERN = `^${PROJECT_ID_PATTERN}$`;
-export const REDSHIFT_DB_USER_NAME_PATTERN = '^([a-z0-9-]{1,63})?$';
-export const REDSHIFT_CLUSTER_IDENTIFIER_PATTERN = '^([a-z0-9-]{1,63})?$';
+export const REDSHIFT_DB_USER_NAME_PATTERN = '^([a-zA-Z][a-zA-Z0-9-_]{1,63})?$';
+export const REDSHIFT_CLUSTER_IDENTIFIER_PATTERN = '^([a-zA-Z][a-zA-Z0-9-_]{1,63})?$';
 export const SECRETS_MANAGER_ARN_PATTERN =
   '^$|^arn:aws(-cn|-us-gov)?:secretsmanager:[a-z0-9-]+:[0-9]{12}:secret:[a-zA-Z0-9-\/]+$';
 export const SCHEDULE_EXPRESSION_PATTERN =

--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -225,6 +225,8 @@ export const QUICKSIGHT_USER_NAME_PATTERN =
   '^[A-Za-z0-9][A-Za-z0-9/_@.\\-]+[A-Za-z0-9]$';
 export const QUICKSIGHT_NAMESPACE_PATTERN = '^([A-Za-z])[A-Za-z0-9]{4,63}$';
 export const REDSHIFT_DB_NAME_PATTERN = `^${PROJECT_ID_PATTERN}$`;
+export const REDSHIFT_DB_USER_NAME_PATTERN = '^([a-z0-9-]{1,63})?$';
+export const REDSHIFT_CLUSTER_IDENTIFIER_PATTERN = '^([a-z0-9-]{1,63})?$';
 export const SECRETS_MANAGER_ARN_PATTERN =
   '^$|^arn:aws(-cn|-us-gov)?:secretsmanager:[a-z0-9-]+:[0-9]{12}:secret:[a-zA-Z0-9-\/]+$';
 export const SCHEDULE_EXPRESSION_PATTERN =

--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -34,6 +34,8 @@ import {
   OUTPUT_DATA_PROCESSING_GLUE_DATABASE_SUFFIX,
   OUTPUT_DATA_PROCESSING_GLUE_EVENT_TABLE_SUFFIX,
   S3_PREFIX_PATTERN,
+  REDSHIFT_CLUSTER_IDENTIFIER_PATTERN,
+  REDSHIFT_DB_USER_NAME_PATTERN,
 } from '../common/constants-ln';
 import { REDSHIFT_MODE } from '../common/model-ln';
 import { validateDataProcessingInterval, validatePattern, validateServerlessRedshiftRPU, validateSinkBatch } from '../common/stack-params-valid';
@@ -851,18 +853,24 @@ export class CDataModelingStack extends JSONObject {
     RedshiftMode?: REDSHIFT_MODE;
 
   @JSONObject.optional('')
-  @JSONObject.custom( (stack :CDataModelingStack, _key:string, value:any) => {
+  @JSONObject.custom( (stack :CDataModelingStack, key:string, value:any) => {
     if (stack._pipeline?.dataModeling?.redshift?.provisioned) {
-      return stack._pipeline?.dataModeling?.redshift?.provisioned.clusterIdentifier;
+      value = stack._pipeline?.dataModeling?.redshift?.provisioned.clusterIdentifier;
+    }
+    if (!isEmpty(value)) {
+      validatePattern(key, REDSHIFT_CLUSTER_IDENTIFIER_PATTERN, value);
     }
     return value;
   })
     RedshiftClusterIdentifier?: string;
 
   @JSONObject.optional('')
-  @JSONObject.custom( (stack :CDataModelingStack, _key:string, value:any) => {
+  @JSONObject.custom( (stack :CDataModelingStack, key:string, value:any) => {
     if (stack._pipeline?.dataModeling?.redshift?.provisioned) {
-      return stack._pipeline?.dataModeling?.redshift?.provisioned.dbUser;
+      value = stack._pipeline?.dataModeling?.redshift?.provisioned.dbUser;
+    }
+    if (!isEmpty(value)) {
+      validatePattern(key, REDSHIFT_DB_USER_NAME_PATTERN, value);
     }
     return value;
   })

--- a/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
@@ -620,6 +620,24 @@ export const KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_EMPTY_DBUSER_QUICKSIGH
   },
 };
 
+export const KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_ERROR_DBUSER_QUICKSIGHT_PIPELINE: IPipeline = {
+  ...KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_PIPELINE,
+  dataModeling: {
+    ...KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_PIPELINE.dataModeling,
+    athena: true,
+    redshift: {
+      dataRange: 'rate(6 months)',
+      provisioned: {
+        clusterIdentifier: 'redshift-cluster-1',
+        dbUser: 'HGF%$#@BHHGF',
+      },
+    },
+    upsertUsers: {
+      scheduleExpression: 'rate(5 minutes)',
+    },
+  },
+};
+
 export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_QUICKSIGHT_PIPELINE: IPipeline = {
   ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE,
   reporting: {

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -842,7 +842,7 @@ describe('Pipeline test', () => {
       });
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(400);
-    expect(res.body.message).toEqual('Validation error: RedshiftDbUser: HGF%$#@BHHGF not match ^([a-z0-9-]{1,63})?$. Please check and try again.');
+    expect(res.body.message).toEqual('Validation error: RedshiftDbUser: HGF%$#@BHHGF not match ^([a-zA-Z][a-zA-Z0-9-_]{1,63})?$. Please check and try again.');
   });
   it('Create pipeline with dictionary no found', async () => {
     tokenMock(ddbMock, false);

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -67,6 +67,7 @@ import {
   KINESIS_DATA_PROCESSING_NEW_REDSHIFT_WITH_ERROR_RPU_PIPELINE,
   S3_DATA_PROCESSING_WITH_ERROR_PREFIX_PIPELINE,
   KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW_AND_EXPRESSION_UPDATE,
+  KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_ERROR_DBUSER_QUICKSIGHT_PIPELINE,
 } from './pipeline-mock';
 import { clickStreamTableName, dictionaryTableName } from '../../common/constants';
 import { app, server } from '../../index';
@@ -822,6 +823,26 @@ describe('Pipeline test', () => {
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(400);
     expect(res.body.message).toEqual('Cluster Identifier and DbUser are required when using Redshift Provisioned cluster.');
+  });
+  it('Create pipeline with provisioned redshift error dbuser', async () => {
+    tokenMock(ddbMock, false);
+    projectExistedMock(ddbMock, true);
+    dictionaryMock(ddbMock);
+    createPipelineMock(ddbMock, kafkaMock, redshiftServerlessMock, redshiftMock,
+      ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
+        publicAZContainPrivateAZ: true,
+        subnetsCross3AZ: true,
+      });
+    ddbMock.on(PutCommand).resolves({});
+    const res = await request(app)
+      .post('/api/pipeline')
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        ...KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_ERROR_DBUSER_QUICKSIGHT_PIPELINE,
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toEqual('Validation error: RedshiftDbUser: HGF%$#@BHHGF not match ^([a-z0-9-]{1,63})?$. Please check and try again.');
   });
   it('Create pipeline with dictionary no found', async () => {
     tokenMock(ddbMock, false);


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

closes: #109 

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module