### PR TITLE
fix: grant api function access to read and write metadata table

### DIFF
--- a/src/alb-control-plane-stack.ts
+++ b/src/alb-control-plane-stack.ts
@@ -31,6 +31,7 @@ import { Construct } from 'constructs';
 import {
   addCfnNagForLogRetention,
   addCfnNagForCustomResourceProvider,
+  addCfnNagToStack,
 } from './common/cfn-nag';
 import { OUTPUT_CONTROL_PLANE_URL, OUTPUT_CONTROL_PLANE_BUCKET } from './common/constant';
 import { Parameters, SubnetParameterType } from './common/parameters';
@@ -292,6 +293,21 @@ export class ApplicationLoadBalancerControlPlaneStack extends Stack {
 }
 
 function addCfnNag(stack: Stack) {
+  const cfnNagList = [
+    {
+      paths_endswith: [
+        'ClickStreamApi/ClickStreamApiFunctionRole/DefaultPolicy/Resource',
+      ],
+      rules_to_suppress: [
+        {
+          id: 'W76',
+          reason:
+          'This policy needs to be able to call other AWS service by design',
+        },
+      ],
+    },
+  ];
+  addCfnNagToStack(stack, cfnNagList);
   addCfnNagForLogRetention(stack);
   addCfnNagForCustomResourceProvider(stack, 'CDK built-in provider for DicInitCustomResourceProvider', 'DicInitCustomResourceProvider', undefined);
   NagSuppressions.addStackSuppressions(stack, [

--- a/src/control-plane/backend/click-stream-api.ts
+++ b/src/control-plane/backend/click-stream-api.ts
@@ -374,6 +374,7 @@ export class ClickStreamApiConstruct extends Construct {
 
     dictionaryTable.grantReadWriteData(this.clickStreamApiFunction);
     clickStreamTable.grantReadWriteData(this.clickStreamApiFunction);
+    analyticsMetadataTable.grantReadWriteData(this.clickStreamApiFunction);
     if (props.authProps?.authorizerTable) {
       props.authProps?.authorizerTable.grantReadWriteData(this.clickStreamApiFunction);
     }

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -484,6 +484,45 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
               },
             ],
           },
+          {
+            Action: [
+              'dynamodb:BatchGetItem',
+              'dynamodb:GetRecords',
+              'dynamodb:GetShardIterator',
+              'dynamodb:Query',
+              'dynamodb:GetItem',
+              'dynamodb:Scan',
+              'dynamodb:ConditionCheckItem',
+              'dynamodb:BatchWriteItem',
+              'dynamodb:PutItem',
+              'dynamodb:UpdateItem',
+              'dynamodb:DeleteItem',
+              'dynamodb:DescribeTable',
+            ],
+            Effect: 'Allow',
+            Resource: [
+              {
+                'Fn::GetAtt': [
+                  'testClickStreamALBApiClickstreamAnalyticsMetadataA20F6663',
+                  'Arn',
+                ],
+              },
+              {
+                'Fn::Join': [
+                  '',
+                  [
+                    {
+                      'Fn::GetAtt': [
+                        'testClickStreamALBApiClickstreamAnalyticsMetadataA20F6663',
+                        'Arn',
+                      ],
+                    },
+                    '/index/*',
+                  ],
+                ],
+              },
+            ],
+          },
         ],
         Version: '2012-10-17',
       },


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy control plane with CloudFront + S3 + API gateway
  - [ ] deploy control plane within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module