### PR TITLE
fix: emr-serverless application upgrade issue when the state is started 

### DIFF
--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -235,6 +235,7 @@ export const SCHEDULE_EXPRESSION_PATTERN =
 export const CORS_PATTERN = `^$|\\*$|^(${DOMAIN_NAME_PATTERN}(,\\s*${DOMAIN_NAME_PATTERN})*)$`;
 export const XSS_PATTERN = '<(?:"[^"]*"[\'"]*|\'[^\']*\'[\'"]*|[^\'">])+(?<!/\s*)>';
 export const REGION_PATTERN = '[a-z]{2}-[a-z0-9]{1,10}-[0-9]{1}';
+export const EMR_VERSION_PATTERN='^emr-[0-9]+\\.[0-9]+\\.[0-9]+$';
 
 export const METADATA_EVENT_NAME_PATTERN = '[a-z][a-z0-9_]{0,64}';
 

--- a/src/common/lambda.ts
+++ b/src/common/lambda.ts
@@ -20,9 +20,12 @@ import {
   ServicePrincipal,
   PrincipalBase,
 } from 'aws-cdk-lib/aws-iam';
-import { IFunction } from 'aws-cdk-lib/aws-lambda';
+import { IFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { IConstruct } from 'constructs';
 import { addCfnNagSuppressRules } from './cfn-nag';
+
+
+export const LAMBDA_NODEJS_RUNTIME = Runtime.NODEJS_18_X;
 
 export function cloudWatchSendLogs(id: string, func: IFunction): IFunction {
   if (func.role !== undefined) {

--- a/src/data-pipeline/lambda/emr-serverless-app/index.ts
+++ b/src/data-pipeline/lambda/emr-serverless-app/index.ts
@@ -1,0 +1,157 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+
+import { EMRServerlessClient, CreateApplicationCommand, Architecture, CreateApplicationCommandInput, DeleteApplicationCommand } from '@aws-sdk/client-emr-serverless';
+import { CloudFormationCustomResourceEvent, Context } from 'aws-lambda';
+import { logger } from '../../../common/powertools';
+import { putStringToS3, readS3ObjectAsJson } from '../../../common/s3';
+import { aws_sdk_client_common_config } from '../../../common/sdk-client-config';
+
+export interface ResourcePropertiesType {
+  ServiceToken: string;
+  projectId: string;
+  name: string;
+  version: string;
+  secourityGroupId: string;
+  subnetIds: string;
+  idleTimeoutMinutes: string;
+}
+
+const region = process.env.AWS_REGION!;
+const stackId = process.env.STACK_ID!;
+const s3Bucket = process.env.PIPELINE_S3_BUCKET_NAME!;
+let s3Prefix = process.env.PIPELINE_S3_PREFIX!;
+
+if (!s3Prefix.endsWith('/')) {
+  s3Prefix = s3Prefix + '/';
+}
+
+const appIdKey = s3Prefix + stackId + '/config/emr-serverless-applicationId.json';
+
+const emrServerlessClient = new EMRServerlessClient({
+  ...aws_sdk_client_common_config,
+  region,
+});
+
+export const handler = async (event: CloudFormationCustomResourceEvent, context: Context) => {
+  logger.info(JSON.stringify(event));
+  try {
+    const res = await _handler(event, context);
+    logger.info('lambda returned', { res });
+    return res;
+  } catch (e: any) {
+    logger.error(e);
+    throw e;
+  }
+};
+
+async function _handler(event: CloudFormationCustomResourceEvent, context: Context) {
+  logger.info(`functionName: ${context.functionName}`);
+  const props = event.ResourceProperties as ResourcePropertiesType;
+  if (event.RequestType == 'Delete') {
+    await deleteEMRServerlessApp();
+    return;
+  } else {
+    const applicationId = await createEMRServerlessApp(props);
+    return {
+      Data: {
+        ApplicationId: applicationId,
+      },
+    };
+  }
+}
+
+async function createEMRServerlessApp(props: ResourcePropertiesType): Promise<string> {
+  const input: CreateApplicationCommandInput = {
+    name: props.name,
+    releaseLabel: props.version,
+    type: 'SPARK',
+    architecture: Architecture.X86_64,
+    networkConfiguration: {
+      subnetIds: props.subnetIds.split(','),
+      securityGroupIds: [props.secourityGroupId],
+    },
+    autoStartConfiguration: {
+      enabled: true,
+    },
+    autoStopConfiguration: {
+      enabled: true,
+      idleTimeoutMinutes: parseInt(props.idleTimeoutMinutes),
+    },
+  };
+
+  logger.info('CreateApplicationCommand input', { input });
+  const command = new CreateApplicationCommand(input);
+  const response = await emrServerlessClient.send(command);
+  const applicationId = response.applicationId!;
+  logger.info('created emr application applicationId:' + applicationId);
+
+  logger.info('s3Bucket:' + s3Bucket + ', appIdKey:' + appIdKey);
+  let appIdCofing = await readS3ObjectAsJson(s3Bucket, appIdKey);
+  const nowStr = process.env.TEST_TIME_NOW_STR || new Date().toISOString();
+
+  if (appIdCofing) {
+    logger.info('find appIdCofing', { appIdCofing });
+    // only save previous 5 appIds
+    const applicationIds = appIdCofing.applicationIds.slice(-5);
+    // delete old one
+    for (const appInfo of applicationIds) {
+      await deleteEMRServerlessAppById(appInfo.applicationId);
+    }
+    applicationIds.push({
+      applicationId,
+      createAt: nowStr,
+    });
+    appIdCofing.applicationIds = applicationIds;
+  } else {
+    logger.info('not find appIdCofing');
+    appIdCofing = {
+      applicationIds: [
+        {
+          applicationId,
+          createAt: nowStr,
+        },
+      ],
+    };
+  }
+
+  logger.info('save new appIdCofing', appIdCofing);
+  await putStringToS3(JSON.stringify(appIdCofing), s3Bucket, appIdKey);
+  return applicationId;
+}
+
+async function deleteEMRServerlessApp() {
+  const appIdCofing = await readS3ObjectAsJson(s3Bucket, appIdKey);
+  if (appIdCofing) {
+    logger.info('find appIdCofing', { appIdCofing });
+    const applicationIds = appIdCofing.applicationIds;
+    for (const app of applicationIds) {
+      await deleteEMRServerlessAppById(app.applicationId);
+    }
+  }
+}
+
+async function deleteEMRServerlessAppById(appId: string) {
+  try {
+    logger.info('delete ' + appId);
+    await emrServerlessClient.send(new DeleteApplicationCommand({
+      applicationId: appId,
+    }));
+  } catch (err) {
+    // if app is 'started' state, which cannot be deleted,  we ignore this error.
+    logger.error(err + '');
+  }
+}
+
+

--- a/src/data-pipeline/parameter.ts
+++ b/src/data-pipeline/parameter.ts
@@ -13,7 +13,7 @@
 
 import { CfnParameter } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { PARAMETER_GROUP_LABEL_VPC, PARAMETER_LABEL_PRIVATE_SUBNETS, PARAMETER_LABEL_VPCID, S3_BUCKET_NAME_PATTERN, S3_PATH_PLUGIN_FILES_PATTERN, S3_PATH_PLUGIN_JARS_PATTERN, SCHEDULE_EXPRESSION_PATTERN } from '../common/constant';
+import { EMR_VERSION_PATTERN, PARAMETER_GROUP_LABEL_VPC, PARAMETER_LABEL_PRIVATE_SUBNETS, PARAMETER_LABEL_VPCID, S3_BUCKET_NAME_PATTERN, S3_PATH_PLUGIN_FILES_PATTERN, S3_PATH_PLUGIN_JARS_PATTERN, SCHEDULE_EXPRESSION_PATTERN } from '../common/constant';
 import { Parameters, SubnetParameterType } from '../common/parameters';
 
 export function createStackParameters(scope: Construct) {
@@ -103,6 +103,21 @@ export function createStackParameters(scope: Construct) {
     type: 'String',
   });
 
+  const emrVersionParam = new CfnParameter(scope, 'EmrVersion', {
+    description: 'EMR Version',
+    allowedPattern: EMR_VERSION_PATTERN,
+    default: 'emr-6.11.0',
+    type: 'String',
+  });
+
+  const emrApplicationIdleTimeoutMinutesParam = new CfnParameter(scope, 'EmrApplicationIdleTimeoutMinutes', {
+    description: 'Emr-Serverless application idle timeout minutes',
+    default: 5,
+    minValue: 1,
+    maxValue: 10080,
+    type: 'Number',
+  });
+
   const metadata = {
     'AWS::CloudFormation::Interface': {
       ParameterGroups: [
@@ -153,6 +168,14 @@ export function createStackParameters(scope: Construct) {
             s3PathPluginJarsParam.logicalId,
             s3PathPluginFilesParam.logicalId,
             outputFormatParam.logicalId,
+          ],
+        },
+
+        {
+          Label: { default: 'EMR serverless application configuration' },
+          Parameters: [
+            emrVersionParam.logicalId,
+            emrApplicationIdleTimeoutMinutesParam.logicalId,
           ],
         },
       ],
@@ -218,6 +241,14 @@ export function createStackParameters(scope: Construct) {
         [outputFormatParam.logicalId]: {
           default: 'Output Format',
         },
+
+        [emrVersionParam.logicalId]: {
+          default: 'EMR version',
+        },
+
+        [emrApplicationIdleTimeoutMinutesParam.logicalId]: {
+          default: 'EMR serverless idle timeout minutes',
+        },
       },
     },
   };
@@ -242,6 +273,8 @@ export function createStackParameters(scope: Construct) {
       s3PathPluginJarsParam,
       s3PathPluginFilesParam,
       outputFormatParam,
+      emrVersionParam,
+      emrApplicationIdleTimeoutMinutesParam,
     },
   };
 }

--- a/test/data-pipeline/emr-serverless-app.test.ts
+++ b/test/data-pipeline/emr-serverless-app.test.ts
@@ -1,0 +1,344 @@
+
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+//@ts-nocheck
+
+import { CreateApplicationCommand, DeleteApplicationCommand, EMRServerlessClient } from '@aws-sdk/client-emr-serverless';
+import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+
+
+import { CloudFormationCustomResourceEvent } from 'aws-lambda';
+import { mockClient } from 'aws-sdk-client-mock';
+import 'aws-sdk-client-mock-jest';
+
+const s3ClientMock = mockClient(S3Client);
+const emrClientMock = mockClient(EMRServerlessClient);
+
+process.env.AWS_REGION = 'us-east-1';
+process.env.STACK_ID = 'test-stack-001';
+process.env.PIPELINE_S3_BUCKET_NAME = 'bucket1';
+process.env.PIPELINE_S3_PREFIX = 'prefix1';
+
+process.env.TEST_TIME_NOW_STR = new Date().toISOString();
+
+import { handler } from '../../src/data-pipeline/lambda/emr-serverless-app';
+import { getMockContext } from '../common/lambda-context';
+import { basicCloudFormationEvent } from '../common/lambda-events';
+
+beforeEach(() => {
+  s3ClientMock.reset();
+  emrClientMock.reset();
+});
+
+test('should create EMR-serverless application when RequestType is Create', async () => {
+  const event: CloudFormationCustomResourceEvent = {
+    ...basicCloudFormationEvent,
+    RequestType: 'Create',
+    ResourceProperties: {
+      ServiceToken: 'ServiceToken1',
+      projectId: 'test-stack-id',
+      name: 'spark-test-app-name',
+      version: 'emr-6.10.0',
+      secourityGroupId: 'sg-102392x23df',
+      subnetIds: 'subnet-0001,subnet-0002',
+      idleTimeoutMinutes: '3',
+    },
+  };
+  const context = getMockContext();
+
+  emrClientMock.on(CreateApplicationCommand).resolvesOnce({
+    applicationId: 'applicationId-001',
+  });
+
+  s3ClientMock.on(GetObjectCommand).resolves({
+    Body: undefined,
+  } as any);
+
+  const res = await handler(event, context);
+  expect(res).toEqual({
+    Data: {
+      ApplicationId: 'applicationId-001',
+    },
+  });
+  expect(emrClientMock).toHaveReceivedCommandTimes(CreateApplicationCommand, 1);
+  expect(emrClientMock).toHaveReceivedCommandTimes(DeleteApplicationCommand, 0);
+  expect(s3ClientMock).toHaveReceivedCommandTimes(GetObjectCommand, 1);
+  expect(s3ClientMock).toHaveReceivedCommandTimes(PutObjectCommand, 1);
+
+  expect(emrClientMock).toHaveReceivedNthCommandWith(1, CreateApplicationCommand, {
+    architecture: 'X86_64',
+    autoStartConfiguration: {
+      enabled: true,
+    },
+    autoStopConfiguration: {
+      enabled: true,
+      idleTimeoutMinutes: 3,
+    },
+    name: 'spark-test-app-name',
+    networkConfiguration: {
+      securityGroupIds: [
+        'sg-102392x23df',
+      ],
+      subnetIds: [
+        'subnet-0001',
+        'subnet-0002',
+      ],
+    },
+    releaseLabel: 'emr-6.10.0',
+    type: 'SPARK',
+  });
+
+  expect(s3ClientMock).toHaveReceivedNthCommandWith(2, PutObjectCommand,
+    {
+      Body: JSON.stringify(
+        {
+          applicationIds: [
+            {
+              applicationId: 'applicationId-001',
+              createAt: process.env.TEST_TIME_NOW_STR,
+            },
+          ],
+        },
+      ),
+      Bucket: 'bucket1',
+      Key: 'prefix1/test-stack-001/config/emr-serverless-applicationId.json',
+    } );
+
+});
+
+test('should delete EMR-serverless application when RequestType is Delete', async () => {
+  const event: CloudFormationCustomResourceEvent = {
+    ...basicCloudFormationEvent,
+    RequestType: 'Delete',
+    ResourceProperties: {
+      ServiceToken: 'ServiceToken1',
+      projectId: 'test-stack-id',
+      name: 'spark-test-app-name',
+      version: 'emr-6.10.0',
+      secourityGroupId: 'sg-102392x23df',
+      subnetIds: 'subnet-0001,subnet-0002',
+      idleTimeoutMinutes: '6',
+    },
+  };
+  const context = getMockContext();
+
+  const applicationIdsConfig = JSON.stringify({
+    applicationIds: [
+      {
+        applicationId: 'appId-00001',
+        createAt: '2023-08-04T07:32:27.490Z',
+      },
+      {
+        applicationId: 'appId-00002',
+        createAt: '2023-08-04T09:32:27.490Z',
+      },
+    ],
+  });
+
+  s3ClientMock.on(GetObjectCommand).resolves({
+    Body: {
+      transformToString: async () => {
+        return applicationIdsConfig;
+      },
+    },
+  } as any);
+
+  const res = await handler(event, context);
+  expect(res);
+  expect(emrClientMock).toHaveReceivedCommandTimes(CreateApplicationCommand, 0);
+  expect(emrClientMock).toHaveReceivedCommandTimes(DeleteApplicationCommand, 2);
+  expect(s3ClientMock).toHaveReceivedCommandTimes(GetObjectCommand, 1);
+  expect(emrClientMock).toHaveReceivedNthCommandWith(1, DeleteApplicationCommand, {
+    applicationId: 'appId-00001',
+  });
+  expect(emrClientMock).toHaveReceivedNthCommandWith(2, DeleteApplicationCommand, {
+    applicationId: 'appId-00002',
+  });
+
+});
+
+
+test('should create EMR-serverless application when RequestType is Update ', async () => {
+  const event: CloudFormationCustomResourceEvent = {
+    ...basicCloudFormationEvent,
+    RequestType: 'Update',
+    ResourceProperties: {
+      ServiceToken: 'ServiceToken1',
+      projectId: 'test-stack-id',
+      name: 'spark-test-app-name',
+      version: 'emr-6.10.0',
+      secourityGroupId: 'sg-102392x23df',
+      subnetIds: 'subnet-0001,subnet-0002',
+      idleTimeoutMinutes: '6',
+    },
+  };
+  const context = getMockContext();
+
+  emrClientMock.on(CreateApplicationCommand).resolvesOnce({
+    applicationId: 'applicationId-002',
+  });
+
+  const applicationIdsConfig = JSON.stringify({
+    applicationIds: [
+      {
+        applicationId: 'appId-0000',
+        createAt: '2023-08-04T07:32:27.490Z',
+      },
+    ],
+  });
+
+  s3ClientMock.on(GetObjectCommand).resolves({
+    Body: {
+      transformToString: async () => {
+        return applicationIdsConfig;
+      },
+    },
+  } as any);
+
+  const res = await handler(event, context);
+  expect(res).toEqual({
+    Data: {
+      ApplicationId: 'applicationId-002',
+    },
+  });
+  expect(emrClientMock).toHaveReceivedCommandTimes(CreateApplicationCommand, 1);
+  expect(emrClientMock).toHaveReceivedCommandTimes(DeleteApplicationCommand, 1);
+  expect(s3ClientMock).toHaveReceivedCommandTimes(GetObjectCommand, 1);
+  expect(s3ClientMock).toHaveReceivedCommandTimes(PutObjectCommand, 1);
+  expect(s3ClientMock).toHaveReceivedNthCommandWith(2, PutObjectCommand,
+    {
+      Body: JSON.stringify(
+        {
+          applicationIds: [
+            {
+              applicationId: 'appId-0000',
+              createAt: '2023-08-04T07:32:27.490Z',
+            },
+            {
+              applicationId: 'applicationId-002',
+              createAt: process.env.TEST_TIME_NOW_STR,
+            },
+          ],
+        },
+      ),
+      Bucket: 'bucket1',
+      Key: 'prefix1/test-stack-001/config/emr-serverless-applicationId.json',
+    } );
+
+  expect(emrClientMock).toHaveReceivedNthCommandWith(2, DeleteApplicationCommand, {
+    applicationId: 'appId-0000',
+  });
+});
+
+
+test('should handle delete error', async () => {
+  const event: CloudFormationCustomResourceEvent = {
+    ...basicCloudFormationEvent,
+    RequestType: 'Delete',
+    ResourceProperties: {
+      ServiceToken: 'ServiceToken1',
+      projectId: 'test-stack-id',
+      name: 'spark-test-app-name',
+      version: 'emr-6.10.0',
+      secourityGroupId: 'sg-102392x23df',
+      subnetIds: 'subnet-0001,subnet-0002',
+      idleTimeoutMinutes: '6',
+    },
+  };
+  const context = getMockContext();
+
+  const applicationIdsConfig = JSON.stringify({
+    applicationIds: [
+      {
+        applicationId: 'appId-00001',
+        createAt: '2023-08-04T07:32:27.490Z',
+      },
+      {
+        applicationId: 'appId-00002',
+        createAt: '2023-08-04T09:32:27.490Z',
+      },
+    ],
+  });
+
+  s3ClientMock.on(GetObjectCommand).resolves({
+    Body: {
+      transformToString: async () => {
+        return applicationIdsConfig;
+      },
+    },
+  } as any);
+
+  emrClientMock.on(DeleteApplicationCommand).resolvesOnce({}).rejectsOnce({ errorMessage: 'delete error' });
+
+  const res = await handler(event, context);
+  expect(res).toBeUndefined();
+
+  expect(emrClientMock).toHaveReceivedCommandTimes(DeleteApplicationCommand, 2);
+
+  expect(emrClientMock).toHaveReceivedNthCommandWith(1, DeleteApplicationCommand, {
+    applicationId: 'appId-00001',
+  });
+  expect(emrClientMock).toHaveReceivedNthCommandWith(2, DeleteApplicationCommand, {
+    applicationId: 'appId-00002',
+  });
+
+});
+
+
+test('should handle create error', async () => {
+  const event: CloudFormationCustomResourceEvent = {
+    ...basicCloudFormationEvent,
+    RequestType: 'Create',
+    ResourceProperties: {
+      ServiceToken: 'ServiceToken1',
+      projectId: 'test-stack-id',
+      name: 'spark-test-app-name',
+      version: 'emr-6.10.0',
+      secourityGroupId: 'sg-102392x23df',
+      subnetIds: 'subnet-0001,subnet-0002',
+      idleTimeoutMinutes: '6',
+    },
+  };
+  const context = getMockContext();
+
+  const applicationIdsConfig = JSON.stringify({
+    applicationIds: [
+      {
+        applicationId: 'appId-00001',
+        createAt: '2023-08-04T07:32:27.490Z',
+      },
+      {
+        applicationId: 'appId-00002',
+        createAt: '2023-08-04T09:32:27.490Z',
+      },
+    ],
+  });
+
+  s3ClientMock.on(GetObjectCommand).resolves({
+    Body: {
+      transformToString: async () => {
+        return applicationIdsConfig;
+      },
+    },
+  } as any);
+
+  emrClientMock.on(CreateApplicationCommand).rejectsOnce({ errorMessage: 'create error' });
+
+  try {
+    await handler(event, context);
+  } catch (err) {
+    expect(err.errorMessage).toEqual('create error');
+  }
+});
+


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary


(describe what this merge request does)

## Implementation highlights
1. create new EMR-serverless application when update/upgrade via custom resource
2. try to delete old applications if they can be deleted
3. add two parameters:
        - EmrVersion, default value: `emr-6.11.0`
        - EmrApplicationIdleTimeoutMinutes, default value: `5`

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [x] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module