### PR TITLE
feat: backend metadata manage api

### DIFF
--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -236,6 +236,8 @@ export const CORS_PATTERN = `^$|\\*$|^(${DOMAIN_NAME_PATTERN}(,\\s*${DOMAIN_NAME
 export const XSS_PATTERN = '<(?:"[^"]*"[\'"]*|\'[^\']*\'[\'"]*|[^\'">])+(?<!/\s*)>';
 export const REGION_PATTERN = '[a-z]{2}-[a-z0-9]{1,10}-[0-9]{1}';
 
+export const METADATA_EVENT_NAME_PATTERN = '[a-z][a-z0-9_]{0,64}';
+
 // cloudformation parameters
 export const PARAMETER_GROUP_LABEL_VPC = 'VPC Information';
 export const PARAMETER_GROUP_LABEL_DOMAIN = 'Domain Information';

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -24,6 +24,7 @@ export function isEmpty(a: any): boolean {
   return false;
 }
 
+
 /**
  * Given an object, converts all keys to PascalCase given they are currently in camel case.
  * @param obj The object.

--- a/src/control-plane/backend/click-stream-api.ts
+++ b/src/control-plane/backend/click-stream-api.ts
@@ -139,6 +139,7 @@ export class ClickStreamApiConstruct extends Construct {
         name: 'type',
         type: AttributeType.STRING,
       },
+
       billingMode: BillingMode.PAY_PER_REQUEST,
       removalPolicy: RemovalPolicy.DESTROY,
       pointInTimeRecovery: true,
@@ -155,9 +156,9 @@ export class ClickStreamApiConstruct extends Construct {
         type: AttributeType.NUMBER,
       },
     });
-    const reversalGSIName = 'reversal-index';
+    const invertedGSIName = 'inverted-index';
     analyticsMetadataTable.addGlobalSecondaryIndex({
-      indexName: reversalGSIName,
+      indexName: invertedGSIName,
       partitionKey: {
         name: 'type',
         type: AttributeType.STRING,
@@ -330,7 +331,7 @@ export class ClickStreamApiConstruct extends Construct {
         STACK_WORKFLOW_SATE_MACHINE: stackWorkflowStateMachine.stackWorkflowMachine.stateMachineArn,
         STACK_WORKFLOW_S3_BUCKET: props.stackWorkflowS3Bucket.bucketName,
         PREFIX_TIME_GSI_NAME: prefixTimeGSIName,
-        REVERSAL_GSI_NAME: reversalGSIName,
+        INVERTED_GSI_NAME: invertedGSIName,
         AWS_ACCOUNT_ID: Stack.of(this).account,
         AWS_URL_SUFFIX: Aws.URL_SUFFIX,
         WITH_AUTH_MIDDLEWARE: props.fronting === 'alb' ? 'true' : 'false',

--- a/src/control-plane/backend/lambda/api/common/constants.ts
+++ b/src/control-plane/backend/lambda/api/common/constants.ts
@@ -14,10 +14,12 @@
 // Get the DynamoDB table name from environment variables
 const clickStreamTableName = process.env.CLICK_STREAM_TABLE_NAME;
 const dictionaryTableName = process.env.DICTIONARY_TABLE_NAME;
+const analyticsMetadataTable = process.env.ANALYTICS_METADATA_TABLE_NAME;
 const stackActionStateMachineArn = process.env.STACK_ACTION_SATE_MACHINE;
 const stackWorkflowStateMachineArn = process.env.STACK_WORKFLOW_SATE_MACHINE;
 const stackWorkflowS3Bucket = process.env.STACK_WORKFLOW_S3_BUCKET;
 const prefixTimeGSIName = process.env.PREFIX_TIME_GSI_NAME;
+const invertedGSIName = process.env.INVERTED_GSI_NAME;
 const serviceName = process.env.POWERTOOLS_SERVICE_NAME;
 const awsRegion = process.env.AWS_REGION;
 const awsAccountId = process.env.AWS_ACCOUNT_ID;
@@ -61,10 +63,12 @@ const PIPELINE_SUPPORTED_REGIONS = [
 export {
   clickStreamTableName,
   dictionaryTableName,
+  analyticsMetadataTable,
   stackActionStateMachineArn,
   stackWorkflowStateMachineArn,
   stackWorkflowS3Bucket,
   prefixTimeGSIName,
+  invertedGSIName,
   serviceName,
   awsRegion,
   awsAccountId,

--- a/src/control-plane/backend/lambda/api/common/request-valid.ts
+++ b/src/control-plane/backend/lambda/api/common/request-valid.ts
@@ -14,17 +14,14 @@
 import express from 'express';
 import { validationResult, ValidationChain, CustomValidator } from 'express-validator';
 import { ALLOW_UPLOADED_FILE_TYPES, awsRegion } from './constants';
-import { APP_ID_PATTERN, METADATA_EVENT_NAME_PATTERN, MUTIL_EMAIL_PATTERN, PROJECT_ID_PATTERN } from './constants-ln';
+import { APP_ID_PATTERN, MUTIL_EMAIL_PATTERN, PROJECT_ID_PATTERN } from './constants-ln';
 import { validateXSS } from './stack-params-valid';
 import { ApiFail, AssumeRoleType } from './types';
 import { isEmpty } from './utils';
 import { ClickStreamStore } from '../store/click-stream-store';
-import { DynamoDbMetadataStore } from '../store/dynamodb/dynamodb-metadata-store';
 import { DynamoDbStore } from '../store/dynamodb/dynamodb-store';
-import { MetadataStore } from '../store/metadata-store';
 
 const store: ClickStreamStore = new DynamoDbStore();
-const metadataStore: MetadataStore = new DynamoDbMetadataStore();
 
 // can be reused by many routes
 // parallel processing
@@ -126,40 +123,6 @@ export const isValidAppId: CustomValidator = value => {
     return Promise.reject(`Validation error: app name: ${value} not match ${APP_ID_PATTERN}. Please check and try again.`);
   }
   return true;
-};
-
-export const isMetadataEventExisted: CustomValidator = value => {
-  if (isEmpty(value)) {
-    return Promise.reject('Value is empty.');
-  }
-  const regexp = new RegExp(METADATA_EVENT_NAME_PATTERN);
-  const match = value.match(regexp);
-  if (!match || value !== match[0]) {
-    return Promise.reject(`Validation error: event name: ${value} not match ${METADATA_EVENT_NAME_PATTERN}. Please check and try again.`);
-  }
-  return metadataStore.isEventExisted(value).then(existed => {
-    if (!existed) {
-      return Promise.reject('Event resource does not exist.');
-    }
-    return true;
-  });
-};
-
-export const isMetadataEventNotExisted: CustomValidator = value => {
-  if (isEmpty(value)) {
-    return Promise.reject('Value is empty.');
-  }
-  const regexp = new RegExp(METADATA_EVENT_NAME_PATTERN);
-  const match = value.match(regexp);
-  if (!match || value !== match[0]) {
-    return Promise.reject(`Validation error: event name: ${value} not match ${PROJECT_ID_PATTERN}. Please check and try again.`);
-  }
-  return metadataStore.isEventExisted(value).then(existed => {
-    if (existed) {
-      return Promise.reject('Project resource existed.');
-    }
-    return true;
-  });
 };
 
 export const isProjectExisted: CustomValidator = value => {

--- a/src/control-plane/backend/lambda/api/common/request-valid.ts
+++ b/src/control-plane/backend/lambda/api/common/request-valid.ts
@@ -14,14 +14,17 @@
 import express from 'express';
 import { validationResult, ValidationChain, CustomValidator } from 'express-validator';
 import { ALLOW_UPLOADED_FILE_TYPES, awsRegion } from './constants';
-import { APP_ID_PATTERN, MUTIL_EMAIL_PATTERN, PROJECT_ID_PATTERN } from './constants-ln';
+import { APP_ID_PATTERN, METADATA_EVENT_NAME_PATTERN, MUTIL_EMAIL_PATTERN, PROJECT_ID_PATTERN } from './constants-ln';
 import { validateXSS } from './stack-params-valid';
 import { ApiFail, AssumeRoleType } from './types';
 import { isEmpty } from './utils';
 import { ClickStreamStore } from '../store/click-stream-store';
+import { DynamoDbMetadataStore } from '../store/dynamodb/dynamodb-metadata-store';
 import { DynamoDbStore } from '../store/dynamodb/dynamodb-store';
+import { MetadataStore } from '../store/metadata-store';
 
 const store: ClickStreamStore = new DynamoDbStore();
+const metadataStore: MetadataStore = new DynamoDbMetadataStore();
 
 // can be reused by many routes
 // parallel processing
@@ -123,6 +126,40 @@ export const isValidAppId: CustomValidator = value => {
     return Promise.reject(`Validation error: app name: ${value} not match ${APP_ID_PATTERN}. Please check and try again.`);
   }
   return true;
+};
+
+export const isMetadataEventExisted: CustomValidator = value => {
+  if (isEmpty(value)) {
+    return Promise.reject('Value is empty.');
+  }
+  const regexp = new RegExp(METADATA_EVENT_NAME_PATTERN);
+  const match = value.match(regexp);
+  if (!match || value !== match[0]) {
+    return Promise.reject(`Validation error: event name: ${value} not match ${METADATA_EVENT_NAME_PATTERN}. Please check and try again.`);
+  }
+  return metadataStore.isEventExisted(value).then(existed => {
+    if (!existed) {
+      return Promise.reject('Event resource does not exist.');
+    }
+    return true;
+  });
+};
+
+export const isMetadataEventNotExisted: CustomValidator = value => {
+  if (isEmpty(value)) {
+    return Promise.reject('Value is empty.');
+  }
+  const regexp = new RegExp(METADATA_EVENT_NAME_PATTERN);
+  const match = value.match(regexp);
+  if (!match || value !== match[0]) {
+    return Promise.reject(`Validation error: event name: ${value} not match ${PROJECT_ID_PATTERN}. Please check and try again.`);
+  }
+  return metadataStore.isEventExisted(value).then(existed => {
+    if (existed) {
+      return Promise.reject('Project resource existed.');
+    }
+    return true;
+  });
 };
 
 export const isProjectExisted: CustomValidator = value => {

--- a/src/control-plane/backend/lambda/api/common/types.ts
+++ b/src/control-plane/backend/lambda/api/common/types.ts
@@ -408,3 +408,15 @@ export enum FetchType {
   PIPELINE_DNS= 'PipelineDNS',
 }
 
+export enum MetadataEventType {
+  PRESET = 'Preset',
+  CUSTOM = 'Custom',
+}
+
+export enum MetadataEventPlatform {
+  ANDROID = 'Android',
+  IOS = 'iOS',
+  WEB = 'Web',
+  MINIPROGRAM = 'MiniProgram',
+}
+

--- a/src/control-plane/backend/lambda/api/index.ts
+++ b/src/control-plane/backend/lambda/api/index.ts
@@ -19,6 +19,7 @@ import { responseTime } from './middle-ware/response-time';
 import { router_app } from './router/application';
 import { router_dictionary } from './router/dictionary';
 import { router_env } from './router/environment';
+import { router_metadata } from './router/metadata';
 import { router_pipeline } from './router/pipeline';
 import { router_plugin } from './router/plugin';
 import { router_project } from './router/project';
@@ -46,6 +47,7 @@ app.use('/api/project', router_project);
 app.use('/api/app', router_app);
 app.use('/api/pipeline', router_pipeline);
 app.use('/api/plugin', router_plugin);
+app.use('/api/metadata', router_metadata);
 
 // Implement the “catch-all” errorHandler function
 app.use(errorHandler);

--- a/src/control-plane/backend/lambda/api/model/metadata.ts
+++ b/src/control-plane/backend/lambda/api/model/metadata.ts
@@ -27,6 +27,11 @@ export interface IMetadataEvent {
   readonly deleted: boolean;
 }
 
+export interface IMetadataAttributeValue {
+  readonly value: string;
+  readonly displayValue: string;
+}
+
 export interface IMetadataEventAttribute {
   readonly id: string;
   readonly type: string;
@@ -35,7 +40,8 @@ export interface IMetadataEventAttribute {
   readonly name: string;
   readonly displayName: string;
   readonly description: string;
-  readonly eventType: string;
+  readonly valueType: string;
+  readonly valueEnum: IMetadataAttributeValue[];
 
   readonly createAt: number;
   readonly updateAt: number;

--- a/src/control-plane/backend/lambda/api/model/metadata.ts
+++ b/src/control-plane/backend/lambda/api/model/metadata.ts
@@ -11,15 +11,24 @@
  *  and limitations under the License.
  */
 
+import { MetadataEventType } from '../common/types';
+
 export interface IMetadataEvent {
   readonly id: string;
   readonly type: string;
   readonly prefix: string;
 
+  readonly projectId: string;
+  readonly appId: string;
+
   readonly name: string;
   readonly displayName: string;
   readonly description: string;
-  readonly eventType: string;
+  readonly eventType: MetadataEventType;
+  readonly hasData: boolean;
+  readonly platform: string;
+  readonly dataVolumeLastDay: number;
+  attributes? : IMetadataEventAttribute[];
 
   readonly createAt: number;
   readonly updateAt: number;
@@ -37,6 +46,9 @@ export interface IMetadataEventAttribute {
   readonly type: string;
   readonly prefix: string;
 
+  readonly projectId: string;
+  readonly appId: string;
+
   readonly name: string;
   readonly displayName: string;
   readonly description: string;
@@ -53,6 +65,9 @@ export interface IMetadataUserAttribute {
   readonly id: string;
   readonly type: string;
   readonly prefix: string;
+
+  readonly projectId: string;
+  readonly appId: string;
 
   readonly name: string;
   readonly displayName: string;

--- a/src/control-plane/backend/lambda/api/model/metadata.ts
+++ b/src/control-plane/backend/lambda/api/model/metadata.ts
@@ -1,0 +1,60 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+export interface IMetadataEvent {
+  readonly id: string;
+  readonly type: string;
+  readonly prefix: string;
+
+  readonly name: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly eventType: string;
+
+  readonly createAt: number;
+  readonly updateAt: number;
+  readonly operator: string;
+  readonly deleted: boolean;
+}
+
+export interface IMetadataEventAttribute {
+  readonly id: string;
+  readonly type: string;
+  readonly prefix: string;
+
+  readonly name: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly eventType: string;
+
+  readonly createAt: number;
+  readonly updateAt: number;
+  readonly operator: string;
+  readonly deleted: boolean;
+}
+
+export interface IMetadataUserAttribute {
+  readonly id: string;
+  readonly type: string;
+  readonly prefix: string;
+
+  readonly name: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly eventType: string;
+
+  readonly createAt: number;
+  readonly updateAt: number;
+  readonly operator: string;
+  readonly deleted: boolean;
+}

--- a/src/control-plane/backend/lambda/api/router/metadata.ts
+++ b/src/control-plane/backend/lambda/api/router/metadata.ts
@@ -1,0 +1,123 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import express from 'express';
+import { body, header, param, query } from 'express-validator';
+import { defaultOrderValueValid, isMetadataEventExisted, isMetadataEventNotExisted, isRequestIdExisted, isValidEmpty, isXSSRequest, validate } from '../common/request-valid';
+import { MetadataEventAttributeServ, MetadataEventServ } from '../service/metadata';
+
+const router_metadata = express.Router();
+const metadataEventServ: MetadataEventServ = new MetadataEventServ();
+const metadataEventAttributeServ: MetadataEventAttributeServ = new MetadataEventAttributeServ();
+// const metadataUserAttributeServ: MetadataUserAttributeServ = new MetadataUserAttributeServ();
+
+router_metadata.get(
+  '/events',
+  validate([
+    query()
+      .custom((value: any, { req }: any) => defaultOrderValueValid(value, {
+        req,
+        location: 'body',
+        path: '',
+      })),
+  ]),
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return metadataEventServ.list(req, res, next);
+  });
+
+router_metadata.post(
+  '/event',
+  validate([
+    body().custom(isValidEmpty).custom(isXSSRequest),
+    body('name').custom(isMetadataEventNotExisted),
+    header('X-Click-Stream-Request-Id').custom(isRequestIdExisted),
+  ]),
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return metadataEventServ.add(req, res, next);
+  });
+
+router_metadata.get('/event/:name', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  return metadataEventServ.details(req, res, next);
+});
+
+router_metadata.put(
+  '/event',
+  validate([
+    body().custom(isValidEmpty),
+    body('name')
+      .custom(isMetadataEventExisted),
+  ]),
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return metadataEventServ.update(req, res, next);
+  });
+
+router_metadata.delete(
+  '/event/:name',
+  validate([
+    param('name').custom(isMetadataEventExisted),
+  ]),
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return metadataEventServ.delete(req, res, next);
+  });
+
+router_metadata.get(
+  '/event_attributes',
+  validate([
+    query()
+      .custom((value: any, { req }: any) => defaultOrderValueValid(value, {
+        req,
+        location: 'body',
+        path: '',
+      })),
+  ]),
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return metadataEventAttributeServ.list(req, res, next);
+  });
+
+router_metadata.post(
+  '/event_attribute',
+  validate([
+    body().custom(isValidEmpty).custom(isXSSRequest),
+    header('X-Click-Stream-Request-Id').custom(isRequestIdExisted),
+  ]),
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return metadataEventAttributeServ.add(req, res, next);
+  });
+
+router_metadata.get('/event/:name', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  return metadataEventAttributeServ.details(req, res, next);
+});
+
+router_metadata.put(
+  '/event',
+  validate([
+    body().custom(isValidEmpty),
+    body('name')
+      .custom(isMetadataEventExisted),
+  ]),
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return metadataEventAttributeServ.update(req, res, next);
+  });
+
+router_metadata.delete(
+  '/event/:name',
+  validate([
+    param('name').custom(isMetadataEventExisted),
+  ]),
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return metadataEventAttributeServ.delete(req, res, next);
+  });
+
+export {
+  router_metadata,
+};

--- a/src/control-plane/backend/lambda/api/router/metadata.ts
+++ b/src/control-plane/backend/lambda/api/router/metadata.ts
@@ -12,8 +12,8 @@
  */
 
 import express from 'express';
-import { body, header, param, query } from 'express-validator';
-import { defaultOrderValueValid, isMetadataEventExisted, isMetadataEventNotExisted, isRequestIdExisted, isValidEmpty, isXSSRequest, validate } from '../common/request-valid';
+import { body, header, query } from 'express-validator';
+import { defaultOrderValueValid, isRequestIdExisted, isValidEmpty, isXSSRequest, validate } from '../common/request-valid';
 import { MetadataEventAttributeServ, MetadataEventServ, MetadataUserAttributeServ } from '../service/metadata';
 
 const router_metadata = express.Router();
@@ -24,6 +24,8 @@ const metadataUserAttributeServ: MetadataUserAttributeServ = new MetadataUserAtt
 router_metadata.get(
   '/events',
   validate([
+    query('projectId').custom(isValidEmpty),
+    query('appId').custom(isValidEmpty),
     query()
       .custom((value: any, { req }: any) => defaultOrderValueValid(value, {
         req,
@@ -39,23 +41,29 @@ router_metadata.post(
   '/event',
   validate([
     body().custom(isValidEmpty).custom(isXSSRequest),
-    body('name').custom(isMetadataEventNotExisted),
+    body('projectId').custom(isValidEmpty),
+    body('appId').custom(isValidEmpty),
     header('X-Click-Stream-Request-Id').custom(isRequestIdExisted),
   ]),
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     return metadataEventServ.add(req, res, next);
   });
 
-router_metadata.get('/event/:name', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
-  return metadataEventServ.details(req, res, next);
-});
+router_metadata.get('/event/:name',
+  validate([
+    query('projectId').custom(isValidEmpty),
+    query('appId').custom(isValidEmpty),
+  ]),
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return metadataEventServ.details(req, res, next);
+  });
 
 router_metadata.put(
   '/event',
   validate([
     body().custom(isValidEmpty),
-    body('name')
-      .custom(isMetadataEventExisted),
+    body('projectId').custom(isValidEmpty),
+    body('appId').custom(isValidEmpty),
   ]),
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     return metadataEventServ.update(req, res, next);
@@ -64,7 +72,8 @@ router_metadata.put(
 router_metadata.delete(
   '/event/:name',
   validate([
-    param('name').custom(isMetadataEventExisted),
+    query('projectId').custom(isValidEmpty),
+    query('appId').custom(isValidEmpty),
   ]),
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     return metadataEventServ.delete(req, res, next);
@@ -88,13 +97,15 @@ router_metadata.post(
   '/event_attribute',
   validate([
     body().custom(isValidEmpty).custom(isXSSRequest),
+    body('projectId').custom(isValidEmpty),
+    body('appId').custom(isValidEmpty),
     header('X-Click-Stream-Request-Id').custom(isRequestIdExisted),
   ]),
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     return metadataEventAttributeServ.add(req, res, next);
   });
 
-router_metadata.get('/event_attribute/:name', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+router_metadata.get('/event_attribute/:id', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
   return metadataEventAttributeServ.details(req, res, next);
 });
 
@@ -102,17 +113,18 @@ router_metadata.put(
   '/event_attribute',
   validate([
     body().custom(isValidEmpty),
-    body('name')
-      .custom(isMetadataEventExisted),
+    body('projectId').custom(isValidEmpty),
+    body('appId').custom(isValidEmpty),
   ]),
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     return metadataEventAttributeServ.update(req, res, next);
   });
 
 router_metadata.delete(
-  '/event_attribute/:name',
+  '/event_attribute/:id',
   validate([
-    param('name').custom(isMetadataEventExisted),
+    query('projectId').custom(isValidEmpty),
+    query('appId').custom(isValidEmpty),
   ]),
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     return metadataEventAttributeServ.delete(req, res, next);
@@ -121,6 +133,8 @@ router_metadata.delete(
 router_metadata.get(
   '/user_attributes',
   validate([
+    query('projectId').custom(isValidEmpty),
+    query('appId').custom(isValidEmpty),
     query()
       .custom((value: any, { req }: any) => defaultOrderValueValid(value, {
         req,
@@ -136,13 +150,15 @@ router_metadata.post(
   '/user_attribute',
   validate([
     body().custom(isValidEmpty).custom(isXSSRequest),
+    body('projectId').custom(isValidEmpty),
+    body('appId').custom(isValidEmpty),
     header('X-Click-Stream-Request-Id').custom(isRequestIdExisted),
   ]),
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     return metadataUserAttributeServ.add(req, res, next);
   });
 
-router_metadata.get('/user_attribute/:name', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+router_metadata.get('/user_attribute/:id', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
   return metadataUserAttributeServ.details(req, res, next);
 });
 
@@ -150,17 +166,18 @@ router_metadata.put(
   '/user_attribute',
   validate([
     body().custom(isValidEmpty),
-    body('name')
-      .custom(isMetadataEventExisted),
+    body('projectId').custom(isValidEmpty),
+    body('appId').custom(isValidEmpty),
   ]),
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     return metadataUserAttributeServ.update(req, res, next);
   });
 
 router_metadata.delete(
-  '/user_attribute/:name',
+  '/user_attribute/:id',
   validate([
-    param('name').custom(isMetadataEventExisted),
+    query('projectId').custom(isValidEmpty),
+    query('appId').custom(isValidEmpty),
   ]),
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     return metadataUserAttributeServ.delete(req, res, next);

--- a/src/control-plane/backend/lambda/api/router/metadata.ts
+++ b/src/control-plane/backend/lambda/api/router/metadata.ts
@@ -14,12 +14,12 @@
 import express from 'express';
 import { body, header, param, query } from 'express-validator';
 import { defaultOrderValueValid, isMetadataEventExisted, isMetadataEventNotExisted, isRequestIdExisted, isValidEmpty, isXSSRequest, validate } from '../common/request-valid';
-import { MetadataEventAttributeServ, MetadataEventServ } from '../service/metadata';
+import { MetadataEventAttributeServ, MetadataEventServ, MetadataUserAttributeServ } from '../service/metadata';
 
 const router_metadata = express.Router();
 const metadataEventServ: MetadataEventServ = new MetadataEventServ();
 const metadataEventAttributeServ: MetadataEventAttributeServ = new MetadataEventAttributeServ();
-// const metadataUserAttributeServ: MetadataUserAttributeServ = new MetadataUserAttributeServ();
+const metadataUserAttributeServ: MetadataUserAttributeServ = new MetadataUserAttributeServ();
 
 router_metadata.get(
   '/events',
@@ -94,12 +94,12 @@ router_metadata.post(
     return metadataEventAttributeServ.add(req, res, next);
   });
 
-router_metadata.get('/event/:name', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+router_metadata.get('/event_attribute/:name', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
   return metadataEventAttributeServ.details(req, res, next);
 });
 
 router_metadata.put(
-  '/event',
+  '/event_attribute',
   validate([
     body().custom(isValidEmpty),
     body('name')
@@ -110,12 +110,60 @@ router_metadata.put(
   });
 
 router_metadata.delete(
-  '/event/:name',
+  '/event_attribute/:name',
   validate([
     param('name').custom(isMetadataEventExisted),
   ]),
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     return metadataEventAttributeServ.delete(req, res, next);
+  });
+
+router_metadata.get(
+  '/user_attributes',
+  validate([
+    query()
+      .custom((value: any, { req }: any) => defaultOrderValueValid(value, {
+        req,
+        location: 'body',
+        path: '',
+      })),
+  ]),
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return metadataUserAttributeServ.list(req, res, next);
+  });
+
+router_metadata.post(
+  '/user_attribute',
+  validate([
+    body().custom(isValidEmpty).custom(isXSSRequest),
+    header('X-Click-Stream-Request-Id').custom(isRequestIdExisted),
+  ]),
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return metadataUserAttributeServ.add(req, res, next);
+  });
+
+router_metadata.get('/user_attribute/:name', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  return metadataUserAttributeServ.details(req, res, next);
+});
+
+router_metadata.put(
+  '/user_attribute',
+  validate([
+    body().custom(isValidEmpty),
+    body('name')
+      .custom(isMetadataEventExisted),
+  ]),
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return metadataUserAttributeServ.update(req, res, next);
+  });
+
+router_metadata.delete(
+  '/user_attribute/:name',
+  validate([
+    param('name').custom(isMetadataEventExisted),
+  ]),
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return metadataUserAttributeServ.delete(req, res, next);
   });
 
 export {

--- a/src/control-plane/backend/lambda/api/service/metadata.ts
+++ b/src/control-plane/backend/lambda/api/service/metadata.ts
@@ -1,0 +1,91 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { logger } from '../common/powertools';
+import { ApiFail, ApiSuccess } from '../common/types';
+import { paginateData } from '../common/utils';
+import { IPlugin } from '../model/plugin';
+import { ClickStreamStore } from '../store/click-stream-store';
+import { DynamoDbStore } from '../store/dynamodb/dynamodb-store';
+
+const store: ClickStreamStore = new DynamoDbStore();
+
+export class MetadataServ {
+  public async list(req: any, res: any, next: any) {
+    try {
+      const { type, order, pageNumber, pageSize } = req.query;
+      const result = await store.listPlugin(type, order);
+      return res.json(new ApiSuccess({
+        totalCount: result.length,
+        items: paginateData(result, true, pageSize, pageNumber),
+      }));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  public async add(req: any, res: any, next: any) {
+    try {
+      req.body.operator = res.get('X-Click-Stream-Operator');
+      req.body.id = uuidv4().replace(/-/g, '');
+      const plugin: IPlugin = req.body;
+      const id = await store.addPlugin(plugin);
+      return res.status(201).json(new ApiSuccess({ id }, 'Plugin created.'));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  public async details(req: any, res: any, next: any) {
+    try {
+      const { id } = req.params;
+      const result = await store.getPlugin(id);
+      if (!result) {
+        logger.warn(`No Plugin with ID ${id} found in the databases while trying to retrieve a Plugin`);
+        return res.status(404).json(new ApiFail('Plugin not found'));
+      }
+      return res.json(new ApiSuccess(result));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  public async update(req: any, res: any, next: any) {
+    try {
+      req.body.operator = res.get('X-Click-Stream-Operator');
+      let plugin: IPlugin = req.body as IPlugin;
+      await store.updatePlugin(plugin);
+      return res.status(201).json(new ApiSuccess(null, 'Plugin updated.'));
+    } catch (error) {
+      if ((error as Error).name === 'ConditionalCheckFailedException') {
+        return res.status(400).json(new ApiFail('The bounded plugin does not support modification.'));
+      }
+      next(error);
+    }
+  }
+
+  public async delete(req: any, res: any, next: any) {
+    try {
+      const { id } = req.params;
+      const operator = res.get('X-Click-Stream-Operator');
+      await store.deletePlugin(id, operator);
+      return res.status(200).json(new ApiSuccess(null, 'Plugin deleted.'));
+    } catch (error) {
+      if ((error as Error).name === 'ConditionalCheckFailedException') {
+        return res.status(400).json(new ApiFail('The bounded plugin does not support deleted.'));
+      }
+      next(error);
+    }
+  };
+}

--- a/src/control-plane/backend/lambda/api/service/metadata.ts
+++ b/src/control-plane/backend/lambda/api/service/metadata.ts
@@ -12,23 +12,21 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import { logger } from '../common/powertools';
 import { ApiFail, ApiSuccess } from '../common/types';
-import { paginateData } from '../common/utils';
-import { IPlugin } from '../model/plugin';
-import { ClickStreamStore } from '../store/click-stream-store';
-import { DynamoDbStore } from '../store/dynamodb/dynamodb-store';
+import { IMetadataEvent, IMetadataEventAttribute, IMetadataUserAttribute } from '../model/metadata';
+import { DynamoDbMetadataStore } from '../store/dynamodb/dynamodb-metadata-store';
+import { MetadataStore } from '../store/metadata-store';
 
-const store: ClickStreamStore = new DynamoDbStore();
+const metadataStore: MetadataStore = new DynamoDbMetadataStore();
 
-export class MetadataServ {
+export class MetadataEventServ {
   public async list(req: any, res: any, next: any) {
     try {
-      const { type, order, pageNumber, pageSize } = req.query;
-      const result = await store.listPlugin(type, order);
+      const { order } = req.query;
+      const result = await metadataStore.listEvents(order);
       return res.json(new ApiSuccess({
         totalCount: result.length,
-        items: paginateData(result, true, pageSize, pageNumber),
+        items: result,
       }));
     } catch (error) {
       next(error);
@@ -38,10 +36,9 @@ export class MetadataServ {
   public async add(req: any, res: any, next: any) {
     try {
       req.body.operator = res.get('X-Click-Stream-Operator');
-      req.body.id = uuidv4().replace(/-/g, '');
-      const plugin: IPlugin = req.body;
-      const id = await store.addPlugin(plugin);
-      return res.status(201).json(new ApiSuccess({ id }, 'Plugin created.'));
+      const event: IMetadataEvent = req.body;
+      const name = await metadataStore.createEvent(event);
+      return res.status(201).json(new ApiSuccess({ name }, 'Event created.'));
     } catch (error) {
       next(error);
     }
@@ -49,11 +46,10 @@ export class MetadataServ {
 
   public async details(req: any, res: any, next: any) {
     try {
-      const { id } = req.params;
-      const result = await store.getPlugin(id);
+      const { name } = req.params;
+      const result = await metadataStore.getEvent(name);
       if (!result) {
-        logger.warn(`No Plugin with ID ${id} found in the databases while trying to retrieve a Plugin`);
-        return res.status(404).json(new ApiFail('Plugin not found'));
+        return res.status(404).json(new ApiFail('Event not found'));
       }
       return res.json(new ApiSuccess(result));
     } catch (error) {
@@ -64,28 +60,149 @@ export class MetadataServ {
   public async update(req: any, res: any, next: any) {
     try {
       req.body.operator = res.get('X-Click-Stream-Operator');
-      let plugin: IPlugin = req.body as IPlugin;
-      await store.updatePlugin(plugin);
-      return res.status(201).json(new ApiSuccess(null, 'Plugin updated.'));
+      const event: IMetadataEvent = req.body as IMetadataEvent;
+      await metadataStore.updateEvent(event);
+      return res.status(201).json(new ApiSuccess(null, 'Event updated.'));
     } catch (error) {
-      if ((error as Error).name === 'ConditionalCheckFailedException') {
-        return res.status(400).json(new ApiFail('The bounded plugin does not support modification.'));
-      }
       next(error);
     }
-  }
+  };
+
+  public async delete(req: any, res: any, next: any) {
+    try {
+      const { name } = req.params;
+      const operator = res.get('X-Click-Stream-Operator');
+      await metadataStore.deleteEvent(name, operator);
+      return res.json(new ApiSuccess(null, 'Event deleted.'));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+}
+
+export class MetadataEventAttributeServ {
+  public async list(req: any, res: any, next: any) {
+    try {
+      const { order } = req.query;
+      const result = await metadataStore.listEventAttributes(order);
+      return res.json(new ApiSuccess({
+        totalCount: result.length,
+        items: result,
+      }));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  public async add(req: any, res: any, next: any) {
+    try {
+      req.body.operator = res.get('X-Click-Stream-Operator');
+      req.body.id = uuidv4().replace(/-/g, '');
+      const eventAttribute: IMetadataEventAttribute = req.body;
+      const name = await metadataStore.createEventAttribute(eventAttribute);
+      return res.status(201).json(new ApiSuccess({ name }, 'Event attribute created.'));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  public async details(req: any, res: any, next: any) {
+    try {
+      const { id } = req.params;
+      const result = await metadataStore.getEventAttribute(id);
+      if (!result) {
+        return res.status(404).json(new ApiFail('Event attribute not found'));
+      }
+      return res.json(new ApiSuccess(result));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  public async update(req: any, res: any, next: any) {
+    try {
+      req.body.operator = res.get('X-Click-Stream-Operator');
+      const eventAttribute: IMetadataEventAttribute = req.body as IMetadataEventAttribute;
+      await metadataStore.updateEventAttribute(eventAttribute);
+      return res.status(201).json(new ApiSuccess(null, 'Event attribute updated.'));
+    } catch (error) {
+      next(error);
+    }
+  };
 
   public async delete(req: any, res: any, next: any) {
     try {
       const { id } = req.params;
       const operator = res.get('X-Click-Stream-Operator');
-      await store.deletePlugin(id, operator);
-      return res.status(200).json(new ApiSuccess(null, 'Plugin deleted.'));
+      await metadataStore.deleteEventAttribute(id, operator);
+      return res.json(new ApiSuccess(null, 'Event attribute deleted.'));
     } catch (error) {
-      if ((error as Error).name === 'ConditionalCheckFailedException') {
-        return res.status(400).json(new ApiFail('The bounded plugin does not support deleted.'));
-      }
       next(error);
     }
   };
+
+}
+
+export class MetadataUserAttributeServ {
+  public async list(req: any, res: any, next: any) {
+    try {
+      const { order } = req.query;
+      const result = await metadataStore.listUserAttributes(order);
+      return res.json(new ApiSuccess({
+        totalCount: result.length,
+        items: result,
+      }));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  public async add(req: any, res: any, next: any) {
+    try {
+      req.body.operator = res.get('X-Click-Stream-Operator');
+      req.body.id = uuidv4().replace(/-/g, '');
+      const userAttribute: IMetadataUserAttribute = req.body;
+      const name = await metadataStore.createUserAttribute(userAttribute);
+      return res.status(201).json(new ApiSuccess({ name }, 'User attribute created.'));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  public async details(req: any, res: any, next: any) {
+    try {
+      const { id } = req.params;
+      const result = await metadataStore.getUserAttribute(id);
+      if (!result) {
+        return res.status(404).json(new ApiFail('User attribute not found'));
+      }
+      return res.json(new ApiSuccess(result));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  public async update(req: any, res: any, next: any) {
+    try {
+      req.body.operator = res.get('X-Click-Stream-Operator');
+      const userAttribute: IMetadataUserAttribute = req.body as IMetadataUserAttribute;
+      await metadataStore.updateUserAttribute(userAttribute);
+      return res.status(201).json(new ApiSuccess(null, 'User attribute updated.'));
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  public async delete(req: any, res: any, next: any) {
+    try {
+      const { id } = req.params;
+      const operator = res.get('X-Click-Stream-Operator');
+      await metadataStore.deleteUserAttribute(id, operator);
+      return res.json(new ApiSuccess(null, 'User attribute deleted.'));
+    } catch (error) {
+      next(error);
+    }
+  };
+
 }

--- a/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-metadata-store.ts
+++ b/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-metadata-store.ts
@@ -1,0 +1,441 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import {
+  GetCommand,
+  GetCommandOutput,
+  PutCommand,
+  UpdateCommand,
+  ScanCommandInput,
+  QueryCommandInput,
+} from '@aws-sdk/lib-dynamodb';
+import { analyticsMetadataTable, prefixTimeGSIName } from '../../common/constants';
+import { docClient, query, scan } from '../../common/dynamodb-client';
+import { KeyVal } from '../../common/types';
+import { IMetadataEvent, IMetadataEventAttribute, IMetadataUserAttribute } from '../../model/metadata';
+import { MetadataStore } from '../metadata-store';
+
+export class DynamoDbMetadataStore implements MetadataStore {
+
+  public async isEventExisted(eventName: string): Promise<boolean> {
+    const params: GetCommand = new GetCommand({
+      TableName: analyticsMetadataTable,
+      Key: {
+        id: `EVENT#${eventName}`,
+        type: `#METADATA#${eventName}`,
+      },
+    });
+    const result: GetCommandOutput = await docClient.send(params);
+    if (!result.Item) {
+      return false;
+    }
+    const event: IMetadataEvent = result.Item as IMetadataEvent;
+    return event && !event.deleted;
+  };
+
+  public async createEvent(event: IMetadataEvent): Promise<string> {
+    const params: PutCommand = new PutCommand({
+      TableName: analyticsMetadataTable,
+      Item: {
+        id: `EVENT#${event.name}`,
+        type: `#METADATA#${event.name}`,
+        prefix: 'EVENT',
+        name: event.name,
+        displayName: event.displayName ?? '',
+        description: event.description ?? '',
+        createAt: Date.now(),
+        updateAt: Date.now(),
+        operator: event.operator?? '',
+        deleted: false,
+      },
+    });
+    await docClient.send(params);
+    return event.name;
+  };
+
+  public async getEvent(eventName: string): Promise<any> {
+    const input: QueryCommandInput = {
+      TableName: analyticsMetadataTable,
+      KeyConditionExpression: 'id = :id AND #type BETWEEN :metadata AND :attribute',
+      FilterExpression: 'deleted = :d',
+      ExpressionAttributeNames: {
+        '#type': 'type',
+      },
+      ExpressionAttributeValues: {
+        ':d': false,
+        ':id': `EVENT#${eventName}`,
+        ':metadata': `#METADATA#${eventName}`,
+        ':attribute': 'EVENT_ATTRIBUTE$',
+      },
+    };
+    const records = await query(input);
+    return records;
+  };
+
+  public async updateEvent(event: IMetadataEvent): Promise<void> {
+    let updateExpression = 'SET #updateAt= :u, #operator= :operator';
+    let expressionAttributeValues = new Map();
+    let expressionAttributeNames = {} as KeyVal<string>;
+    expressionAttributeValues.set(':u', Date.now());
+    expressionAttributeValues.set(':operator', event.operator);
+    expressionAttributeNames['#updateAt'] = 'updateAt';
+    expressionAttributeNames['#operator'] = 'operator';
+    if (event.displayName) {
+      updateExpression = `${updateExpression}, #displayName= :n`;
+      expressionAttributeValues.set(':n', event.displayName);
+      expressionAttributeNames['#displayName'] = 'displayName';
+    }
+    if (event.description) {
+      updateExpression = `${updateExpression}, description= :d`;
+      expressionAttributeValues.set(':d', event.description);
+    }
+    const params: UpdateCommand = new UpdateCommand({
+      TableName: analyticsMetadataTable,
+      Key: {
+        id: `EVENT#${event.name}`,
+        type: `#METADATA#${event.name}`,
+      },
+      // Define expressions for the new or updated attributes
+      UpdateExpression: updateExpression,
+      ExpressionAttributeNames: expressionAttributeNames as KeyVal<string>,
+      ExpressionAttributeValues: expressionAttributeValues,
+      ReturnValues: 'ALL_NEW',
+    });
+    await docClient.send(params);
+  };
+
+  public async deleteEvent(eventName: string, operator: string): Promise<void> {
+    const input: ScanCommandInput = {
+      TableName: analyticsMetadataTable,
+      FilterExpression: 'id = :p AND deleted = :d',
+      ExpressionAttributeValues: {
+        ':p': `EVENT#${eventName}`,
+        ':d': false,
+      },
+    };
+    const records = await scan(input);
+    const events = records as IMetadataEvent[];
+    for (let index in events) {
+      const params: UpdateCommand = new UpdateCommand({
+        TableName: analyticsMetadataTable,
+        Key: {
+          id: `EVENT#${eventName}`,
+          type: events[index].type,
+        },
+        // Define expressions for the new or updated attributes
+        UpdateExpression: 'SET deleted= :d, #operator= :operator',
+        ExpressionAttributeNames: {
+          '#operator': 'operator',
+        },
+        ExpressionAttributeValues: {
+          ':d': true,
+          ':operator': operator,
+        },
+        ReturnValues: 'ALL_NEW',
+      });
+      await docClient.send(params);
+    }
+  };
+
+  public async listEvents(order: string): Promise<IMetadataEvent[]> {
+    const input: QueryCommandInput = {
+      TableName: analyticsMetadataTable,
+      IndexName: prefixTimeGSIName,
+      KeyConditionExpression: '#prefix= :prefix',
+      FilterExpression: 'deleted = :d',
+      ExpressionAttributeNames: {
+        '#prefix': 'prefix',
+      },
+      ExpressionAttributeValues: {
+        ':d': false,
+        ':prefix': 'EVENT',
+      },
+      ScanIndexForward: order === 'asc',
+    };
+    const records = await query(input);
+    return records as IMetadataEvent[];
+  };
+
+  public async isEventAttributeExisted(eventAttributeId: string): Promise<boolean> {
+    const params: GetCommand = new GetCommand({
+      TableName: analyticsMetadataTable,
+      Key: {
+        id: `EVENT_ATTRIBUTE#${eventAttributeId}`,
+        type: `#METADATA#${eventAttributeId}`,
+      },
+    });
+    const result: GetCommandOutput = await docClient.send(params);
+    if (!result.Item) {
+      return false;
+    }
+    const eventAttribute: IMetadataEventAttribute = result.Item as IMetadataEventAttribute;
+    return eventAttribute && !eventAttribute.deleted;
+  };
+
+  public async createEventAttribute(eventAttribute: IMetadataEventAttribute): Promise<string> {
+    const params: PutCommand = new PutCommand({
+      TableName: analyticsMetadataTable,
+      Item: {
+        id: `EVENT_ATTRIBUTE#${eventAttribute.id}`,
+        type: `#METADATA#${eventAttribute.id}`,
+        prefix: 'EVENT_ATTRIBUTE',
+        name: eventAttribute.name,
+        displayName: eventAttribute.displayName,
+        description: eventAttribute.description,
+        createAt: Date.now(),
+        updateAt: Date.now(),
+        operator: eventAttribute.operator?? '',
+        deleted: false,
+      },
+    });
+    await docClient.send(params);
+    return eventAttribute.id;
+  };
+
+  public async getEventAttribute(eventAttributeId: string): Promise<IMetadataEventAttribute | undefined> {
+    const params: GetCommand = new GetCommand({
+      TableName: analyticsMetadataTable,
+      Key: {
+        id: `EVENT_ATTRIBUTE#${eventAttributeId}`,
+        type: `#METADATA#${eventAttributeId}`,
+      },
+    });
+    const result: GetCommandOutput = await docClient.send(params);
+    if (!result.Item) {
+      return undefined;
+    }
+    const eventAttribute: IMetadataEventAttribute = result.Item as IMetadataEventAttribute;
+    return !eventAttribute.deleted ? eventAttribute : undefined;
+  };
+
+  public async updateEventAttribute(eventAttribute: IMetadataEventAttribute): Promise<void> {
+    let updateExpression = 'SET #updateAt= :u, #operator= :operator';
+    let expressionAttributeValues = new Map();
+    let expressionAttributeNames = {} as KeyVal<string>;
+    expressionAttributeValues.set(':u', Date.now());
+    expressionAttributeValues.set(':operator', eventAttribute.operator);
+    expressionAttributeNames['#updateAt'] = 'updateAt';
+    expressionAttributeNames['#operator'] = 'operator';
+    if (eventAttribute.displayName) {
+      updateExpression = `${updateExpression}, #displayName= :n`;
+      expressionAttributeValues.set(':n', eventAttribute.displayName);
+      expressionAttributeNames['#displayName'] = 'displayName';
+    }
+    if (eventAttribute.description) {
+      updateExpression = `${updateExpression}, description= :d`;
+      expressionAttributeValues.set(':d', eventAttribute.description);
+    }
+    const params: UpdateCommand = new UpdateCommand({
+      TableName: analyticsMetadataTable,
+      Key: {
+        id: `EVENT_ATTRIBUTE#${eventAttribute.id}`,
+        type: `#METADATA#${eventAttribute.id}`,
+      },
+      // Define expressions for the new or updated attributes
+      UpdateExpression: updateExpression,
+      ExpressionAttributeNames: expressionAttributeNames as KeyVal<string>,
+      ExpressionAttributeValues: expressionAttributeValues,
+      ReturnValues: 'ALL_NEW',
+    });
+    await docClient.send(params);
+  };
+
+  public async deleteEventAttribute(eventAttributeId: string, operator: string): Promise<void> {
+    // TODO: if attribute binded with any event, should not delete
+    const input: ScanCommandInput = {
+      TableName: analyticsMetadataTable,
+      FilterExpression: 'id = :p AND deleted = :d',
+      ExpressionAttributeValues: {
+        ':p': `EVENT_ATTRIBUTE#${eventAttributeId}`,
+        ':d': false,
+      },
+    };
+    const records = await scan(input);
+    const eventAttributes = records as IMetadataEventAttribute[];
+    for (let index in eventAttributes) {
+      const params: UpdateCommand = new UpdateCommand({
+        TableName: analyticsMetadataTable,
+        Key: {
+          id: `EVENT_ATTRIBUTE#${eventAttributeId}`,
+          type: eventAttributes[index].type,
+        },
+        // Define expressions for the new or updated attributes
+        UpdateExpression: 'SET deleted= :d, #operator= :operator',
+        ExpressionAttributeNames: {
+          '#operator': 'operator',
+        },
+        ExpressionAttributeValues: {
+          ':d': true,
+          ':operator': operator,
+        },
+        ReturnValues: 'ALL_NEW',
+      });
+      await docClient.send(params);
+    }
+  };
+
+  public async listEventAttributes(order: string): Promise<IMetadataEventAttribute[]> {
+    const input: QueryCommandInput = {
+      TableName: analyticsMetadataTable,
+      IndexName: prefixTimeGSIName,
+      KeyConditionExpression: '#prefix= :prefix',
+      FilterExpression: 'deleted = :d',
+      ExpressionAttributeNames: {
+        '#prefix': 'prefix',
+      },
+      ExpressionAttributeValues: {
+        ':d': false,
+        ':prefix': 'EVENT',
+      },
+      ScanIndexForward: order === 'asc',
+    };
+    const records = await query(input);
+    return records as IMetadataEventAttribute[];
+  };
+
+  public async isUserAttributeExisted(userAttributeId: string): Promise<boolean> {
+    const params: GetCommand = new GetCommand({
+      TableName: analyticsMetadataTable,
+      Key: {
+        id: `USER_ATTRIBUTE#${userAttributeId}`,
+        type: `#METADATA#${userAttributeId}`,
+      },
+    });
+    const result: GetCommandOutput = await docClient.send(params);
+    if (!result.Item) {
+      return false;
+    }
+    const userAttribute: IMetadataUserAttribute = result.Item as IMetadataUserAttribute;
+    return userAttribute && !userAttribute.deleted;
+  };
+
+  public async createUserAttribute(userAttribute: IMetadataUserAttribute): Promise<string> {
+    const params: PutCommand = new PutCommand({
+      TableName: analyticsMetadataTable,
+      Item: {
+        id: `USER_ATTRIBUTE#${userAttribute.id}`,
+        type: `#METADATA#${userAttribute.id}`,
+        prefix: 'USER_ATTRIBUTE',
+        name: userAttribute.name,
+        displayName: userAttribute.displayName,
+        description: userAttribute.description,
+        createAt: Date.now(),
+        updateAt: Date.now(),
+        operator: userAttribute.operator?? '',
+        deleted: false,
+      },
+    });
+    await docClient.send(params);
+    return userAttribute.id;
+  };
+
+  public async getUserAttribute(userAttributeId: string): Promise<IMetadataUserAttribute | undefined> {
+    const params: GetCommand = new GetCommand({
+      TableName: analyticsMetadataTable,
+      Key: {
+        id: `USER_ATTRIBUTE#${userAttributeId}`,
+        type: `#METADATA#${userAttributeId}`,
+      },
+    });
+    const result: GetCommandOutput = await docClient.send(params);
+    if (!result.Item) {
+      return undefined;
+    }
+    const userAttribute: IMetadataUserAttribute = result.Item as IMetadataUserAttribute;
+    return !userAttribute.deleted ? userAttribute : undefined;
+  };
+
+  public async updateUserAttribute(userAttribute: IMetadataUserAttribute): Promise<void> {
+    let updateExpression = 'SET #updateAt= :u, #operator= :operator';
+    let expressionAttributeValues = new Map();
+    let expressionAttributeNames = {} as KeyVal<string>;
+    expressionAttributeValues.set(':u', Date.now());
+    expressionAttributeValues.set(':operator', userAttribute.operator);
+    expressionAttributeNames['#updateAt'] = 'updateAt';
+    expressionAttributeNames['#operator'] = 'operator';
+    if (userAttribute.displayName) {
+      updateExpression = `${updateExpression}, #displayName= :n`;
+      expressionAttributeValues.set(':n', userAttribute.displayName);
+      expressionAttributeNames['#displayName'] = 'displayName';
+    }
+    if (userAttribute.description) {
+      updateExpression = `${updateExpression}, description= :d`;
+      expressionAttributeValues.set(':d', userAttribute.description);
+    }
+    const params: UpdateCommand = new UpdateCommand({
+      TableName: analyticsMetadataTable,
+      Key: {
+        id: `USER_ATTRIBUTE#${userAttribute.id}`,
+        type: `#METADATA#${userAttribute.id}`,
+      },
+      // Define expressions for the new or updated attributes
+      UpdateExpression: updateExpression,
+      ExpressionAttributeNames: expressionAttributeNames as KeyVal<string>,
+      ExpressionAttributeValues: expressionAttributeValues,
+      ReturnValues: 'ALL_NEW',
+    });
+    await docClient.send(params);
+  };
+
+  public async deleteUserAttribute(userAttributeId: string, operator: string): Promise<void> {
+    const input: ScanCommandInput = {
+      TableName: analyticsMetadataTable,
+      FilterExpression: 'id = :p AND deleted = :d',
+      ExpressionAttributeValues: {
+        ':p': `USER_ATTRIBUTE#${userAttributeId}`,
+        ':d': false,
+      },
+    };
+    const records = await scan(input);
+    const userAttributes = records as IMetadataUserAttribute[];
+    for (let index in userAttributes) {
+      const params: UpdateCommand = new UpdateCommand({
+        TableName: analyticsMetadataTable,
+        Key: {
+          id: `USER_ATTRIBUTE#${userAttributeId}`,
+          type: userAttributes[index].type,
+        },
+        // Define expressions for the new or updated attributes
+        UpdateExpression: 'SET deleted= :d, #operator= :operator',
+        ExpressionAttributeNames: {
+          '#operator': 'operator',
+        },
+        ExpressionAttributeValues: {
+          ':d': true,
+          ':operator': operator,
+        },
+        ReturnValues: 'ALL_NEW',
+      });
+      await docClient.send(params);
+    }
+  };
+
+  public async listUserAttributes(order: string): Promise<IMetadataUserAttribute[]> {
+    const input: QueryCommandInput = {
+      TableName: analyticsMetadataTable,
+      IndexName: prefixTimeGSIName,
+      KeyConditionExpression: '#prefix= :prefix',
+      FilterExpression: 'deleted = :d',
+      ExpressionAttributeNames: {
+        '#prefix': 'prefix',
+      },
+      ExpressionAttributeValues: {
+        ':d': false,
+        ':prefix': 'EVENT',
+      },
+      ScanIndexForward: order === 'asc',
+    };
+    const records = await query(input);
+    return records as IMetadataUserAttribute[];
+  };
+}

