### PR TITLE
fix: error in node.js18 when using Architecture.X86_64

### DIFF
--- a/src/data-pipeline/lambda/emr-serverless-app/index.ts
+++ b/src/data-pipeline/lambda/emr-serverless-app/index.ts
@@ -12,7 +12,7 @@
  */
 
 
-import { EMRServerlessClient, CreateApplicationCommand, Architecture, CreateApplicationCommandInput, DeleteApplicationCommand } from '@aws-sdk/client-emr-serverless';
+import { EMRServerlessClient, CreateApplicationCommand, CreateApplicationCommandInput, DeleteApplicationCommand } from '@aws-sdk/client-emr-serverless';
 import { CloudFormationCustomResourceEvent, Context } from 'aws-lambda';
 import { logger } from '../../../common/powertools';
 import { putStringToS3, readS3ObjectAsJson } from '../../../common/s3';
@@ -77,7 +77,7 @@ async function createEMRServerlessApp(props: ResourcePropertiesType): Promise<st
     name: props.name,
     releaseLabel: props.version,
     type: 'SPARK',
-    architecture: Architecture.X86_64,
+    architecture: 'X86_64',
     networkConfiguration: {
       subnetIds: props.subnetIds.split(','),
       securityGroupIds: [props.secourityGroupId],


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

The installation gets error:
"Cannot read properties of undefined(reading X86_64)" in `node.js18`.  

No problem when set lambda runtime to `node.js16` in CDK. 
  
 
(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [x] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module