### PR TITLE
chore: enable ALB drop_invalid_header_fields attribute

### DIFF
--- a/src/ingestion-server/server/private/alb.ts
+++ b/src/ingestion-server/server/private/alb.ts
@@ -97,6 +97,7 @@ export function createApplicationLoadBalancer(
     vpcSubnets: {
       subnetType: SubnetType.PUBLIC,
     },
+    dropInvalidHeaderFields: true,
   });
 
   if (props.albLogProps?.enableAccessLog) {

--- a/test/ingestion-server/server/ingestion-server.test.ts
+++ b/test/ingestion-server/server/ingestion-server.test.ts
@@ -489,6 +489,29 @@ test('Alb is internet-facing and ipv4 by default', () => {
   });
 });
 
+test('Alb drop_invalid_header_fields is enabled', () => {
+  const app = new App();
+  const stack = new TestStack(app, 'test', {
+    withMskConfig: true,
+    withAlbAccessLog: true,
+  });
+  const template = Template.fromStack(stack);
+  const alb = findFirstResource(
+    template,
+    'AWS::ElasticLoadBalancingV2::LoadBalancer',
+  )?.resource;
+  const albAttrs = alb.Properties.LoadBalancerAttributes;
+
+  let drop_invalid_header_fields = false;
+
+  for (const attr of albAttrs) {
+    if (attr.Key == 'routing.http.drop_invalid_header_fields.enabled') {
+      drop_invalid_header_fields = attr.Value;
+    }
+  }
+  expect(drop_invalid_header_fields).toBeTruthy();
+});
+
 test('enable Alb access log is configured', () => {
   const app = new App();
   const stack = new TestStack(app, 'test', {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

enable ALB drop_invalid_header_fields attribute

## Implementation highlights

1. enable ALB drop_invalid_header_fields attribute
2. Add Unit test case

## Test checklist

- [x] add new test cases
- [x] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [x] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [x] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module