--- a/src/control-plane/backend/lambda/api/store/metadata-store.ts
+++ b/src/control-plane/backend/lambda/api/store/metadata-store.ts
@@ -1,0 +1,37 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { IMetadataEvent, IMetadataEventAttribute, IMetadataUserAttribute } from '../model/metadata';
+
+export interface MetadataStore {
+  createEvent: (event: IMetadataEvent) => Promise<string>;
+  getEvent: (eventName: string) => Promise<any>;
+  updateEvent: (event: IMetadataEvent) => Promise<void>;
+  listEvents: (order: string) => Promise<IMetadataEvent[]>;
+  deleteEvent: (eventName: string, operator: string) => Promise<void>;
+  isEventExisted: (eventName: string) => Promise<boolean>;
+
+  createEventAttribute: (eventAttribute: IMetadataEventAttribute) => Promise<string>;
+  getEventAttribute: (eventAttributeId: string) => Promise<IMetadataEventAttribute | undefined>;
+  updateEventAttribute: (eventAttribute: IMetadataEventAttribute) => Promise<void>;
+  listEventAttributes: (order: string) => Promise<IMetadataEventAttribute[]>;
+  deleteEventAttribute: (eventAttributeId: string, operator: string) => Promise<void>;
+  isEventAttributeExisted: (eventAttributeId: string) => Promise<boolean>;
+
+  createUserAttribute: (userAttribute: IMetadataUserAttribute) => Promise<string>;
+  getUserAttribute: (userAttributeId: string) => Promise<IMetadataUserAttribute | undefined>;
+  updateUserAttribute: (userAttribute: IMetadataUserAttribute) => Promise<void>;
+  listUserAttributes: (order: string) => Promise<IMetadataUserAttribute[]>;
+  deleteUserAttribute: (userAttributeId: string, operator: string) => Promise<void>;
+  isUserAttributeExisted: (userAttributeId: string) => Promise<boolean>;
+}

--- a/src/control-plane/backend/lambda/api/store/metadata-store.ts
+++ b/src/control-plane/backend/lambda/api/store/metadata-store.ts
@@ -15,23 +15,23 @@ import { IMetadataEvent, IMetadataEventAttribute, IMetadataUserAttribute } from 
 
 export interface MetadataStore {
   createEvent: (event: IMetadataEvent) => Promise<string>;
-  getEvent: (eventName: string) => Promise<any>;
+  getEvent: (projectId: string, appId: string, eventName: string) => Promise<any>;
   updateEvent: (event: IMetadataEvent) => Promise<void>;
-  listEvents: (order: string) => Promise<IMetadataEvent[]>;
-  deleteEvent: (eventName: string, operator: string) => Promise<void>;
-  isEventExisted: (eventName: string) => Promise<boolean>;
+  listEvents: (projectId: string, appId: string, order: string) => Promise<IMetadataEvent[]>;
+  deleteEvent: (projectId: string, appId: string, eventName: string, operator: string) => Promise<void>;
+  isEventExisted: (projectId: string, appId: string, eventName: string) => Promise<boolean>;
 
   createEventAttribute: (eventAttribute: IMetadataEventAttribute) => Promise<string>;
-  getEventAttribute: (eventAttributeId: string) => Promise<IMetadataEventAttribute | undefined>;
+  getEventAttribute: (projectId: string, appId: string, eventAttributeId: string) => Promise<IMetadataEventAttribute | undefined>;
   updateEventAttribute: (eventAttribute: IMetadataEventAttribute) => Promise<void>;
-  listEventAttributes: (order: string) => Promise<IMetadataEventAttribute[]>;
-  deleteEventAttribute: (eventAttributeId: string, operator: string) => Promise<void>;
-  isEventAttributeExisted: (eventAttributeId: string) => Promise<boolean>;
+  listEventAttributes: (projectId: string, appId: string, order: string) => Promise<IMetadataEventAttribute[]>;
+  deleteEventAttribute: (projectId: string, appId: string, eventAttributeId: string, operator: string) => Promise<void>;
+  isEventAttributeExisted: (projectId: string, appId: string, eventAttributeId: string) => Promise<boolean>;
 
   createUserAttribute: (userAttribute: IMetadataUserAttribute) => Promise<string>;
-  getUserAttribute: (userAttributeId: string) => Promise<IMetadataUserAttribute | undefined>;
+  getUserAttribute: (projectId: string, appId: string, userAttributeId: string) => Promise<IMetadataUserAttribute | undefined>;
   updateUserAttribute: (userAttribute: IMetadataUserAttribute) => Promise<void>;
-  listUserAttributes: (order: string) => Promise<IMetadataUserAttribute[]>;
-  deleteUserAttribute: (userAttributeId: string, operator: string) => Promise<void>;
-  isUserAttributeExisted: (userAttributeId: string) => Promise<boolean>;
+  listUserAttributes: (projectId: string, appId: string, order: string) => Promise<IMetadataUserAttribute[]>;
+  deleteUserAttribute: (projectId: string, appId: string, userAttributeId: string, operator: string) => Promise<void>;
+  isUserAttributeExisted: (projectId: string, appId: string, userAttributeId: string) => Promise<boolean>;
 }

--- a/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
@@ -29,7 +29,7 @@ import { GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
 import { StartExecutionCommand } from '@aws-sdk/client-sfn';
 import { GetCommand, GetCommandInput, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { AllowIAMUserPutObejectPolicyInApSouthEast1, AllowIAMUserPutObejectPolicyWithErrorService } from './env-bucket-policy.test';
-import { clickStreamTableName, dictionaryTableName } from '../../common/constants';
+import { analyticsMetadataTable, clickStreamTableName, dictionaryTableName } from '../../common/constants';
 import { ProjectEnvironment } from '../../common/types';
 import { IPipeline } from '../../model/pipeline';
 
@@ -44,6 +44,11 @@ const MOCK_EXECUTION_ID = 'main-3333-3333';
 const MOCK_BUILT_IN_PLUGIN_ID = 'BUILT-IN-1';
 const MOCK_NEW_TEMPLATE_VERSION = '1.0.0-main-sdjes12';
 const MOCK_SOLUTION_VERSION = 'v1.0.0';
+const MOCK_EVENT_NAME = 'event-mock';
+const MOCK_EVENT_ATTRIBUTE_ID = '1111-1111';
+const MOCK_EVENT_ATTRIBUTE_NAME = 'event-attribute-mock';
+const MOCK_USER_ATTRIBUTE_ID = '2222-2222';
+const MOCK_USER_ATTRIBUTE_NAME = 'user-attribute-mock';
 
 function tokenMock(ddbMock: any, expect: boolean): any {
   if (!expect) {
@@ -132,6 +137,57 @@ function pluginExistedMock(ddbMock: any, existed: boolean): any {
     Item: {
       id: MOCK_PLUGIN_ID,
       type: `PLUGIN#${MOCK_PLUGIN_ID}`,
+      deleted: !existed,
+    },
+  });
+}
+
+function metadataEventExistedMock(ddbMock: any, projectId:string, appId: string, existed: boolean): any {
+  const tokenInput: GetCommandInput = {
+    TableName: analyticsMetadataTable,
+    Key: {
+      id: `EVENT#${projectId}#${appId}#${MOCK_EVENT_NAME}`,
+      type: `#METADATA#${projectId}#${appId}#${MOCK_EVENT_NAME}`,
+    },
+  };
+  return ddbMock.on(GetCommand, tokenInput).resolves({
+    Item: {
+      id: `EVENT#${projectId}#${appId}#${MOCK_EVENT_NAME}`,
+      type: `#METADATA#${projectId}#${appId}#${MOCK_EVENT_NAME}`,
+      deleted: !existed,
+    },
+  });
+}
+
+function metadataEventAttributeExistedMock(ddbMock: any, projectId:string, appId: string, existed: boolean): any {
+  const tokenInput: GetCommandInput = {
+    TableName: analyticsMetadataTable,
+    Key: {
+      id: `EVENT_ATTRIBUTE#${projectId}#${appId}#${MOCK_EVENT_ATTRIBUTE_ID}`,
+      type: `#METADATA#${projectId}#${appId}#${MOCK_EVENT_ATTRIBUTE_ID}`,
+    },
+  };
+  return ddbMock.on(GetCommand, tokenInput).resolves({
+    Item: {
+      id: `EVENT_ATTRIBUTE#${projectId}#${appId}#${MOCK_EVENT_ATTRIBUTE_ID}`,
+      type: `#METADATA#${projectId}#${appId}#${MOCK_EVENT_ATTRIBUTE_ID}`,
+      deleted: !existed,
+    },
+  });
+}
+
+function metadataUserAttributeExistedMock(ddbMock: any, projectId:string, appId: string, existed: boolean): any {
+  const tokenInput: GetCommandInput = {
+    TableName: analyticsMetadataTable,
+    Key: {
+      id: `USER_ATTRIBUTE#${projectId}#${appId}#${MOCK_USER_ATTRIBUTE_ID}`,
+      type: `#METADATA#${projectId}#${appId}#${MOCK_USER_ATTRIBUTE_ID}`,
+    },
+  };
+  return ddbMock.on(GetCommand, tokenInput).resolves({
+    Item: {
+      id: `USER_ATTRIBUTE#${projectId}#${appId}#${MOCK_USER_ATTRIBUTE_ID}`,
+      type: `#METADATA#${projectId}#${appId}#${MOCK_USER_ATTRIBUTE_ID}`,
       deleted: !existed,
     },
   });
@@ -766,6 +822,11 @@ export {
   MOCK_BUILT_IN_PLUGIN_ID,
   MOCK_NEW_TEMPLATE_VERSION,
   MOCK_SOLUTION_VERSION,
+  MOCK_EVENT_NAME,
+  MOCK_EVENT_ATTRIBUTE_ID,
+  MOCK_EVENT_ATTRIBUTE_NAME,
+  MOCK_USER_ATTRIBUTE_ID,
+  MOCK_USER_ATTRIBUTE_NAME,
   tokenMock,
   projectExistedMock,
   appExistedMock,
@@ -773,4 +834,7 @@ export {
   pluginExistedMock,
   dictionaryMock,
   createPipelineMock,
+  metadataEventExistedMock,
+  metadataEventAttributeExistedMock,
+  metadataUserAttributeExistedMock,
 };

--- a/src/control-plane/backend/lambda/api/test/api/metadata.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/metadata.test.ts
@@ -1,0 +1,1087 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  ScanCommand,
+  UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { mockClient } from 'aws-sdk-client-mock';
+import request from 'supertest';
+import { metadataEventAttributeExistedMock, metadataEventExistedMock, metadataUserAttributeExistedMock, MOCK_APP_ID, MOCK_EVENT_ATTRIBUTE_ID, MOCK_EVENT_ATTRIBUTE_NAME, MOCK_EVENT_NAME, MOCK_PROJECT_ID, MOCK_TOKEN, MOCK_USER_ATTRIBUTE_ID, MOCK_USER_ATTRIBUTE_NAME, tokenMock } from './ddb-mock';
+import { app, server } from '../../index';
+import 'aws-sdk-client-mock-jest';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+describe('Metadata Event test', () => {
+  beforeEach(() => {
+    ddbMock.reset();
+  });
+  it('Create metadata event', async () => {
+    tokenMock(ddbMock, false);
+    ddbMock.on(PutCommand).resolvesOnce({});
+    const res = await request(app)
+      .post('/api/metadata/event')
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        name: MOCK_EVENT_NAME,
+        description: 'Description of event',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(201);
+    expect(res.body.message).toEqual('Event created.');
+    expect(res.body.success).toEqual(true);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 2);
+  });
+  it('Create metadata event with XSS', async () => {
+    tokenMock(ddbMock, false);
+    ddbMock.on(PutCommand).resolvesOnce({});
+    const res = await request(app)
+      .post('/api/metadata/event')
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        name: '<IMG SRC=javascript:alert(\'XSS\')><script>alert(234)</script>',
+        description: 'Description of event',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Parameter verification failed.',
+      error: [
+        {
+          location: 'body',
+          msg: 'Bad request. Please check and try again.',
+          param: '',
+          value: {
+            projectId: MOCK_PROJECT_ID,
+            appId: MOCK_APP_ID,
+            name: '<IMG SRC=javascript:alert(\'XSS\')><script>alert(234)</script>',
+            description: 'Description of event',
+          },
+        },
+      ],
+    });
+  });
+  it('Create metadata event with mock error', async () => {
+    tokenMock(ddbMock, false);
+    // Mock DynamoDB error
+    ddbMock.on(PutCommand).rejects(new Error('Mock DynamoDB error'));;
+    const res = await request(app)
+      .post('/api/metadata/event')
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        name: MOCK_EVENT_NAME,
+        description: 'Description of event',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Unexpected error occurred at server.',
+      error: 'Error',
+    });
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
+  });
+  it('Create metadata event 400', async () => {
+    tokenMock(ddbMock, false);
+    const res = await request(app)
+      .post('/api/metadata/event');
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Parameter verification failed.',
+      error: [
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: 'projectId',
+        },
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: 'appId',
+        },
+        {
+          location: 'headers',
+          msg: 'Value is empty.',
+          param: 'x-click-stream-request-id',
+        },
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: '',
+          value: {},
+        },
+      ],
+    });
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+  });
+  it('Create metadata event Not Modified', async () => {
+    tokenMock(ddbMock, true);
+    const res = await request(app)
+      .post('/api/metadata/event')
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        name: MOCK_EVENT_NAME,
+        description: 'Description of event',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Parameter verification failed.',
+      error: [
+        {
+          location: 'headers',
+          msg: 'Not Modified.',
+          param: 'x-click-stream-request-id',
+          value: '0000-0000',
+        },
+      ],
+    });
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+  });
+  it('Get metadata event by name', async () => {
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        {
+          deleted: false,
+          updateAt: 1690788840458,
+          createAt: 1690788840458,
+          prefix: `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+          operator: '',
+          id: `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}`,
+          description: 'description of event 1',
+          name: 'event1',
+          type: `#METADATA#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}`,
+        },
+        {
+          deleted: false,
+          updateAt: 1690788840458,
+          createAt: 1690788840458,
+          prefix: 'RELATION',
+          operator: '',
+          id: `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}`,
+          name: 'EventAttributeName1',
+          type: `EVENT_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#eventAttribute1`,
+        },
+      ],
+    });
+    let res = await request(app)
+      .get(`/api/metadata/event/${MOCK_EVENT_NAME}?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      message: '',
+      data: {
+        createAt: 1690788840458,
+        deleted: false,
+        description: 'description of event 1',
+        id: `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}`,
+        name: 'event1',
+        operator: '',
+        prefix: `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+        type: `#METADATA#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}`,
+        updateAt: 1690788840458,
+        attributes: [
+          {
+            createAt: 1690788840458,
+            deleted: false,
+            id: `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}`,
+            name: 'EventAttributeName1',
+            operator: '',
+            prefix: 'RELATION',
+            type: `EVENT_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#eventAttribute1`,
+            updateAt: 1690788840458,
+          },
+        ],
+      },
+    });
+  });
+  it('Get non-existent metadata event', async () => {
+    ddbMock.on(QueryCommand).resolves({
+      Items: [],
+    });
+    const res = await request(app)
+      .get(`/api/metadata/event/${MOCK_EVENT_NAME}?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Event not found',
+    });
+  });
+  it('Get metadata event list', async () => {
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        { name: 'event-01' },
+        { name: 'event-02' },
+        { name: 'event-03' },
+      ],
+    });
+    let res = await request(app)
+      .get(`/api/metadata/events?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      message: '',
+      data: {
+        items: [
+          { name: 'event-01' },
+          { name: 'event-02' },
+          { name: 'event-03' },
+        ],
+        totalCount: 3,
+      },
+    });
+
+    // Mock DynamoDB error
+    ddbMock.on(QueryCommand).rejects(new Error('Mock DynamoDB error'));
+    res = await request(app)
+      .get(`/api/metadata/events?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(500);
+
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Unexpected error occurred at server.',
+      error: 'Error',
+    });
+  });
+  it('Update metadata event', async () => {
+    metadataEventExistedMock(ddbMock, MOCK_PROJECT_ID, MOCK_APP_ID, true);
+    ddbMock.on(UpdateCommand).resolves({});
+    let res = await request(app)
+      .put('/api/metadata/event')
+      .send({
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        name: MOCK_EVENT_NAME,
+        description: 'Description of event',
+        displayName: 'display name of event 555',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toEqual({
+      data: null,
+      success: true,
+      message: 'Event updated.',
+    });
+  });
+  it('Update metadata event with not body', async () => {
+    metadataEventExistedMock(ddbMock, MOCK_PROJECT_ID, MOCK_APP_ID, true);
+    ddbMock.on(PutCommand).resolves({});
+    const res = await request(app)
+      .put('/api/metadata/event');
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Parameter verification failed.',
+      error: [
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: '',
+          value: {},
+        },
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: 'projectId',
+        },
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: 'appId',
+        },
+      ],
+    });
+  });
+  it('Update metadata event with no existed', async () => {
+    metadataEventExistedMock(ddbMock, MOCK_PROJECT_ID, MOCK_APP_ID, false);
+    const res = await request(app)
+      .put('/api/metadata/event')
+      .send({
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        name: MOCK_EVENT_NAME,
+        description: 'Description of event',
+        displayName: 'display name of event 555',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Event not found',
+    });
+  });
+  it('Delete metadata event', async () => {
+    metadataEventExistedMock(ddbMock, MOCK_PROJECT_ID, MOCK_APP_ID, true);
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        {
+          id: 'EVENT#project1#app1#event2',
+          type: 'EVENT',
+          deleted: false,
+          updateAt: 1690788840458,
+        },
+        {
+          id: 'EVENT#project1#app1#event2',
+          type: 'EVENT',
+          deleted: false,
+          updateAt: 1690788840458,
+        },
+      ],
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    let res = await request(app)
+      .delete(`/api/metadata/event/${MOCK_EVENT_NAME}?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      data: null,
+      success: true,
+      message: 'Event deleted.',
+    });
+    expect(ddbMock).toHaveReceivedCommandTimes(ScanCommand, 1);
+    expect(ddbMock).toHaveReceivedCommandTimes(UpdateCommand, 2);
+  });
+  it('Delete metadata event with no existed', async () => {
+    metadataEventExistedMock(ddbMock, MOCK_PROJECT_ID, MOCK_APP_ID, false);
+    ddbMock.on(UpdateCommand).resolves({});
+    const res = await request(app)
+      .delete(`/api/metadata/event/${MOCK_EVENT_NAME}?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Event not found',
+    });
+    expect(ddbMock).toHaveReceivedCommandTimes(ScanCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(UpdateCommand, 0);
+  });
+
+  afterAll((done) => {
+    server.close();
+    done();
+  });
+});
+
+describe('Metadata Event Attribute test', () => {
+  beforeEach(() => {
+    ddbMock.reset();
+  });
+  it('Create metadata event attribute', async () => {
+    tokenMock(ddbMock, false);
+    ddbMock.on(PutCommand).resolvesOnce({});
+    const res = await request(app)
+      .post('/api/metadata/event_attribute')
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        name: MOCK_EVENT_ATTRIBUTE_NAME,
+        description: 'Description of event',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(201);
+    expect(res.body.message).toEqual('Event attribute created.');
+    expect(res.body.success).toEqual(true);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 2);
+  });
+  it('Create metadata event attribute with XSS', async () => {
+    tokenMock(ddbMock, false);
+    ddbMock.on(PutCommand).resolvesOnce({});
+    const res = await request(app)
+      .post('/api/metadata/event_attribute')
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        name: '<IMG SRC=javascript:alert(\'XSS\')><script>alert(234)</script>',
+        description: 'Description of event',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Parameter verification failed.',
+      error: [
+        {
+          location: 'body',
+          msg: 'Bad request. Please check and try again.',
+          param: '',
+          value: {
+            projectId: MOCK_PROJECT_ID,
+            appId: MOCK_APP_ID,
+            name: '<IMG SRC=javascript:alert(\'XSS\')><script>alert(234)</script>',
+            description: 'Description of event',
+          },
+        },
+      ],
+    });
+  });
+  it('Create metadata event attribute with mock error', async () => {
+    tokenMock(ddbMock, false);
+    // Mock DynamoDB error
+    ddbMock.on(PutCommand).rejects(new Error('Mock DynamoDB error'));;
+    const res = await request(app)
+      .post('/api/metadata/event_attribute')
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        name: MOCK_EVENT_ATTRIBUTE_NAME,
+        description: 'Description of event',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Unexpected error occurred at server.',
+      error: 'Error',
+    });
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
+  });
+  it('Create metadata event attribute 400', async () => {
+    tokenMock(ddbMock, false);
+    const res = await request(app)
+      .post('/api/metadata/event_attribute');
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Parameter verification failed.',
+      error: [
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: 'projectId',
+        },
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: 'appId',
+        },
+        {
+          location: 'headers',
+          msg: 'Value is empty.',
+          param: 'x-click-stream-request-id',
+        },
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: '',
+          value: {},
+        },
+      ],
+    });
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+  });
+  it('Create metadata event attribute Not Modified', async () => {
+    tokenMock(ddbMock, true);
+    const res = await request(app)
+      .post('/api/metadata/event_attribute')
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        name: MOCK_EVENT_ATTRIBUTE_NAME,
+        description: 'Description of event',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Parameter verification failed.',
+      error: [
+        {
+          location: 'headers',
+          msg: 'Not Modified.',
+          param: 'x-click-stream-request-id',
+          value: '0000-0000',
+        },
+      ],
+    });
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+  });
+  it('Get metadata event attribute by name', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item:
+        {
+          deleted: false,
+          updateAt: 1690788840458,
+          createAt: 1690788840458,
+          prefix: `EVENT_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+          operator: '',
+          id: `EVENT_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_ATTRIBUTE_ID}`,
+          description: 'description of event 1',
+          name: 'event1',
+          type: `#METADATA#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_ATTRIBUTE_ID}`,
+        },
+    });
+    let res = await request(app)
+      .get(`/api/metadata/event_attribute/${MOCK_EVENT_ATTRIBUTE_ID}?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      message: '',
+      data: {
+        createAt: 1690788840458,
+        deleted: false,
+        description: 'description of event 1',
+        id: `EVENT_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_ATTRIBUTE_ID}`,
+        name: 'event1',
+        operator: '',
+        prefix: `EVENT_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+        type: `#METADATA#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_ATTRIBUTE_ID}`,
+        updateAt: 1690788840458,
+      },
+    });
+  });
+  it('Get non-existent metadata event attribute', async () => {
+    ddbMock.on(GetCommand).resolves({});
+    const res = await request(app)
+      .get(`/api/metadata/event_attribute/${MOCK_EVENT_ATTRIBUTE_ID}?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Event attribute not found',
+    });
+  });
+  it('Get metadata event attribute list', async () => {
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        { name: 'event-01' },
+        { name: 'event-02' },
+        { name: 'event-03' },
+      ],
+    });
+    let res = await request(app)
+      .get(`/api/metadata/event_attributes?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      message: '',
+      data: {
+        items: [
+          { name: 'event-01' },
+          { name: 'event-02' },
+          { name: 'event-03' },
+        ],
+        totalCount: 3,
+      },
+    });
+
+    // Mock DynamoDB error
+    ddbMock.on(QueryCommand).rejects(new Error('Mock DynamoDB error'));
+    res = await request(app)
+      .get(`/api/metadata/event_attributes?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(500);
+
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Unexpected error occurred at server.',
+      error: 'Error',
+    });
+  });
+  it('Update metadata event attribute', async () => {
+    metadataEventAttributeExistedMock(ddbMock, MOCK_PROJECT_ID, MOCK_APP_ID, true);
+    ddbMock.on(UpdateCommand).resolves({});
+    let res = await request(app)
+      .put('/api/metadata/event_attribute')
+      .send({
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        id: MOCK_EVENT_ATTRIBUTE_ID,
+        name: MOCK_EVENT_ATTRIBUTE_NAME,
+        description: 'Description of event',
+        displayName: 'display name of event 555',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toEqual({
+      data: null,
+      success: true,
+      message: 'Event attribute updated.',
+    });
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
+    expect(ddbMock).toHaveReceivedCommandTimes(UpdateCommand, 1);
+  });
+  it('Update metadata event attribute with not body', async () => {
+    metadataEventAttributeExistedMock(ddbMock, MOCK_PROJECT_ID, MOCK_APP_ID, true);
+    ddbMock.on(PutCommand).resolves({});
+    const res = await request(app)
+      .put('/api/metadata/event_attribute');
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Parameter verification failed.',
+      error: [
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: '',
+          value: {},
+        },
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: 'projectId',
+        },
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: 'appId',
+        },
+      ],
+    });
+  });
+  it('Update metadata event attribute with no existed', async () => {
+    metadataEventAttributeExistedMock(ddbMock, MOCK_PROJECT_ID, MOCK_APP_ID, false);
+    const res = await request(app)
+      .put('/api/metadata/event_attribute')
+      .send({
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        id: MOCK_EVENT_ATTRIBUTE_ID,
+        name: MOCK_EVENT_ATTRIBUTE_NAME,
+        description: 'Description of event',
+        displayName: 'display name of event 555',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Event attribute not found',
+    });
+  });
+  it('Delete metadata event attribute', async () => {
+    metadataEventAttributeExistedMock(ddbMock, MOCK_PROJECT_ID, MOCK_APP_ID, true);
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        {
+          id: 'EVENT#project1#app1#event2',
+          type: 'EVENT',
+          deleted: false,
+          updateAt: 1690788840458,
+        },
+        {
+          id: 'EVENT#project1#app1#event2',
+          type: 'EVENT',
+          deleted: false,
+          updateAt: 1690788840458,
+        },
+      ],
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    let res = await request(app)
+      .delete(`/api/metadata/event_attribute/${MOCK_EVENT_ATTRIBUTE_ID}?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      data: null,
+      success: true,
+      message: 'Event attribute deleted.',
+    });
+    expect(ddbMock).toHaveReceivedCommandTimes(ScanCommand, 1);
+    expect(ddbMock).toHaveReceivedCommandTimes(UpdateCommand, 2);
+  });
+  it('Delete metadata event attribute with no existed', async () => {
+    metadataEventAttributeExistedMock(ddbMock, MOCK_PROJECT_ID, MOCK_APP_ID, false);
+    ddbMock.on(UpdateCommand).resolves({});
+    const res = await request(app)
+      .delete(`/api/metadata/event_attribute/${MOCK_EVENT_ATTRIBUTE_ID}?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Event attribute not found',
+    });
+    expect(ddbMock).toHaveReceivedCommandTimes(ScanCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(UpdateCommand, 0);
+  });
+
+  afterAll((done) => {
+    server.close();
+    done();
+  });
+});
+
+describe('Metadata User Attribute test', () => {
+  beforeEach(() => {
+    ddbMock.reset();
+  });
+  it('Create metadata user attribute', async () => {
+    tokenMock(ddbMock, false);
+    ddbMock.on(PutCommand).resolvesOnce({});
+    const res = await request(app)
+      .post('/api/metadata/user_attribute')
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        name: MOCK_USER_ATTRIBUTE_NAME,
+        description: 'Description of event',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(201);
+    expect(res.body.message).toEqual('User attribute created.');
+    expect(res.body.success).toEqual(true);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 2);
+  });
+  it('Create metadata user attribute with XSS', async () => {
+    tokenMock(ddbMock, false);
+    ddbMock.on(PutCommand).resolvesOnce({});
+    const res = await request(app)
+      .post('/api/metadata/user_attribute')
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        name: '<IMG SRC=javascript:alert(\'XSS\')><script>alert(234)</script>',
+        description: 'Description of event',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Parameter verification failed.',
+      error: [
+        {
+          location: 'body',
+          msg: 'Bad request. Please check and try again.',
+          param: '',
+          value: {
+            projectId: MOCK_PROJECT_ID,
+            appId: MOCK_APP_ID,
+            name: '<IMG SRC=javascript:alert(\'XSS\')><script>alert(234)</script>',
+            description: 'Description of event',
+          },
+        },
+      ],
+    });
+  });
+  it('Create metadata user attribute with mock error', async () => {
+    tokenMock(ddbMock, false);
+    // Mock DynamoDB error
+    ddbMock.on(PutCommand).rejects(new Error('Mock DynamoDB error'));;
+    const res = await request(app)
+      .post('/api/metadata/user_attribute')
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        name: MOCK_USER_ATTRIBUTE_NAME,
+        description: 'Description of event',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Unexpected error occurred at server.',
+      error: 'Error',
+    });
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
+  });
+  it('Create metadata user attribute 400', async () => {
+    tokenMock(ddbMock, false);
+    const res = await request(app)
+      .post('/api/metadata/user_attribute');
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Parameter verification failed.',
+      error: [
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: 'projectId',
+        },
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: 'appId',
+        },
+        {
+          location: 'headers',
+          msg: 'Value is empty.',
+          param: 'x-click-stream-request-id',
+        },
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: '',
+          value: {},
+        },
+      ],
+    });
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+  });
+  it('Create metadata user attribute Not Modified', async () => {
+    tokenMock(ddbMock, true);
+    const res = await request(app)
+      .post('/api/metadata/user_attribute')
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        name: MOCK_USER_ATTRIBUTE_NAME,
+        description: 'Description of event',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Parameter verification failed.',
+      error: [
+        {
+          location: 'headers',
+          msg: 'Not Modified.',
+          param: 'x-click-stream-request-id',
+          value: '0000-0000',
+        },
+      ],
+    });
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+  });
+  it('Get metadata user attribute by name', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item:
+        {
+          deleted: false,
+          updateAt: 1690788840458,
+          createAt: 1690788840458,
+          prefix: `EVENT_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+          operator: '',
+          id: `EVENT_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_ID}`,
+          description: 'description of event 1',
+          name: 'event1',
+          type: `#METADATA#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_ID}`,
+        },
+    });
+    let res = await request(app)
+      .get(`/api/metadata/user_attribute/${MOCK_USER_ATTRIBUTE_ID}?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      message: '',
+      data: {
+        createAt: 1690788840458,
+        deleted: false,
+        description: 'description of event 1',
+        id: `EVENT_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_ID}`,
+        name: 'event1',
+        operator: '',
+        prefix: `EVENT_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+        type: `#METADATA#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_ID}`,
+        updateAt: 1690788840458,
+      },
+    });
+  });
+  it('Get non-existent metadata user attribute', async () => {
+    ddbMock.on(GetCommand).resolves({});
+    const res = await request(app)
+      .get(`/api/metadata/user_attribute/${MOCK_USER_ATTRIBUTE_ID}?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'User attribute not found',
+    });
+  });
+  it('Get metadata user attribute list', async () => {
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        { name: 'event-01' },
+        { name: 'event-02' },
+        { name: 'event-03' },
+      ],
+    });
+    let res = await request(app)
+      .get(`/api/metadata/user_attributes?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      message: '',
+      data: {
+        items: [
+          { name: 'event-01' },
+          { name: 'event-02' },
+          { name: 'event-03' },
+        ],
+        totalCount: 3,
+      },
+    });
+
+    // Mock DynamoDB error
+    ddbMock.on(QueryCommand).rejects(new Error('Mock DynamoDB error'));
+    res = await request(app)
+      .get(`/api/metadata/user_attributes?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(500);
+
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Unexpected error occurred at server.',
+      error: 'Error',
+    });
+  });
+  it('Update metadata user attribute', async () => {
+    metadataUserAttributeExistedMock(ddbMock, MOCK_PROJECT_ID, MOCK_APP_ID, true);
+    ddbMock.on(UpdateCommand).resolves({});
+    let res = await request(app)
+      .put('/api/metadata/user_attribute')
+      .send({
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        id: MOCK_USER_ATTRIBUTE_ID,
+        name: MOCK_USER_ATTRIBUTE_NAME,
+        description: 'Description of event',
+        displayName: 'display name of event 555',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toEqual({
+      data: null,
+      success: true,
+      message: 'User attribute updated.',
+    });
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
+    expect(ddbMock).toHaveReceivedCommandTimes(UpdateCommand, 1);
+  });
+  it('Update metadata user attribute with not body', async () => {
+    metadataUserAttributeExistedMock(ddbMock, MOCK_PROJECT_ID, MOCK_APP_ID, true);
+    ddbMock.on(PutCommand).resolves({});
+    const res = await request(app)
+      .put('/api/metadata/user_attribute');
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Parameter verification failed.',
+      error: [
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: '',
+          value: {},
+        },
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: 'projectId',
+        },
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: 'appId',
+        },
+      ],
+    });
+  });
+  it('Update metadata user attribute with no existed', async () => {
+    metadataUserAttributeExistedMock(ddbMock, MOCK_PROJECT_ID, MOCK_APP_ID, false);
+    const res = await request(app)
+      .put('/api/metadata/user_attribute')
+      .send({
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        id: MOCK_USER_ATTRIBUTE_ID,
+        name: MOCK_USER_ATTRIBUTE_NAME,
+        description: 'Description of event',
+        displayName: 'display name of event 555',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'User attribute not found',
+    });
+  });
+  it('Delete metadata user attribute', async () => {
+    metadataUserAttributeExistedMock(ddbMock, MOCK_PROJECT_ID, MOCK_APP_ID, true);
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        {
+          id: 'EVENT#project1#app1#event2',
+          type: 'EVENT',
+          deleted: false,
+          updateAt: 1690788840458,
+        },
+        {
+          id: 'EVENT#project1#app1#event2',
+          type: 'EVENT',
+          deleted: false,
+          updateAt: 1690788840458,
+        },
+      ],
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    let res = await request(app)
+      .delete(`/api/metadata/user_attribute/${MOCK_USER_ATTRIBUTE_ID}?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      data: null,
+      success: true,
+      message: 'User attribute deleted.',
+    });
+    expect(ddbMock).toHaveReceivedCommandTimes(ScanCommand, 1);
+    expect(ddbMock).toHaveReceivedCommandTimes(UpdateCommand, 2);
+  });
+  it('Delete metadata user attribute with no existed', async () => {
+    metadataUserAttributeExistedMock(ddbMock, MOCK_PROJECT_ID, MOCK_APP_ID, false);
+    ddbMock.on(UpdateCommand).resolves({});
+    const res = await request(app)
+      .delete(`/api/metadata/user_attribute/${MOCK_USER_ATTRIBUTE_ID}?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'User attribute not found',
+    });
+    expect(ddbMock).toHaveReceivedCommandTimes(ScanCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(UpdateCommand, 0);
+  });
+
+  afterAll((done) => {
+    server.close();
+    done();
+  });
+});

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -22,6 +22,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
       .toEqual([
         'testClickStreamALBApiClickstreamDictionary0A1156B6',
         'testClickStreamALBApiClickstreamMetadataA721B303',
+        'testClickStreamALBApiClickstreamAnalyticsMetadataA20F6663',
       ]);
 
     newALBApiStackTemplate.hasResourceProperties('AWS::DynamoDB::Table', {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. Add DDB table for metadata of project/app events.
2. Add new api **/api/metadata** for `event`, `event attribute`, `user attribute`

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module