### PR TITLE
feat: Dashboards management

### DIFF
--- a/.viperlightignore
+++ b/.viperlightignore
@@ -90,15 +90,15 @@ frontend/src/ts/constant-ln.ts:80
 frontend/src/ts/constant-ln.ts:83
 frontend/src/ts/constant-ln.ts:86
 frontend/src/ts/constant-ln.ts:89
-src/control-plane/backend/lambda/api/test/api/env-bucket-policy.test.ts:28
-src/control-plane/backend/lambda/api/test/api/env-bucket-policy.test.ts:29
-src/control-plane/backend/lambda/api/test/api/env-bucket-policy.test.ts:30
-src/control-plane/backend/lambda/api/test/api/env-bucket-policy.test.ts:31
-src/control-plane/backend/lambda/api/test/api/env-bucket-policy.test.ts:32
-src/control-plane/backend/lambda/api/test/api/env-bucket-policy.test.ts:33
-src/control-plane/backend/lambda/api/test/api/env-bucket-policy.test.ts:34
-src/control-plane/backend/lambda/api/test/api/env-bucket-policy.test.ts:35
-src/control-plane/backend/lambda/api/test/api/env-bucket-policy.test.ts:36
+src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:54
+src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:55
+src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:56
+src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:57
+src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:58
+src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:59
+src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:60
+src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:61
+src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:62
 src/control-plane/backend/lambda/api/common/constants.ts:65
 
 [node-yarnoutdated]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -83,7 +83,8 @@
     "webpack": "^5.85.0",
     "webpack-dev-server": "^4.15.0",
     "webpack-manifest-plugin": "^4.0.2",
-    "workbox-webpack-plugin": "^6.4.1"
+    "workbox-webpack-plugin": "^6.4.1",
+    "uuid": "^9.0.0"
   },
   "scripts": {
     "start": "node scripts/start.js",
@@ -113,6 +114,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.191",
+    "@types/uuid": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^5.42.0",
     "esbuild": "^0.17.12",
     "esbuild-plugin-inline-image": "^0.0.9",

--- a/frontend/public/locales/en/analytics.json
+++ b/frontend/public/locales/en/analytics.json
@@ -8,7 +8,9 @@
     "createInputNamePlaceholder": "e.g. my-dashboard",
     "createDesc": "Dashboard description - optional",
     "createDescPlaceholder": "e.g. description of dashboard",
-    "createSheets": "Dashboard sheets - optional"
+    "createSheets": "Dashboard sheets - optional",
+    "deleteTip1": "Are you sure you want to delete the dashboard ",
+    "deleteTip2": " delete dashboard will delete all data in QuickSight."
   },
   "list": {
     "loading": "Loading dashboards.",

--- a/frontend/public/locales/en/analytics.json
+++ b/frontend/public/locales/en/analytics.json
@@ -2,7 +2,13 @@
   "analytics": "Analytics",
   "dashboard": {
     "title": "Dashboards",
-    "description": "This page lists all the dashboards."
+    "description": "This page lists all the dashboards.",
+    "createTitle": "Create Dashboard",
+    "createInputName": "Please input a name for your dashboard",
+    "createInputNamePlaceholder": "e.g. my-dashboard",
+    "createDesc": "Dashboard description - optional",
+    "createDescPlaceholder": "e.g. description of dashboard",
+    "createSheets": "Dashboard sheets - optional"
   },
   "list": {
     "loading": "Loading dashboards.",
@@ -123,7 +129,9 @@
   },
   "valid": {
     "projectSelectError": "Must select a project",
-    "appSelectError": "Must select an application"
+    "appSelectError": "Must select an application",
+    "dashboardNameEmptyError": "Please input dashboard name.",
+    "dashboardSheetTooMuchError": "Dashboard sheet can't be more than 10."
   },
   "emptyData": "No Data"
 }

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -164,7 +164,8 @@
     "viewAlarms": "View Alarms",
     "refreshMetadata": "Refresh Metadata",
     "clearFilters": "Clear filters",
-    "preview": "Preview"
+    "preview": "Preview",
+    "createDashboard": "Create Dashboard"
   },
   "item": "item",
   "items": "items",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -165,7 +165,8 @@
     "refreshMetadata": "Refresh Metadata",
     "clearFilters": "Clear filters",
     "preview": "Preview",
-    "createDashboard": "Create Dashboard"
+    "createDashboard": "Create Dashboard",
+    "deleteDashboard": "Delete Dashboard"
   },
   "item": "item",
   "items": "items",

--- a/frontend/public/locales/zh/analytics.json
+++ b/frontend/public/locales/zh/analytics.json
@@ -2,7 +2,15 @@
   "analytics": "分析",
   "dashboard": {
     "title": "看板",
-    "description": "此页面列出所有看板。"
+    "description": "此页面列出所有看板。",
+    "createTitle": "创建看板",
+    "createInputName": "请输入看板名称",
+    "createInputNamePlaceholder": "例如，my-dashboard",
+    "createDesc": "看板描述-可选",
+    "createDescPlaceholder": "例如，description of dashboard",
+    "createSheets": "看板Sheet-可选",
+    "deleteTip1": "您确定要删除该看板吗 ",
+    "deleteTip2": " 删除看板将删除 QuickSight 中的所有数据。"
   },
   "list": {
     "loading": "正在加载看板。",

--- a/frontend/public/locales/zh/analytics.json
+++ b/frontend/public/locales/zh/analytics.json
@@ -131,6 +131,8 @@
   },
   "valid": {
     "projectSelectError": "必须选择一个项目",
-    "appSelectError": "必须选择一个应用程序"
+    "appSelectError": "必须选择一个应用程序",
+    "dashboardNameEmptyError": "请输入看板名称",
+    "dashboardSheetTooMuchError": "工作表不能超过10个"
   }
 }

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -163,7 +163,8 @@
     "viewAlarms": "查看告警",
     "refreshMetadata": "刷新元数据",
     "clearFilters": "清理筛选",
-    "preview": "预览"
+    "preview": "预览",
+    "createDashboard": "创建看板"
   },
   "item": "项目",
   "items": "项目",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -164,7 +164,8 @@
     "refreshMetadata": "刷新元数据",
     "clearFilters": "清理筛选",
     "preview": "预览",
-    "createDashboard": "创建看板"
+    "createDashboard": "创建看板",
+    "deleteDashboard": "删除看板"
   },
   "item": "项目",
   "items": "项目",

--- a/frontend/src/apis/analytics.ts
+++ b/frontend/src/apis/analytics.ts
@@ -37,6 +37,22 @@ export const createAnalyticsDashboard = async (
   return result;
 };
 
+export const deleteAnalyticsDashboard = async (dashboardId: string) => {
+  const result: any = await apiRequest(
+    'delete',
+    `/project/dashboard/${dashboardId}`
+  );
+  return result;
+};
+
+export const getAnalyticsDashboard = async (dashboardId: string) => {
+  const result: any = await apiRequest(
+    'get',
+    `/project/dashboard/${dashboardId}`
+  );
+  return result;
+};
+
 export const getMetadataEventsList = async (params: {
   projectId: string;
   appId: string;

--- a/frontend/src/apis/analytics.ts
+++ b/frontend/src/apis/analytics.ts
@@ -14,34 +14,26 @@
 import { apiRequest } from 'ts/request';
 
 export const getAnalyticsDashboardList = async (params: {
+  projectId: string;
   pageNumber: number;
   pageSize: number;
 }) => {
   await new Promise((r) => setTimeout(r, 3000));
-  const result: any = await new Promise((resolve, reject) => {
-    resolve({
-      success: true,
-      message: 'OK',
-      data: {
-        totalCount: 2,
-        items: [
-          {
-            id: 'asdsdsadsad',
-            name: 'Dashboard Name 1',
-            description: 'Dashboard description 1',
-            createAt: 1690251290,
-          },
-          {
-            id: 'asdsdsadsadasd',
-            name: 'Dashboard Name 2',
-            description: 'Dashboard description 2',
-            createAt: 1690251290,
-          },
-        ],
-      },
-      error: '',
-    });
-  });
+  const result: any = await apiRequest(
+    'get',
+    `/project/${params.projectId}/dashboards?pageNumber=${params.pageNumber}&pageSize=${params.pageSize}`
+  );
+  return result;
+};
+
+export const createAnalyticsDashboard = async (
+  dashboard: IAnalyticsDashboard
+) => {
+  const result: any = await apiRequest(
+    'post',
+    `/project/${dashboard.projectId}/dashboard`,
+    dashboard
+  );
   return result;
 };
 

--- a/frontend/src/pages/analytics/comps/DashboardHeader.tsx
+++ b/frontend/src/pages/analytics/comps/DashboardHeader.tsx
@@ -10,19 +10,20 @@
  *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
  *  and limitations under the License.
  */
-import { Header } from '@cloudscape-design/components';
+import { Button, Header, SpaceBetween } from '@cloudscape-design/components';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface DashboardHeaderProps {
   totalNum: number;
+  onClickCreate: () => void;
 }
 
 const DashboardHeader: React.FC<DashboardHeaderProps> = (
   props: DashboardHeaderProps
 ) => {
   const { t } = useTranslation();
-  const { totalNum } = props;
+  const { totalNum, onClickCreate } = props;
 
   return (
     <>
@@ -30,6 +31,17 @@ const DashboardHeader: React.FC<DashboardHeaderProps> = (
         variant="h1"
         counter={`(${totalNum})`}
         description={t('analytics:dashboard.description')}
+        actions={
+          <SpaceBetween size="xs" direction="horizontal">
+            <Button
+              data-testid="header-btn-create"
+              variant="primary"
+              onClick={onClickCreate}
+            >
+              {t('common:button.createDashboard')}
+            </Button>
+          </SpaceBetween>
+        }
       >
         {t('analytics:dashboard.title')}
       </Header>

--- a/frontend/src/pages/analytics/dashboard/AnalyticsDashboard.tsx
+++ b/frontend/src/pages/analytics/dashboard/AnalyticsDashboard.tsx
@@ -35,6 +35,7 @@ const AnalyticsDashboardCard: React.FC<any> = () => {
   const [loadingData, setLoadingData] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalCount, setTotalCount] = useState(0);
+  const [selectedItems, setSelectedItems] = useState<IAnalyticsDashboard[]>([]);
   const [createDashboardVisible, setCreateDashboardVisible] = useState(false);
   const [analyticsDashboardList, setAnalyticsDashboardList] = useState<
     IAnalyticsDashboard[]
@@ -102,11 +103,16 @@ const AnalyticsDashboardCard: React.FC<any> = () => {
     <div className="pb-30">
       <Cards
         loading={loadingData}
+        selectedItems={selectedItems}
+        onSelectionChange={(event) => {
+          setSelectedItems(event.detail.selectedItems);
+        }}
         stickyHeader={false}
         cardDefinition={CARD_DEFINITIONS}
         loadingText={t('analytics:list.loading') ?? ''}
         items={analyticsDashboardList}
         variant="full-page"
+        selectionType="single"
         empty={
           <Box textAlign="center" color="inherit">
             <Box padding={{ bottom: 's' }} variant="p" color="inherit">
@@ -117,8 +123,16 @@ const AnalyticsDashboardCard: React.FC<any> = () => {
         header={
           <DashboardHeader
             totalNum={totalCount}
+            dashboard={selectedItems?.[0]}
+            setSelectItemEmpty={() => {
+              setSelectedItems([]);
+            }}
             onClickCreate={() => {
               setCreateDashboardVisible(true);
+            }}
+            refreshPage={() => {
+              setSelectedItems([]);
+              listAnalyticsDashboards();
             }}
           />
         }
@@ -137,6 +151,10 @@ const AnalyticsDashboardCard: React.FC<any> = () => {
         appId={appId ?? ''}
         openModel={createDashboardVisible}
         closeModel={() => setCreateDashboardVisible(false)}
+        refreshPage={() => {
+          setSelectedItems([]);
+          listAnalyticsDashboards();
+        }}
       />
     </div>
   );

--- a/frontend/src/pages/analytics/dashboard/AnalyticsDashboard.tsx
+++ b/frontend/src/pages/analytics/dashboard/AnalyticsDashboard.tsx
@@ -25,6 +25,7 @@ import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { TIME_FORMAT } from 'ts/const';
+import CreateDashboard from './create/CreateDashboard';
 import DashboardHeader from '../comps/DashboardHeader';
 
 const AnalyticsDashboardCard: React.FC<any> = () => {
@@ -34,6 +35,7 @@ const AnalyticsDashboardCard: React.FC<any> = () => {
   const [loadingData, setLoadingData] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalCount, setTotalCount] = useState(0);
+  const [createDashboardVisible, setCreateDashboardVisible] = useState(false);
   const [analyticsDashboardList, setAnalyticsDashboardList] = useState<
     IAnalyticsDashboard[]
   >([]);
@@ -76,6 +78,7 @@ const AnalyticsDashboardCard: React.FC<any> = () => {
         data,
       }: ApiResponse<ResponseTableData<IAnalyticsDashboard>> =
         await getAnalyticsDashboardList({
+          projectId: projectId ?? '',
           pageNumber: currentPage,
           pageSize: pageSize,
         });
@@ -111,7 +114,14 @@ const AnalyticsDashboardCard: React.FC<any> = () => {
             </Box>
           </Box>
         }
-        header={<DashboardHeader totalNum={totalCount} />}
+        header={
+          <DashboardHeader
+            totalNum={totalCount}
+            onClickCreate={() => {
+              setCreateDashboardVisible(true);
+            }}
+          />
+        }
         pagination={
           <Pagination
             currentPageIndex={currentPage}
@@ -121,6 +131,12 @@ const AnalyticsDashboardCard: React.FC<any> = () => {
             }}
           />
         }
+      />
+      <CreateDashboard
+        projectId={projectId ?? ''}
+        appId={appId ?? ''}
+        openModel={createDashboardVisible}
+        closeModel={() => setCreateDashboardVisible(false)}
       />
     </div>
   );

--- a/frontend/src/pages/analytics/dashboard/create/CreateDashboard.tsx
+++ b/frontend/src/pages/analytics/dashboard/create/CreateDashboard.tsx
@@ -1,0 +1,211 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import {
+  Box,
+  Button,
+  FormField,
+  Input,
+  Modal,
+  SpaceBetween,
+  Textarea,
+  TokenGroup,
+} from '@cloudscape-design/components';
+import { createAnalyticsDashboard } from 'apis/analytics';
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { MAX_USER_INPUT_LENGTH } from 'ts/const';
+import { XSS_PATTERN } from 'ts/constant-ln';
+
+interface CreateDashboardProps {
+  projectId: string;
+  appId: string;
+  openModel: boolean;
+  closeModel: () => void;
+}
+
+const CreateDashboard: React.FC<CreateDashboardProps> = (
+  props: CreateDashboardProps
+) => {
+  const { t } = useTranslation();
+  const { projectId, appId, openModel, closeModel } = props;
+  const [loadingCreate, setLoadingCreate] = useState(false);
+  const [visible, setVisible] = useState(openModel);
+  const [curDashboard, setCurDashboard] = useState<IAnalyticsDashboard>({
+    name: '',
+    description: '',
+  } as IAnalyticsDashboard);
+
+  const [dashboardNameRequiredError, setDashboardNameRequiredError] =
+    useState(false);
+  const [dashboardSheetTooMuchError, setDashboardSheetTooMuchError] =
+    useState(false);
+  const [sheetName, setSheetName] = React.useState('');
+  const [sheetNames, setSheetNames] = React.useState([{ label: 'Sheet 1' }]);
+
+  const navigate = useNavigate();
+  useEffect(() => {
+    setDashboardNameRequiredError(false);
+    setVisible(openModel);
+  }, [openModel]);
+
+  const confirmCreateDashboard = async () => {
+    setLoadingCreate(true);
+    try {
+      const params = {
+        ...curDashboard,
+        projectId: projectId,
+      } as IAnalyticsDashboard;
+      const { success, data }: ApiResponse<ResponseCreate> =
+        await createAnalyticsDashboard(params);
+      if (success && data.id) {
+        navigate(`analytics/${projectId}/app/${appId}/dashboards`);
+      }
+      setLoadingCreate(false);
+    } catch (error) {
+      setLoadingCreate(false);
+    }
+  };
+
+  return (
+    <div>
+      <Modal
+        onDismiss={() => {
+          closeModel();
+        }}
+        visible={visible}
+        closeAriaLabel="Close modal"
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button
+                variant="link"
+                onClick={() => {
+                  closeModel();
+                }}
+              >
+                {t('button.cancel')}
+              </Button>
+              <Button
+                loading={loadingCreate}
+                variant="primary"
+                onClick={() => {
+                  if (!curDashboard.name.trim()) {
+                    setDashboardNameRequiredError(true);
+                    return false;
+                  }
+                  confirmCreateDashboard();
+                }}
+              >
+                {t('button.create')}
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+        header={t('analytics:dashboard.createTitle')}
+      >
+        <>
+          <FormField
+            label={t('analytics:dashboard.createInputName')}
+            errorText={
+              dashboardNameRequiredError
+                ? t('analytics:valid.dashboardNameEmptyError')
+                : ''
+            }
+          >
+            <SpaceBetween direction="vertical" size="s">
+              <Input
+                placeholder={
+                  t('analytics:dashboard.createInputNamePlaceholder') || ''
+                }
+                value={curDashboard.name ?? ''}
+                onChange={(e) => {
+                  setDashboardNameRequiredError(false);
+                  setCurDashboard((prev) => {
+                    return {
+                      ...prev,
+                      name: e.detail.value,
+                    };
+                  });
+                }}
+              />
+            </SpaceBetween>
+          </FormField>
+          <div className="mt-10">
+            <FormField label={t('analytics:dashboard.createDesc')}>
+              <Textarea
+                placeholder={
+                  t('analytics:dashboard.createDescPlaceholder') || ''
+                }
+                rows={3}
+                value={curDashboard.description}
+                onChange={(e) => {
+                  if (
+                    new RegExp(XSS_PATTERN).test(e.detail.value) ||
+                    e.detail.value.length > MAX_USER_INPUT_LENGTH
+                  ) {
+                    return false;
+                  }
+                  setCurDashboard((prev) => {
+                    return { ...prev, description: e.detail.value };
+                  });
+                }}
+              />
+            </FormField>
+          </div>
+
+          <FormField
+            label={t('analytics:dashboard.createSheets')}
+            errorText={
+              dashboardSheetTooMuchError
+                ? t('analytics:valid.dashboardSheetTooMuchError')
+                : ''
+            }
+            secondaryControl={
+              <Button
+                iconName="add-plus"
+                onClick={() => {
+                  if (!sheetName.trim()) {
+                    return false;
+                  }
+                  if (sheetNames.length >= 10) {
+                    setDashboardSheetTooMuchError(true);
+                    return false;
+                  }
+                  setSheetNames(sheetNames.concat({ label: sheetName }));
+                }}
+              />
+            }
+          >
+            <Input
+              onChange={({ detail }) => setSheetName(detail.value)}
+              value={sheetName}
+            />
+          </FormField>
+          <TokenGroup
+            onDismiss={({ detail: { itemIndex } }) => {
+              setSheetNames([
+                ...sheetNames.slice(0, itemIndex),
+                ...sheetNames.slice(itemIndex + 1),
+              ]);
+            }}
+            items={sheetNames}
+          />
+        </>
+      </Modal>
+    </div>
+  );
+};
+
+export default CreateDashboard;

--- a/frontend/src/pages/analytics/dashboard/create/CreateDashboard.tsx
+++ b/frontend/src/pages/analytics/dashboard/create/CreateDashboard.tsx
@@ -66,6 +66,9 @@ const CreateDashboard: React.FC<CreateDashboardProps> = (
       const params = {
         ...curDashboard,
         projectId: projectId,
+        appId: appId,
+        sheets: sheetNames.map((item) => item.label),
+        
       } as IAnalyticsDashboard;
       const { success, data }: ApiResponse<ResponseCreate> =
         await createAnalyticsDashboard(params);

--- a/frontend/src/pages/analytics/dashboard/create/CreateDashboard.tsx
+++ b/frontend/src/pages/analytics/dashboard/create/CreateDashboard.tsx
@@ -35,6 +35,7 @@ import {
   XSS_PATTERN,
 } from 'ts/constant-ln';
 import { getValueFromStackOutputs } from 'ts/utils';
+import { v4 as uuidv4 } from 'uuid';
 
 interface CreateDashboardProps {
   projectId: string;
@@ -85,7 +86,9 @@ const CreateDashboard: React.FC<CreateDashboardProps> = (
         defaultDataSourceArn:
           reportingOutputs.get(OUTPUT_REPORTING_QUICKSIGHT_DATA_SOURCE_ARN) ||
           '',
-        sheetNames: sheetNames.map((item) => item.label),
+        sheets: sheetNames.map((item) => {
+          return { id: uuidv4().replace(/-/g, ''), name: item.label };
+        }),
       };
       const { success, data }: ApiResponse<ResponseCreate> =
         await createAnalyticsDashboard(params);
@@ -94,7 +97,7 @@ const CreateDashboard: React.FC<CreateDashboardProps> = (
           ...curDashboard,
           name: '',
           description: '',
-          sheetNames: [],
+          sheets: [],
         } as IAnalyticsDashboard);
         closeModel();
         refreshPage();
@@ -133,7 +136,6 @@ const CreateDashboard: React.FC<CreateDashboardProps> = (
           closeModel();
         }}
         visible={visible}
-        closeAriaLabel="Close modal"
         footer={
           <Box float="right">
             <SpaceBetween direction="horizontal" size="xs">
@@ -247,8 +249,8 @@ const CreateDashboard: React.FC<CreateDashboardProps> = (
             <TokenGroup
               onDismiss={({ detail: { itemIndex } }) => {
                 setSheetNames([
-                  ...sheetNames.slice(0, itemIndex),
-                  ...sheetNames.slice(itemIndex + 1),
+                  ...sheetNames.slice(0, 0),
+                  ...sheetNames.slice(0 + 1),
                 ]);
               }}
               items={sheetNames}

--- a/frontend/src/pages/analytics/dashboard/detail/AnalyticsDashboardDetail.tsx
+++ b/frontend/src/pages/analytics/dashboard/detail/AnalyticsDashboardDetail.tsx
@@ -13,20 +13,22 @@
 
 import { AppLayout } from '@cloudscape-design/components';
 import { createEmbeddingContext } from 'amazon-quicksight-embedding-sdk';
-import { fetchEmbeddingUrl } from 'apis/analytics';
+import { fetchEmbeddingUrl, getAnalyticsDashboard } from 'apis/analytics';
 import Loading from 'components/common/Loading';
 import Navigation from 'components/layouts/Navigation';
 import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 
 const AnalyticsDashboardDetail: React.FC = () => {
+  const { did } = useParams();
   const [loadingData, setLoadingData] = useState(false);
 
-  const getEmbeddingUrl = async () => {
+  const getEmbeddingUrl = async (dashboard: IAnalyticsDashboard) => {
     try {
       const { success, data }: ApiResponse<any> = await fetchEmbeddingUrl(
-        'ap-southeast-1',
+        dashboard.region,
         window.location.origin,
-        'clickstream_dashboard_explore_xfrh_app1_c2580a7f'
+        dashboard.id
       );
       if (success) {
         const embedDashboard = async () => {
@@ -43,11 +45,25 @@ const AnalyticsDashboardDetail: React.FC = () => {
     }
   };
 
-  useEffect(() => {
+  const getAnalyticsDashboardDetails = async () => {
     setLoadingData(true);
-    getEmbeddingUrl();
-    setLoadingData(false);
-  }, []);
+    try {
+      const { success, data }: ApiResponse<IAnalyticsDashboard> =
+        await getAnalyticsDashboard(did ?? '');
+      if (success) {
+        getEmbeddingUrl(data);
+        setLoadingData(false);
+      }
+    } catch (error) {
+      setLoadingData(false);
+    }
+  };
+
+  useEffect(() => {
+    if (did) {
+      getAnalyticsDashboardDetails();
+    }
+  }, [did]);
 
   return (
     <AppLayout

--- a/frontend/src/pages/analytics/dashboard/detail/AnalyticsDashboardDetail.tsx
+++ b/frontend/src/pages/analytics/dashboard/detail/AnalyticsDashboardDetail.tsx
@@ -20,7 +20,7 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 const AnalyticsDashboardDetail: React.FC = () => {
-  const { did } = useParams();
+  const { dashboardId } = useParams();
   const [loadingData, setLoadingData] = useState(false);
 
   const getEmbeddingUrl = async (dashboard: IAnalyticsDashboard) => {
@@ -49,7 +49,7 @@ const AnalyticsDashboardDetail: React.FC = () => {
     setLoadingData(true);
     try {
       const { success, data }: ApiResponse<IAnalyticsDashboard> =
-        await getAnalyticsDashboard(did ?? '');
+        await getAnalyticsDashboard(dashboardId ?? '');
       if (success) {
         getEmbeddingUrl(data);
         setLoadingData(false);
@@ -60,10 +60,10 @@ const AnalyticsDashboardDetail: React.FC = () => {
   };
 
   useEffect(() => {
-    if (did) {
+    if (dashboardId) {
       getAnalyticsDashboardDetails();
     }
-  }, [did]);
+  }, [dashboardId]);
 
   return (
     <AppLayout

--- a/frontend/src/types/analytics.d.ts
+++ b/frontend/src/types/analytics.d.ts
@@ -169,4 +169,23 @@ declare global {
       readonly dataSourceArn: string;
     };
   }
+
+  interface IAnalyticsDashboard {
+    readonly id: string;
+    readonly type: string;
+    readonly prefix: string;
+
+    readonly projectId: string;
+    readonly dashboardId: string;
+
+    readonly name: string;
+    readonly description: string;
+    readonly region: string;
+    readonly sheetNames: string[];
+
+    readonly createAt: number;
+    readonly updateAt: number;
+    readonly operator: string;
+    readonly deleted: boolean;
+  }
 }

--- a/frontend/src/types/analytics.d.ts
+++ b/frontend/src/types/analytics.d.ts
@@ -13,13 +13,6 @@
 
 export {};
 declare global {
-  interface IAnalyticsDashboard {
-    readonly id: string;
-    readonly name: string;
-    readonly description: string;
-    readonly createAt: number;
-  }
-
   interface IMetadataEvent {
     readonly id: string;
     readonly type: string;
@@ -176,12 +169,15 @@ declare global {
     readonly prefix: string;
 
     readonly projectId: string;
+    readonly appId: string;
     readonly dashboardId: string;
 
     readonly name: string;
     readonly description: string;
     readonly region: string;
     readonly sheetNames: string[];
+    readonly ownerPrincipal: string;
+    readonly defaultDataSourceArn: string;
 
     readonly createAt: number;
     readonly updateAt: number;

--- a/frontend/src/types/analytics.d.ts
+++ b/frontend/src/types/analytics.d.ts
@@ -175,7 +175,7 @@ declare global {
     readonly name: string;
     readonly description: string;
     readonly region: string;
-    readonly sheetNames: string[];
+    readonly sheets: IAnalyticsDashboardSheet[];
     readonly ownerPrincipal: string;
     readonly defaultDataSourceArn: string;
 
@@ -183,5 +183,10 @@ declare global {
     readonly updateAt: number;
     readonly operator: string;
     readonly deleted: boolean;
+  }
+
+  export interface IAnalyticsDashboardSheet {
+    readonly id: string;
+    readonly name: string;
   }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3515,6 +3515,11 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.3.tgz#a136f83b0758698df454e328759dbd3d44555311"
   integrity sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==
 
+"@types/uuid@^9.0.0":
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.2.tgz#ede1d1b1e451548d44919dc226253e32a6952c4b"
+  integrity sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==
+
 "@types/ws@^8.5.5":
   version "8.5.5"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.5.tgz#af587964aa06682702ee6dcbc7be41a80e4b28eb"

--- a/src/control-plane/backend/lambda/api/model/project.ts
+++ b/src/control-plane/backend/lambda/api/model/project.ts
@@ -49,7 +49,7 @@ export interface IDashboard {
   readonly name: string;
   readonly description: string;
   readonly region: string;
-  readonly sheetNames: string[];
+  readonly sheets: IDashboardSheet[];
   readonly ownerPrincipal: string;
   readonly defaultDataSourceArn: string;
 
@@ -58,3 +58,9 @@ export interface IDashboard {
   readonly operator: string;
   readonly deleted: boolean;
 }
+
+export interface IDashboardSheet {
+  readonly id: string;
+  readonly name: string;
+}
+

--- a/src/control-plane/backend/lambda/api/model/project.ts
+++ b/src/control-plane/backend/lambda/api/model/project.ts
@@ -36,3 +36,22 @@ export interface IProjectList {
   totalCount: number | undefined;
   items: IProject[];
 }
+
+export interface IDashboard {
+  readonly id: string;
+  readonly type: string;
+  readonly prefix: string;
+
+  readonly projectId: string;
+  readonly dashboardId: string;
+
+  readonly name: string;
+  readonly description: string;
+  readonly region: string;
+  readonly sheetNames: string[];
+
+  readonly createAt: number;
+  readonly updateAt: number;
+  readonly operator: string;
+  readonly deleted: boolean;
+}

--- a/src/control-plane/backend/lambda/api/model/project.ts
+++ b/src/control-plane/backend/lambda/api/model/project.ts
@@ -43,12 +43,15 @@ export interface IDashboard {
   readonly prefix: string;
 
   readonly projectId: string;
+  readonly appId: string;
   readonly dashboardId: string;
 
   readonly name: string;
   readonly description: string;
   readonly region: string;
   readonly sheetNames: string[];
+  readonly ownerPrincipal: string;
+  readonly defaultDataSourceArn: string;
 
   readonly createAt: number;
   readonly updateAt: number;

--- a/src/control-plane/backend/lambda/api/router/project.ts
+++ b/src/control-plane/backend/lambda/api/router/project.ts
@@ -20,6 +20,41 @@ const router_project = express.Router();
 const projectServ: ProjectServ = new ProjectServ();
 
 router_project.get(
+  '/:id/dashboards',
+  validate([
+    query().custom((value: any, { req }: any) => defaultPageValueValid(value, {
+      req,
+      location: 'body',
+      path: '',
+    }))
+      .custom((value: any, { req }: any) => defaultOrderValueValid(value, {
+        req,
+        location: 'body',
+        path: '',
+      })),
+  ]),
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return projectServ.listDashboards(req, res, next);
+  });
+
+router_project.post(
+  '/:id/dashboard',
+  validate([
+    body().custom(isValidEmpty).custom(isXSSRequest),
+    param('id').custom(isProjectExisted),
+    header('X-Click-Stream-Request-Id').custom(isRequestIdExisted),
+  ]),
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return projectServ.createDashboard(req, res, next);
+  });
+
+router_project.delete(
+  '/dashboard/:dashboardId',
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return projectServ.deleteDashboard(req, res, next);
+  });
+
+router_project.get(
   '',
   validate([
     query().custom((value: any, { req }: any) => defaultPageValueValid(value, {

--- a/src/control-plane/backend/lambda/api/router/project.ts
+++ b/src/control-plane/backend/lambda/api/router/project.ts
@@ -37,6 +37,12 @@ router_project.get(
     return projectServ.listDashboards(req, res, next);
   });
 
+router_project.get(
+  '/dashboard/:dashboardId',
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return projectServ.getDashboard(req, res, next);
+  });
+
 router_project.post(
   '/:id/dashboard',
   validate([

--- a/src/control-plane/backend/lambda/api/router/project.ts
+++ b/src/control-plane/backend/lambda/api/router/project.ts
@@ -47,6 +47,8 @@ router_project.post(
   '/:id/dashboard',
   validate([
     body().custom(isValidEmpty).custom(isXSSRequest),
+    body('ownerPrincipal').custom(isValidEmpty),
+    body('defaultDataSourceArn').custom(isValidEmpty),
     param('id').custom(isProjectExisted),
     header('X-Click-Stream-Request-Id').custom(isRequestIdExisted),
   ]),

--- a/src/control-plane/backend/lambda/api/service/project.ts
+++ b/src/control-plane/backend/lambda/api/service/project.ts
@@ -82,10 +82,10 @@ export class ProjectServ {
         });
       // Create dashboard in QuickSight
       const sheets: SheetDefinition[] = [];
-      for (let sheetName of dashboard.sheetNames) {
+      for (let sheet of dashboard.sheets) {
         const sheetDefinition: SheetDefinition = {
-          SheetId: uuidv4().replace(/-/g, ''),
-          Name: sheetName,
+          SheetId: sheet.id,
+          Name: sheet.name,
         };
         sheets.push(sheetDefinition);
       }

--- a/src/control-plane/backend/lambda/api/service/project.ts
+++ b/src/control-plane/backend/lambda/api/service/project.ts
@@ -11,12 +11,16 @@
  *  and limitations under the License.
  */
 
+import { CreateDashboardCommandInput, DataSetImportMode, QuickSight, SheetDefinition } from '@aws-sdk/client-quicksight';
 import { v4 as uuidv4 } from 'uuid';
+import { createDataSet } from './quicksight/reporting-utils';
 import { logger } from '../common/powertools';
+import { aws_sdk_client_common_config } from '../common/sdk-client-config-ln';
 import { ApiFail, ApiSuccess } from '../common/types';
 import { isEmpty, paginateData } from '../common/utils';
 import { CPipeline } from '../model/pipeline';
 import { IDashboard, IProject } from '../model/project';
+import { createDashboard } from '../store/aws/quicksight';
 import { ClickStreamStore } from '../store/click-stream-store';
 import { DynamoDbStore } from '../store/dynamodb/dynamodb-store';
 
@@ -40,11 +44,79 @@ export class ProjectServ {
 
   public async createDashboard(req: any, res: any, next: any) {
     try {
-      req.body.id = uuidv4().replace(/-/g, '');
+      const dashboardId = uuidv4().replace(/-/g, '');
+      req.body.id = dashboardId;
       req.body.operator = res.get('X-Click-Stream-Operator');
-      let dashboard: IDashboard = req.body;
-      // TODO: Create dashboard in QuickSight
-      // dashboard.id = xxxx
+      const dashboard: IDashboard = req.body;
+      if (isEmpty(dashboard.defaultDataSourceArn) || isEmpty(dashboard.ownerPrincipal)) {
+        return res.status(400).json(new ApiFail('Default data source ARN and owner principal is required.'));
+      }
+      // Create dataset in QuickSight
+      const quickSightClient = new QuickSight({
+        region: dashboard.region,
+        ...aws_sdk_client_common_config,
+      });
+      const dataset = await createDataSet(
+        quickSightClient,
+        process.env.AWS_ACCOUNT_ID!,
+        dashboard.ownerPrincipal,
+        dashboard.defaultDataSourceArn, {
+          name: `${dashboard.name}-default-dataset`,
+          tableName: 'ods_events',
+          columns: [
+            {
+              Name: 'event_date',
+              Type: 'DATETIME',
+            },
+            {
+              Name: 'event_name',
+              Type: 'STRING',
+            },
+            {
+              Name: 'x_id',
+              Type: 'STRING',
+            },
+          ],
+          importMode: DataSetImportMode.DIRECT_QUERY,
+          customSql: `select * from ${dashboard.appId}.ods_events`,
+        });
+      // Create dashboard in QuickSight
+      const sheets: SheetDefinition[] = [];
+      for (let sheetName of dashboard.sheetNames) {
+        const sheetDefinition: SheetDefinition = {
+          SheetId: uuidv4().replace(/-/g, ''),
+          Name: sheetName,
+        };
+        sheets.push(sheetDefinition);
+      }
+      const dashboardInput: CreateDashboardCommandInput = {
+        AwsAccountId: process.env.AWS_ACCOUNT_ID,
+        DashboardId: dashboardId,
+        Name: dashboard.name,
+        Definition: {
+          DataSetIdentifierDeclarations: [
+            {
+              Identifier: 'default',
+              DataSetArn: dataset?.Arn,
+            },
+          ],
+          Sheets: sheets,
+        },
+        Permissions: [{
+          Principal: dashboard.ownerPrincipal,
+          Actions: [
+            'quicksight:DescribeDashboard',
+            'quicksight:ListDashboardVersions',
+            'quicksight:QueryDashboard',
+            'quicksight:UpdateDashboard',
+            'quicksight:DeleteDashboard',
+            'quicksight:UpdateDashboardPermissions',
+            'quicksight:DescribeDashboardPermissions',
+            'quicksight:UpdateDashboardPublishedVersion',
+          ],
+        }],
+      };
+      await createDashboard(dashboard.region, dashboardInput);
       const id = await store.createDashboard(dashboard);
       return res.status(201).json(new ApiSuccess({ id }, 'Dashboard created.'));
     } catch (error) {
@@ -56,6 +128,18 @@ export class ProjectServ {
     try {
       const { dashboardId } = req.params;
       const operator = res.get('X-Click-Stream-Operator');
+      const dashboard = await store.getDashboard(dashboardId);
+      if (!dashboard) {
+        return res.status(404).json(new ApiFail('Dashboard not found'));
+      }
+      const quickSightClient = new QuickSight({
+        region: dashboard.region,
+        ...aws_sdk_client_common_config,
+      });
+      await quickSightClient.deleteDashboard({
+        AwsAccountId: process.env.AWS_ACCOUNT_ID,
+        DashboardId: dashboardId,
+      });
       await store.deleteDashboard(dashboardId, operator);
       return res.json(new ApiSuccess(null, 'Dashboard deleted.'));
     } catch (error) {

--- a/src/control-plane/backend/lambda/api/service/project.ts
+++ b/src/control-plane/backend/lambda/api/service/project.ts
@@ -124,6 +124,19 @@ export class ProjectServ {
     }
   };
 
+  public async getDashboard(req: any, res: any, next: any) {
+    try {
+      const { dashboardId } = req.params;
+      const dashboard = await store.getDashboard(dashboardId);
+      if (!dashboard) {
+        return res.status(404).json(new ApiFail('Dashboard not found'));
+      }
+      return res.json(new ApiSuccess(dashboard));
+    } catch (error) {
+      next(error);
+    }
+  };
+
   public async deleteDashboard(req: any, res: any, next: any) {
     try {
       const { dashboardId } = req.params;

--- a/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
@@ -26,6 +26,9 @@ import {
   UpdateDashboardPermissionsCommand,
   GenerateEmbedUrlForRegisteredUserCommandInput,
   ResourceExistsException,
+  CreateDashboardCommand,
+  CreateDashboardCommandOutput,
+  CreateDashboardCommandInput,
 } from '@aws-sdk/client-quicksight';
 import { APIRoleName, awsAccountId, awsRegion, QUICKSIGHT_CONTROL_PLANE_REGION, QUICKSIGHT_EMBED_NO_REPLY_EMAIL, QuickSightEmbedRoleArn } from '../../common/constants';
 import { REGION_PATTERN } from '../../common/constants-ln';
@@ -319,4 +322,25 @@ export const getClickstreamUserArn = async (): Promise<QuickSightUserArns> => {
   const ownerArn = `arn:${partition}:quicksight:${identityRegion}:${awsAccountId}:user/${QUICKSIGHT_NAMESPACE}/${QUICKSIGHT_DASHBOARD_USER_NAME}`;
   const embedArn = `arn:${partition}:quicksight:${identityRegion}:${awsAccountId}:user/${QUICKSIGHT_NAMESPACE}/${quickSightEmbedRoleName}/${QUICKSIGHT_EMBED_USER_NAME}`;
   return { dashboardOwner: ownerArn, embedOwner: embedArn };
+};
+
+export const createDashboard = async (
+  region: string,
+  input: CreateDashboardCommandInput,
+): Promise<CreateDashboardCommandOutput> => {
+  try {
+    const quickSightClient = new QuickSightClient({
+      ...aws_sdk_client_common_config,
+      region: region,
+    });
+    const command: CreateDashboardCommand = new CreateDashboardCommand(input);
+    return await quickSightClient.send(command);
+  } catch (err) {
+    logger.error('Create Dashboard Error.', { err });
+    throw err;
+  }
+};
+
+export const Sleep = (ms: number) => {
+  return new Promise(resolve=>setTimeout(resolve, ms));
 };

--- a/src/control-plane/backend/lambda/api/store/click-stream-store.ts
+++ b/src/control-plane/backend/lambda/api/store/click-stream-store.ts
@@ -26,6 +26,7 @@ export interface ClickStreamStore {
   isProjectExisted: (projectId: string) => Promise<boolean>;
 
   createDashboard: (dashboard: IDashboard) => Promise<string>;
+  getDashboard: (dashboardId: string) => Promise<IDashboard | undefined>;
   listDashboards: (projectId: string, order: string) => Promise<IDashboard[]>;
   deleteDashboard: (dashboardId: string, operator: string) => Promise<void>;
 

--- a/src/control-plane/backend/lambda/api/store/click-stream-store.ts
+++ b/src/control-plane/backend/lambda/api/store/click-stream-store.ts
@@ -15,7 +15,7 @@ import { IApplication } from '../model/application';
 import { IDictionary } from '../model/dictionary';
 import { IPipeline } from '../model/pipeline';
 import { IPlugin } from '../model/plugin';
-import { IProject } from '../model/project';
+import { IDashboard, IProject } from '../model/project';
 
 export interface ClickStreamStore {
   createProject: (project: IProject) => Promise<string>;
@@ -24,6 +24,10 @@ export interface ClickStreamStore {
   listProjects: (order: string) => Promise<IProject[]>;
   deleteProject: (id: string, operator: string) => Promise<void>;
   isProjectExisted: (projectId: string) => Promise<boolean>;
+
+  createDashboard: (dashboard: IDashboard) => Promise<string>;
+  listDashboards: (projectId: string, order: string) => Promise<IDashboard[]>;
+  deleteDashboard: (dashboardId: string, operator: string) => Promise<void>;
 
   addApplication: (app: IApplication) => Promise<string>;
   getApplication: (projectId: string, appId: string) => Promise<IApplication | undefined>;

--- a/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-store.ts
+++ b/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-store.ts
@@ -29,10 +29,71 @@ import { IApplication } from '../../model/application';
 import { IDictionary } from '../../model/dictionary';
 import { IPipeline } from '../../model/pipeline';
 import { IPlugin } from '../../model/plugin';
-import { IProject } from '../../model/project';
+import { IDashboard, IProject } from '../../model/project';
 import { ClickStreamStore } from '../click-stream-store';
 
 export class DynamoDbStore implements ClickStreamStore {
+  public async createDashboard(dashboard: IDashboard): Promise<string> {
+    const params: PutCommand = new PutCommand({
+      TableName: clickStreamTableName,
+      Item: {
+        id: dashboard.id,
+        type: `DASHBOARD#${dashboard.id}`,
+        prefix: 'DASHBOARD',
+        projectId: dashboard.projectId,
+        name: dashboard.name ?? '',
+        description: dashboard.description ?? '',
+        region: dashboard.region ?? '',
+        sheetNames: dashboard.sheetNames ?? [],
+        createAt: Date.now(),
+        updateAt: Date.now(),
+        operator: dashboard.operator?? '',
+        deleted: false,
+      },
+    });
+    await docClient.send(params);
+    return dashboard.id;
+  };
+
+  public async listDashboards(projectId: string, order: string): Promise<IDashboard[]> {
+    const input: QueryCommandInput = {
+      TableName: clickStreamTableName,
+      IndexName: prefixTimeGSIName,
+      KeyConditionExpression: '#prefix= :prefix',
+      FilterExpression: 'deleted = :d',
+      ExpressionAttributeNames: {
+        '#prefix': 'prefix',
+      },
+      ExpressionAttributeValues: {
+        ':d': false,
+        ':prefix': 'DASHBOARD',
+      },
+      ScanIndexForward: order === 'asc',
+    };
+    const records = await query(input) as IDashboard[];
+    return records.filter(d => d.projectId === projectId);
+  };
+
+  public async deleteDashboard(dashboardId: string, operator: string): Promise<void> {
+    const params: UpdateCommand = new UpdateCommand({
+      TableName: clickStreamTableName,
+      Key: {
+        id: dashboardId,
+        type: `DASHBOARD#${dashboardId}`,
+      },
+      // Define expressions for the new or updated attributes
+      UpdateExpression: 'SET deleted= :d, #operator= :operator',
+      ExpressionAttributeNames: {
+        '#operator': 'operator',
+      },
+      ExpressionAttributeValues: {
+        ':d': true,
+        ':operator': operator,
+      },
+      ReturnValues: 'ALL_NEW',
+    });
+    await docClient.send(params);
+  };
 
   public async createProject(project: IProject): Promise<string> {
     const params: PutCommand = new PutCommand({

--- a/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-store.ts
+++ b/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-store.ts
@@ -45,7 +45,7 @@ export class DynamoDbStore implements ClickStreamStore {
         name: dashboard.name ?? '',
         description: dashboard.description ?? '',
         region: dashboard.region ?? '',
-        sheetNames: dashboard.sheetNames ?? [],
+        sheetNames: dashboard.sheets ?? [],
         ownerPrincipal: dashboard.ownerPrincipal ?? '',
         defaultDataSourceArn: dashboard.defaultDataSourceArn ?? '',
         createAt: Date.now(),

--- a/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-store.ts
+++ b/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-store.ts
@@ -41,10 +41,13 @@ export class DynamoDbStore implements ClickStreamStore {
         type: `DASHBOARD#${dashboard.id}`,
         prefix: 'DASHBOARD',
         projectId: dashboard.projectId,
+        appId: dashboard.appId,
         name: dashboard.name ?? '',
         description: dashboard.description ?? '',
         region: dashboard.region ?? '',
         sheetNames: dashboard.sheetNames ?? [],
+        ownerPrincipal: dashboard.ownerPrincipal ?? '',
+        defaultDataSourceArn: dashboard.defaultDataSourceArn ?? '',
         createAt: Date.now(),
         updateAt: Date.now(),
         operator: dashboard.operator?? '',
@@ -53,6 +56,22 @@ export class DynamoDbStore implements ClickStreamStore {
     });
     await docClient.send(params);
     return dashboard.id;
+  };
+
+  public async getDashboard(dashboardId: string): Promise<IDashboard | undefined> {
+    const params: GetCommand = new GetCommand({
+      TableName: clickStreamTableName,
+      Key: {
+        id: dashboardId,
+        type: `DASHBOARD#${dashboardId}`,
+      },
+    });
+    const result: GetCommandOutput = await docClient.send(params);
+    if (!result.Item) {
+      return undefined;
+    }
+    const dashboard: IDashboard = result.Item as IDashboard;
+    return !dashboard.deleted ? dashboard : undefined;
   };
 
   public async listDashboards(projectId: string, order: string): Promise<IDashboard[]> {

--- a/src/control-plane/backend/lambda/api/test/api/analytics-dashboard.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/analytics-dashboard.test.ts
@@ -1,0 +1,66 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { CreateDashboardCommand, CreateDataSetCommand, QuickSightClient } from '@aws-sdk/client-quicksight';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { mockClient } from 'aws-sdk-client-mock';
+import request from 'supertest';
+import { MOCK_PROJECT_ID, MOCK_TOKEN, projectExistedMock, tokenMock } from './ddb-mock';
+import { app, server } from '../../index';
+import 'aws-sdk-client-mock-jest';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const quickSightMock = mockClient(QuickSightClient);
+
+describe('Analytics dashboard test', () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    quickSightMock.reset();
+  });
+  it('Create dashboard', async () => {
+    tokenMock(ddbMock, false);
+    projectExistedMock(ddbMock, true);
+    ddbMock.on(PutCommand).resolvesOnce({});
+    quickSightMock.on(CreateDataSetCommand).resolvesOnce({});
+    quickSightMock.on(CreateDashboardCommand).resolvesOnce({});
+    const res = await request(app)
+      .post(`/api/project/${MOCK_PROJECT_ID}/dashboard`)
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        name: 'd11',
+        appId: 'app1',
+        description: 'Description of dd-01',
+        region: 'ap-southeast-1',
+        sheetNames: ['s1', 's2'],
+        ownerPrincipal: 'arn:aws:quicksight:us-west-2:5555555555555:user/default/user',
+        defaultDataSourceArn: 'arn:aws:quicksight:ap-southeast-1:5555555555555:datasource/clickstream_datasource_project_1',
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(201);
+    expect(res.body.message).toEqual('Dashboard created.');
+    expect(res.body.success).toEqual(true);
+    expect(quickSightMock).toHaveReceivedCommandTimes(CreateDataSetCommand, 1);
+    expect(quickSightMock).toHaveReceivedCommandTimes(CreateDashboardCommand, 1);
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 2);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 2);
+  });
+
+  afterAll((done) => {
+    server.close();
+    done();
+  });
+});

--- a/src/control-plane/backend/lambda/api/test/api/analytics-dashboard.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/analytics-dashboard.test.ts
@@ -16,10 +16,12 @@ import {
   DynamoDBDocumentClient,
   GetCommand,
   PutCommand,
+  QueryCommand,
+  UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
 import { mockClient } from 'aws-sdk-client-mock';
 import request from 'supertest';
-import { MOCK_PROJECT_ID, MOCK_TOKEN, projectExistedMock, tokenMock } from './ddb-mock';
+import { MOCK_DASHBOARD_ID, MOCK_PROJECT_ID, MOCK_TOKEN, projectExistedMock, tokenMock } from './ddb-mock';
 import { app, server } from '../../index';
 import 'aws-sdk-client-mock-jest';
 
@@ -31,6 +33,7 @@ describe('Analytics dashboard test', () => {
     ddbMock.reset();
     quickSightMock.reset();
   });
+
   it('Create dashboard', async () => {
     tokenMock(ddbMock, false);
     projectExistedMock(ddbMock, true);
@@ -57,6 +60,132 @@ describe('Analytics dashboard test', () => {
     expect(quickSightMock).toHaveReceivedCommandTimes(CreateDashboardCommand, 1);
     expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 2);
     expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 2);
+  });
+
+  it('Create dashboard with empty parameters', async () => {
+    tokenMock(ddbMock, false);
+    projectExistedMock(ddbMock, true);
+    ddbMock.on(PutCommand).resolvesOnce({});
+    quickSightMock.on(CreateDataSetCommand).resolvesOnce({});
+    quickSightMock.on(CreateDashboardCommand).resolvesOnce({});
+    const res = await request(app)
+      .post(`/api/project/${MOCK_PROJECT_ID}/dashboard`)
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        name: 'd11',
+        appId: 'app1',
+        description: 'Description of dd-01',
+        region: 'ap-southeast-1',
+        sheetNames: ['s1', 's2'],
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Parameter verification failed.',
+      error: [
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: 'ownerPrincipal',
+        },
+        {
+          location: 'body',
+          msg: 'Value is empty.',
+          param: 'defaultDataSourceArn',
+        },
+      ],
+    });
+    expect(quickSightMock).toHaveReceivedCommandTimes(CreateDataSetCommand, 0);
+    expect(quickSightMock).toHaveReceivedCommandTimes(CreateDashboardCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 2);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+  });
+
+  it('List dashboards of project', async () => {
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        {
+          dashboardId: 'dashboard-1',
+          name: 'dashboard-1',
+          projectId: MOCK_PROJECT_ID,
+          description: 'Description of dashboard-1',
+          region: 'ap-southeast-1',
+          sheetNames: ['s1', 's2'],
+          ownerPrincipal: 'arn:aws:quicksight:us-west-2:5555555555555:user/default/user',
+          defaultDataSourceArn: 'arn:aws:quicksight:ap-southeast-1:5555555555555:datasource/clickstream_datasource_project_1',
+          deleted: false,
+        },
+        {
+          dashboardId: 'dashboard-2',
+          name: 'dashboard-2',
+          projectId: 'project-1',
+          description: 'Description of dashboard-2',
+          region: 'ap-southeast-1',
+          sheetNames: ['s1', 's2'],
+          ownerPrincipal: 'arn:aws:quicksight:us-west-2:5555555555555:user/default/user',
+          defaultDataSourceArn: 'arn:aws:quicksight:ap-southeast-1:5555555555555:datasource/clickstream_datasource_project_1',
+          deleted: false,
+        },
+      ],
+    });
+    const res = await request(app)
+      .get(`/api/project/${MOCK_PROJECT_ID}/dashboards`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(
+      { data: { items: [{ dashboardId: 'dashboard-1', defaultDataSourceArn: 'arn:aws:quicksight:ap-southeast-1:5555555555555:datasource/clickstream_datasource_project_1', deleted: false, description: 'Description of dashboard-1', name: 'dashboard-1', ownerPrincipal: 'arn:aws:quicksight:us-west-2:5555555555555:user/default/user', projectId: 'project_8888_8888', region: 'ap-southeast-1', sheetNames: ['s1', 's2'] }], totalCount: 1 }, message: '', success: true },
+    );
+    expect(ddbMock).toHaveReceivedCommandTimes(QueryCommand, 1);
+  });
+
+  it('get dashboard details', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        dashboardId: MOCK_DASHBOARD_ID,
+        name: 'dashboard-1',
+        projectId: MOCK_PROJECT_ID,
+        description: 'Description of dashboard-1',
+        region: 'ap-southeast-1',
+        sheetNames: ['s1', 's2'],
+        ownerPrincipal: 'arn:aws:quicksight:us-west-2:5555555555555:user/default/user',
+        defaultDataSourceArn: 'arn:aws:quicksight:ap-southeast-1:5555555555555:datasource/clickstream_datasource_project_1',
+        deleted: false,
+      },
+    });
+    const res = await request(app)
+      .get(`/api/project/dashboard/${MOCK_DASHBOARD_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(
+      { data: { dashboardId: MOCK_DASHBOARD_ID, defaultDataSourceArn: 'arn:aws:quicksight:ap-southeast-1:5555555555555:datasource/clickstream_datasource_project_1', deleted: false, description: 'Description of dashboard-1', name: 'dashboard-1', ownerPrincipal: 'arn:aws:quicksight:us-west-2:5555555555555:user/default/user', projectId: 'project_8888_8888', region: 'ap-southeast-1', sheetNames: ['s1', 's2'] }, message: '', success: true },
+    );
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
+  });
+
+  it('delete dashboard', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        dashboardId: MOCK_DASHBOARD_ID,
+        name: 'dashboard-1',
+        projectId: MOCK_PROJECT_ID,
+        description: 'Description of dashboard-1',
+        region: 'ap-southeast-1',
+        sheetNames: ['s1', 's2'],
+        ownerPrincipal: 'arn:aws:quicksight:us-west-2:5555555555555:user/default/user',
+        defaultDataSourceArn: 'arn:aws:quicksight:ap-southeast-1:5555555555555:datasource/clickstream_datasource_project_1',
+        deleted: false,
+      },
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    const res = await request(app)
+      .delete(`/api/project/dashboard/${MOCK_DASHBOARD_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(
+      { data: null, message: 'Dashboard deleted.', success: true });
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
+    expect(ddbMock).toHaveReceivedCommandTimes(UpdateCommand, 1);
   });
 
   afterAll((done) => {

--- a/src/control-plane/backend/lambda/api/test/api/analytics-dashboard.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/analytics-dashboard.test.ts
@@ -48,7 +48,10 @@ describe('Analytics dashboard test', () => {
         appId: 'app1',
         description: 'Description of dd-01',
         region: 'ap-southeast-1',
-        sheetNames: ['s1', 's2'],
+        sheets: [
+          { id: 's1', name: 'sheet1' },
+          { id: 's2', name: 'sheet2' },
+        ],
         ownerPrincipal: 'arn:aws:quicksight:us-west-2:5555555555555:user/default/user',
         defaultDataSourceArn: 'arn:aws:quicksight:ap-southeast-1:5555555555555:datasource/clickstream_datasource_project_1',
       });
@@ -76,7 +79,10 @@ describe('Analytics dashboard test', () => {
         appId: 'app1',
         description: 'Description of dd-01',
         region: 'ap-southeast-1',
-        sheetNames: ['s1', 's2'],
+        sheets: [
+          { id: 's1', name: 'sheet1' },
+          { id: 's2', name: 'sheet2' },
+        ],
       });
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(400);
@@ -111,7 +117,10 @@ describe('Analytics dashboard test', () => {
           projectId: MOCK_PROJECT_ID,
           description: 'Description of dashboard-1',
           region: 'ap-southeast-1',
-          sheetNames: ['s1', 's2'],
+          sheets: [
+            { id: 's1', name: 'sheet1' },
+            { id: 's2', name: 'sheet2' },
+          ],
           ownerPrincipal: 'arn:aws:quicksight:us-west-2:5555555555555:user/default/user',
           defaultDataSourceArn: 'arn:aws:quicksight:ap-southeast-1:5555555555555:datasource/clickstream_datasource_project_1',
           deleted: false,
@@ -122,7 +131,10 @@ describe('Analytics dashboard test', () => {
           projectId: 'project-1',
           description: 'Description of dashboard-2',
           region: 'ap-southeast-1',
-          sheetNames: ['s1', 's2'],
+          sheets: [
+            { id: 's1', name: 'sheet1' },
+            { id: 's2', name: 'sheet2' },
+          ],
           ownerPrincipal: 'arn:aws:quicksight:us-west-2:5555555555555:user/default/user',
           defaultDataSourceArn: 'arn:aws:quicksight:ap-southeast-1:5555555555555:datasource/clickstream_datasource_project_1',
           deleted: false,
@@ -134,7 +146,27 @@ describe('Analytics dashboard test', () => {
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual(
-      { data: { items: [{ dashboardId: 'dashboard-1', defaultDataSourceArn: 'arn:aws:quicksight:ap-southeast-1:5555555555555:datasource/clickstream_datasource_project_1', deleted: false, description: 'Description of dashboard-1', name: 'dashboard-1', ownerPrincipal: 'arn:aws:quicksight:us-west-2:5555555555555:user/default/user', projectId: 'project_8888_8888', region: 'ap-southeast-1', sheetNames: ['s1', 's2'] }], totalCount: 1 }, message: '', success: true },
+      {
+        data: {
+          items: [{
+            dashboardId: 'dashboard-1',
+            defaultDataSourceArn: 'arn:aws:quicksight:ap-southeast-1:5555555555555:datasource/clickstream_datasource_project_1',
+            deleted: false,
+            description: 'Description of dashboard-1',
+            name: 'dashboard-1',
+            ownerPrincipal: 'arn:aws:quicksight:us-west-2:5555555555555:user/default/user',
+            projectId: 'project_8888_8888',
+            region: 'ap-southeast-1',
+            sheets: [
+              { id: 's1', name: 'sheet1' },
+              { id: 's2', name: 'sheet2' },
+            ],
+          }],
+          totalCount: 1,
+        },
+        message: '',
+        success: true,
+      },
     );
     expect(ddbMock).toHaveReceivedCommandTimes(QueryCommand, 1);
   });
@@ -147,7 +179,10 @@ describe('Analytics dashboard test', () => {
         projectId: MOCK_PROJECT_ID,
         description: 'Description of dashboard-1',
         region: 'ap-southeast-1',
-        sheetNames: ['s1', 's2'],
+        sheets: [
+          { id: 's1', name: 'sheet1' },
+          { id: 's2', name: 'sheet2' },
+        ],
         ownerPrincipal: 'arn:aws:quicksight:us-west-2:5555555555555:user/default/user',
         defaultDataSourceArn: 'arn:aws:quicksight:ap-southeast-1:5555555555555:datasource/clickstream_datasource_project_1',
         deleted: false,
@@ -158,7 +193,24 @@ describe('Analytics dashboard test', () => {
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual(
-      { data: { dashboardId: MOCK_DASHBOARD_ID, defaultDataSourceArn: 'arn:aws:quicksight:ap-southeast-1:5555555555555:datasource/clickstream_datasource_project_1', deleted: false, description: 'Description of dashboard-1', name: 'dashboard-1', ownerPrincipal: 'arn:aws:quicksight:us-west-2:5555555555555:user/default/user', projectId: 'project_8888_8888', region: 'ap-southeast-1', sheetNames: ['s1', 's2'] }, message: '', success: true },
+      {
+        data: {
+          dashboardId: MOCK_DASHBOARD_ID,
+          defaultDataSourceArn: 'arn:aws:quicksight:ap-southeast-1:5555555555555:datasource/clickstream_datasource_project_1',
+          deleted: false,
+          description: 'Description of dashboard-1',
+          name: 'dashboard-1',
+          ownerPrincipal: 'arn:aws:quicksight:us-west-2:5555555555555:user/default/user',
+          projectId: 'project_8888_8888',
+          region: 'ap-southeast-1',
+          sheets: [
+            { id: 's1', name: 'sheet1' },
+            { id: 's2', name: 'sheet2' },
+          ],
+        },
+        message: '',
+        success: true,
+      },
     );
     expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
   });
@@ -171,7 +223,10 @@ describe('Analytics dashboard test', () => {
         projectId: MOCK_PROJECT_ID,
         description: 'Description of dashboard-1',
         region: 'ap-southeast-1',
-        sheetNames: ['s1', 's2'],
+        sheets: [
+          { id: 's1', name: 'sheet1' },
+          { id: 's2', name: 'sheet2' },
+        ],
         ownerPrincipal: 'arn:aws:quicksight:us-west-2:5555555555555:user/default/user',
         defaultDataSourceArn: 'arn:aws:quicksight:ap-southeast-1:5555555555555:datasource/clickstream_datasource_project_1',
         deleted: false,

--- a/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
@@ -48,6 +48,7 @@ const MOCK_EVENT_PARAMETER_ID = '1111-1111';
 const MOCK_EVENT_PARAMETER_NAME = 'event-attribute-mock';
 const MOCK_USER_ATTRIBUTE_ID = '2222-2222';
 const MOCK_USER_ATTRIBUTE_NAME = 'user-attribute-mock';
+const MOCK_DASHBOARD_ID = 'dash_6666_6666';
 
 
 export const AllowIAMUserPutObejectPolicy = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::127311923021:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/clickstream/*"}]}';
@@ -845,6 +846,7 @@ export {
   MOCK_EVENT_PARAMETER_NAME,
   MOCK_USER_ATTRIBUTE_ID,
   MOCK_USER_ATTRIBUTE_NAME,
+  MOCK_DASHBOARD_ID,
   tokenMock,
   projectExistedMock,
   appExistedMock,

--- a/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
@@ -28,7 +28,6 @@ import { GetBucketPolicyCommand } from '@aws-sdk/client-s3';
 import { GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
 import { StartExecutionCommand } from '@aws-sdk/client-sfn';
 import { GetCommand, GetCommandInput, QueryCommand } from '@aws-sdk/lib-dynamodb';
-import { AllowIAMUserPutObejectPolicyInApSouthEast1, AllowIAMUserPutObejectPolicyWithErrorService } from './env-bucket-policy.test';
 import { analyticsMetadataTable, clickStreamTableName, dictionaryTableName } from '../../common/constants';
 import { ProjectEnvironment } from '../../common/types';
 import { IPipeline } from '../../model/pipeline';
@@ -49,6 +48,18 @@ const MOCK_EVENT_PARAMETER_ID = '1111-1111';
 const MOCK_EVENT_PARAMETER_NAME = 'event-attribute-mock';
 const MOCK_USER_ATTRIBUTE_ID = '2222-2222';
 const MOCK_USER_ATTRIBUTE_NAME = 'user-attribute-mock';
+
+
+export const AllowIAMUserPutObejectPolicy = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::127311923021:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/clickstream/*"}]}';
+export const AllowLogDeliveryPutObejectPolicy = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"logdelivery.elasticloadbalancing.amazonaws.com"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/clickstream/*"}]}';
+export const AllowIAMUserPutObejectPolicyInCN = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws-cn:iam::638102146993:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws-cn:s3:::EXAMPLE_BUCKET/clickstream/*"}]}';
+export const AllowIAMUserPutObejectPolicyWithErrorUserId = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::555555555555:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/clickstream/*"},{"Effect":"Allow","Principal":{"Service":"logdelivery.elasticloadbalancing.amazonaws.com"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/clickstream/*"}]}';
+export const AllowIAMUserPutObejectPolicyWithErrorPartition = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::127311923021:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws-cn:s3:::EXAMPLE_BUCKET/clickstream/*"}]}';
+export const AllowIAMUserPutObejectPolicyWithErrorBucket = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::127311923021:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET1/clickstream/*"}]}';
+export const AllowIAMUserPutObejectPolicyWithErrorBucketPrefix = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::127311923021:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/*"}]}';
+export const AllowIAMUserPutObejectPolicyWithErrorService = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"errorservice.elasticloadbalancing.amazonaws.com"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/clickstream/*"}]}';
+export const AllowIAMUserPutObejectPolicyInApSouthEast1 = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::027434742980:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/clickstream/*"},{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::114774131450:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/clickstream/*"}]}';
+
 
 function tokenMock(ddbMock: any, expect: boolean): any {
   if (!expect) {

--- a/src/control-plane/backend/lambda/api/test/api/env-bucket-policy.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/env-bucket-policy.test.ts
@@ -19,21 +19,20 @@ import {
 import { S3Client, GetBucketPolicyCommand } from '@aws-sdk/client-s3';
 import { mockClient } from 'aws-sdk-client-mock';
 import request from 'supertest';
+import {
+  AllowIAMUserPutObejectPolicy,
+  AllowLogDeliveryPutObejectPolicy,
+  AllowIAMUserPutObejectPolicyInCN,
+  AllowIAMUserPutObejectPolicyWithErrorUserId,
+  AllowIAMUserPutObejectPolicyWithErrorPartition,
+  AllowIAMUserPutObejectPolicyWithErrorBucket,
+  AllowIAMUserPutObejectPolicyWithErrorBucketPrefix,
+} from './ddb-mock';
 import { app, server } from '../../index';
 import 'aws-sdk-client-mock-jest';
 
 const s3Client = mockClient(S3Client);
 const iamClient = mockClient(IAMClient);
-
-const AllowIAMUserPutObejectPolicy = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::127311923021:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/clickstream/*"}]}';
-const AllowLogDeliveryPutObejectPolicy = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"logdelivery.elasticloadbalancing.amazonaws.com"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/clickstream/*"}]}';
-const AllowIAMUserPutObejectPolicyInCN = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws-cn:iam::638102146993:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws-cn:s3:::EXAMPLE_BUCKET/clickstream/*"}]}';
-const AllowIAMUserPutObejectPolicyWithErrorUserId = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::555555555555:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/clickstream/*"},{"Effect":"Allow","Principal":{"Service":"logdelivery.elasticloadbalancing.amazonaws.com"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/clickstream/*"}]}';
-const AllowIAMUserPutObejectPolicyWithErrorPartition = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::127311923021:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws-cn:s3:::EXAMPLE_BUCKET/clickstream/*"}]}';
-const AllowIAMUserPutObejectPolicyWithErrorBucket = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::127311923021:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET1/clickstream/*"}]}';
-const AllowIAMUserPutObejectPolicyWithErrorBucketPrefix = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::127311923021:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/*"}]}';
-export const AllowIAMUserPutObejectPolicyWithErrorService = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"errorservice.elasticloadbalancing.amazonaws.com"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/clickstream/*"}]}';
-export const AllowIAMUserPutObejectPolicyInApSouthEast1 = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::027434742980:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/clickstream/*"},{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::114774131450:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/clickstream/*"}]}';
 
 
 describe('S3 bucket policy test', () => {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. [**backend**] Add api for dashboards.
2. [**frontend**] Create dashboards && delete dashboards
3. [**frontend**] Embedding dashboard url parameters get from dashboard detail

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend