### PR TITLE
fix: keep build assets when building package

### DIFF
--- a/deployment/build-open-source-dist.sh
+++ b/deployment/build-open-source-dist.sh
@@ -45,23 +45,11 @@ echo "mkdir -p $dist_dir"
 mkdir -p $dist_dir
 
 echo "------------------------------------------------------------------------------"
-echo "[Packing] Clean up the built-in assets for open-source distributable"
-echo "------------------------------------------------------------------------------"
-echo $source_dir
-
-rm -rf  $source_dir/deployment/global-s3-assets
-rm -rf  $source_dir/deployment/regional-s3-assets
-rm -rf  $source_dir/cdk.out
-rm -rf  $source_dir/codescan*.sh
-rm -rf  $source_dir/test-reports
-
-echo "------------------------------------------------------------------------------"
 echo "[Packing] all source files"
 echo "------------------------------------------------------------------------------"
 
-echo "rsync -av --exclude='deployment' $source_dir $dist_dir"
-rsync -av --exclude='deployment/open-source' --exclude='.git' \
---exclude='node_modules' --exclude='coverage' $source_dir $dist_dir
+echo "rsync -av --exclude-from='../.gitignore' $source_dir $dist_dir"
+rsync -av --exclude-from='../.gitignore' $source_dir $dist_dir
 
 echo "------------------------------------------------------------------------------"
 echo "[Packing] Create GitHub (open-source) zip file"


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] tested on test pipeline
- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend