### PR TITLE
fix: set the warm pool size

### DIFF
--- a/src/ingestion-server/server/private/ecs-cluster.ts
+++ b/src/ingestion-server/server/private/ecs-cluster.ts
@@ -99,18 +99,19 @@ export function createECSClusterAndService(
     ],
   });
 
-
   if (Token.isUnresolved(ecsAsgSetting.warmPoolSize)) {
     // warmPoolSize is passed by CfnParameter
     new CfnWarmPool(scope, 'warmPool', {
       autoScalingGroupName: autoScalingGroup.autoScalingGroupName,
       minSize: ecsAsgSetting.warmPoolSize,
+      maxGroupPreparedCapacity: ecsAsgSetting.warmPoolSize,
     });
   } else {
     // warmPoolSize is passed by normal variable
     if (ecsAsgSetting.warmPoolSize && ecsAsgSetting.warmPoolSize > 0) {
       autoScalingGroup.addWarmPool({
         minSize: ecsAsgSetting.warmPoolSize,
+        maxGroupPreparedCapacity: ecsAsgSetting.warmPoolSize,
       });
     }
   }

--- a/test/ingestion-server/server/ingestion-server.test.ts
+++ b/test/ingestion-server/server/ingestion-server.test.ts
@@ -63,6 +63,7 @@ test('WarmPool is created as expected', () => {
   const template = Template.fromStack(stack);
   template.hasResourceProperties('AWS::AutoScaling::WarmPool', {
     MinSize: 1,
+    MaxGroupPreparedCapacity: 1,
   });
 });
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Make the warm pool size can be set from value of "WarmPoolSize" of cloudformation parameter

## Implementation highlights

1. Set the "MaxGroupPreparedCapacity" value as "WarmPoolSize" value. According to [document](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-autoscaling-warmpool.html#cfn-autoscaling-warmpool-maxgrouppreparedcapacity)    
      `The size of the warm pool is dynamic. Only when MaxGroupPreparedCapacity and MinSize are set to the same value does the warm pool have an absolute size.`
2. Tested cases as below:

| Asg-MinSize   | Asg-MaxSize    | WarmPoolSize           |  real-warm-pool-size |
|---------|---------|---------|---------|
2                      |    4                     |      0                            |     0 |
2                      |    4                     |      1                             |      1  |
2                      |    4                     |      6                             |      6 |

3. Currently, the "WarmPoolSize" default value in ingestion server is already 0.

## Test checklist

- [x] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [x] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [x] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module