### PR TITLE
fix: support cors multi domain and wildcard in ingestion server

### DIFF
--- a/src/ingestion-server/server/images/nginx/config/docker-entrypoint.sh
+++ b/src/ingestion-server/server/images/nginx/config/docker-entrypoint.sh
@@ -43,7 +43,7 @@ sed -i "s#%%SERVER_ENDPOINT_PATH%%#$SERVER_ENDPOINT_PATH#g; \
 s#%%NGINX_WORKER_CONNECTIONS%%#$NGINX_WORKER_CONNECTIONS#g;" /etc/nginx/nginx.conf
 
 if [ -z "$SERVER_CORS_ORIGIN" ]; then
-    sed -i "/%%SERVER_CORS_ORIGIN%%/d" /etc/nginx/nginx.conf
+    sed -i "s/%%SERVER_CORS_ORIGIN%%/''/g" /etc/nginx/nginx.conf
 else
     sed -i "s#%%SERVER_CORS_ORIGIN%%#$SERVER_CORS_ORIGIN#g;" /etc/nginx/nginx.conf
 fi

--- a/src/ingestion-server/server/images/nginx/config/nginx.conf
+++ b/src/ingestion-server/server/images/nginx/config/nginx.conf
@@ -40,10 +40,12 @@ http {
             # limit_req_status 444;
 
             add_header Content-Type text/plain;
-            add_header 'Access-Control-Allow-Origin' '%%SERVER_CORS_ORIGIN%%';
-            add_header 'Access-Control-Allow-Credentials' 'true';
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+            if ($http_origin ~* (%%SERVER_CORS_ORIGIN%%)) {
+                add_header 'Access-Control-Allow-Origin' "$http_origin";
+                add_header 'Access-Control-Allow-Credentials' 'true';
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+                add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+            }
             add_header 'X-Request-ID' $request_id;
 
             proxy_set_header 'X_Uri'                   $request_uri;


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary
support cors multi domain and wildcard in ingestion server

## Implementation highlights

Change nginx conf to support cors multi domain and wildcard in ingestion server.
The following is the table of UI input, supported cors domains and ingestion stack input parameter(ServerCorsOrigin)


UI Input | Valid domains | Input stack string
-- | -- | --
https://example.com | https://example.com | "https://example\.com“
http://example.com | http://example.com | "http://example\.com“
http://\*example\*.com | http://xxxexamplexxx.com, http://example.com | "http://.\*example.\*\\.com“
https://\*example\*.com | https://xxxexamplexxx.com, https://example.com | "https://.\*example.\*\\.com“
http://example.com,https://abc.com | http://example.com, https://abc.com | "http://example\.com\|https://abc\.com"
http://localhost | http://localhost:xxxx | "http://localhost“
http://127.0.0.1 | http://127.0.0.1:xxxx | "http://127.0.0.1“
|* | Any domain | ".*"

 


## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [x] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [x] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend