### PR TITLE
chore: exclude the false positive rule when instantiating CDK objects

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -19,6 +19,11 @@ src/data-pipeline/spark-etl/*.gradle,\
 src/**/test/**/*,\
 *-ln.ts
 
+sonar.issue.ignore.multicriteria=e1
+# exclude False Positive findings for instantiating CDK objects only
+sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S1848
+sonar.issue.ignore.multicriteria.e1.resourceKey=src/**/*.ts
+
 # required Java compiled bytecode files
 sonar.java.binaries=src/data-pipeline/spark-etl,src/data-pipeline/spark-etl/build/classes
 # Code coverage Specific Properties


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] tested on test pipeline
- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend