### PR TITLE
fix: the run-unit-tests script fails with tests in codebuild

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,8 +16,8 @@
 - [ ] add new test cases
 - [ ] all code changes are covered by unit tests
 - [ ] end-to-end tests
-  - [ ] deploy control plane with CloudFront + S3 + API gateway
-  - [ ] deploy control plane within VPC
+  - [ ] deploy web console with CloudFront + S3 + API gateway
+  - [ ] deploy web console within VPC
   - [ ] deploy ingestion server
     - [ ] with MSK sink
     - [ ] with KDS sink
@@ -34,3 +34,7 @@
 - [ ] add parameters without default value in stack
 - [ ] introduce new service permission in stack
 - [ ] introduce new top level stack module
+
+## Miscellaneous
+
+- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend

--- a/deployment/run-unit-tests.sh
+++ b/deployment/run-unit-tests.sh
@@ -13,7 +13,8 @@ cp src/common/sdk-client-config.ts src/control-plane/backend/lambda/api/common/s
 cp src/common/solution-info.ts src/control-plane/backend/lambda/api/common/solution-info-ln.ts
 rm src/control-plane/backend/lambda/api/middle-ware/authorizer.ts
 cp src/control-plane/auth/authorizer.ts src/control-plane/backend/lambda/api/middle-ware/authorizer.ts
-
+rm src/control-plane/backend/lambda/api/service/quicksight/dashboard-ln.ts
+cp src/reporting/private/dashboard.ts src/control-plane/backend/lambda/api/service/quicksight/dashboard-ln.ts
 
 echo "yarn install"
 yarn install --check-files --frozen-lockfile


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] test the script in local env
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module