### PR TITLE
chore: bump minimum node to 18.17.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.16.1
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: Configure AWS Credentials

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.16.1
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -14,7 +14,7 @@
 const { awscdk, gitlab, javascript, typescript } = require('projen');
 const version = '1.0.0';
 const cdkVersion = '2.81.0';
-const minNodeVersion = '18.16.1';
+const minNodeVersion = '18.17.0';
 
 const cdkAlphaModules = [
   '@aws-cdk/aws-glue-alpha',

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Follow the [implementation guide][doc-deployment] to deploy the solution using A
 
 - Make sure you have an AWS account
 - Configure [credential of aws cli][configure-aws-cli]
-- Install Node.js LTS version 18.16.1 or later
+- Install Node.js LTS version 18.17.0 or later
 - Install Docker Engine
 - Install the dependencies of the solution by executing the command `yarn install --check-files && npx projen`
 - Initialize the CDK toolkit stack into AWS environment (only for deploying via [AWS CDK][aws-cdk] for the first time), and run `npx cdk bootstrap`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,6 +13,8 @@ phases:
   install:
     runtime-versions:
       nodejs: 18.x
+    commands:
+      - n 18.17.1
   pre_build:
     commands:
       - |-

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "uuid": "^9.0.0"
   },
   "engines": {
-    "node": ">= 18.16.1"
+    "node": ">= 18.17.0"
   },
   "license": "Apache-2.0",
   "version": "1.0.0",

--- a/src/control-plane/backend/lambda/api/package.json
+++ b/src/control-plane/backend/lambda/api/package.json
@@ -83,7 +83,7 @@
     "uuid": "^9.0.0"
   },
   "engines": {
-    "node": ">= 18.16.1"
+    "node": ">= 18.17.0"
   },
   "main": "index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend