### PR TITLE
fix: can not update endpoint path in some cases

### DIFF
--- a/src/ingestion-server/custom-resource/update-alb-rules.ts
+++ b/src/ingestion-server/custom-resource/update-alb-rules.ts
@@ -77,6 +77,7 @@ function createUpdateAlbRulesLambda(scope: Construct, listenerArn: string, authe
         'elasticloadbalancing:DescribeRules',
         'elasticloadbalancing:CreateRule',
         'elasticloadbalancing:DeleteRule',
+        'elasticloadbalancing:ModifyRule',
       ],
       resources: ['*'],
     }),


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary
close #128 
Fix the issue of unable to updating endpoint path in ALB rule.

## Implementation highlights

1. Update update alb rules lambda to cover endpoint path updating.
2. Add unit test cases
3. Test below cases:
- Just update endpoint path from /collect to /g/collect 
- Update appIds from "notepad1,notepad2" to "notepad3,notepad2,notepad4", endpoint path from /g/collect to /collectnew
- Update appIds from "notepad3,notepad2,notepad4" to "notepad3", without changing endpoint path

## Test checklist

- [x] add new test cases
- [x] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [x] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [x] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend