### PR TITLE
fix: Add stack cors pattern to check ServerCorsOrigin parameter of ingestion server stack

### DIFF
--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -235,6 +235,11 @@ export const SCHEDULE_EXPRESSION_PATTERN =
 export const CORS_ORIGIN_DOMAIN_PATTERN = '(?:\\*\\.)?[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+\\.?';
 export const CORS_ORIGIN = `(https?:\\/\\/){1}(localhost|${IP_PATTERN}|${CORS_ORIGIN_DOMAIN_PATTERN})(:[0-9]{2,5})?`;
 export const CORS_PATTERN = `^$|^\\*$|^(${CORS_ORIGIN}(,\\s*${CORS_ORIGIN})*)$`;
+
+export const STACK_CORS_ORIGIN_DOMAIN_PATTERN = '(?:\\.\\*\\\\.)?[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\\\\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+\\.?';
+export const STACK_CORS_ORIGIN = `(https?:\\/\\/){1}(localhost|${IP_PATTERN}|${STACK_CORS_ORIGIN_DOMAIN_PATTERN})(:[0-9]{2,5})?`;
+export const STACK_CORS_PATTERN = `^$|^(\\.\\*)$|^(${STACK_CORS_ORIGIN}(\\|${STACK_CORS_ORIGIN})*)$`;
+
 export const XSS_PATTERN = '<(?:"[^"]*"[\'"]*|\'[^\']*\'[\'"]*|[^\'">])+(?<!/\s*)>';
 export const REGION_PATTERN = '[a-z]{2}-[a-z0-9]{1,10}-[0-9]{1}';
 export const EMR_VERSION_PATTERN='^emr-[0-9]+\\.[0-9]+\\.[0-9]+$';

--- a/src/control-plane/backend/lambda/api/test/api/utils.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/utils.test.ts
@@ -27,6 +27,7 @@ import {
   S3_PATH_PLUGIN_FILES_PATTERN,
   SECRETS_MANAGER_ARN_PATTERN,
   CORS_PATTERN,
+  STACK_CORS_PATTERN,
 } from '../../common/constants-ln';
 import { validateDataProcessingInterval, validatePattern, validateSinkBatch, validateXSS } from '../../common/stack-params-valid';
 import { ClickStreamBadRequestError, PipelineSinkType } from '../../common/types';
@@ -319,6 +320,64 @@ describe('Utils test', () => {
       'http://example*.com',
     ];
     invalidValues.forEach(v => expect(() => validatePattern('CORS origin', CORS_PATTERN, v)).toThrow(ClickStreamBadRequestError));
+  });
+
+  it('Input Ingestion stack of mutil CORS origin valid ', async () => {
+    const validValues = [
+      '.*',
+      'http://127.0.0.1',
+      'http://127.0.0.1:8081',
+      'http://192.168.120.204',
+      'http://.*\\.example\\.com',
+      'http://localhost',
+      'https://localhost',
+      'http://example\\.com',
+      'https://example\\.com',
+      'http://example\\.com:80',
+      'https://example\\.com:80',
+      'http://localhost:8080',
+      'https://localhost:8080',
+      'http://localhost|http://example\\.com',
+      'http://localhost|http://example\\.com',
+      'http://localhost:8080|http://example\\.com:80',
+      'http://127.0.0.1:8081|http://localhost:8080',
+      'http://localhost|https://example\\.com',
+      'http://abc1\\.test\\.com|http://abc2\\.test\\.com|http://abc3\\.test\\.com',
+      'http://abc1\\.test\\.com|http://abc2\\.test\\.com',
+    ];
+    validValues.forEach(v => expect(validatePattern('CORS origin', STACK_CORS_PATTERN, v)).toEqual(true));
+    const invalidValues = [
+      ' ',
+      '*',
+      ' example.com',
+      '&example.com',
+      'localhost1',
+      '127.0.0.1',
+      '127.0.0.1:8081',
+      '192.168.120.204',
+      'http:/localhost',
+      'http:/localhost:9',
+      'http:/example.com:100000',
+      'a',
+      'abc1.test.com; abc2.test.com',
+      '*,abc.com',
+      '*.example.com',
+      'http://*.example.com',
+      'https://*.example.com',
+      'https://.*.example.com',
+      'https://.*\\.example.com',
+      'localhost',
+      'example.com',
+      'example.com:80',
+      'localhost,example.com',
+      'localhost, example.com',
+      'localhost:8080,example.com:80',
+      'abc1.test.com, abc2.test.com, abc3.test.com',
+      'http://abc1.test.com,abc2.test.com',
+      'http://*example*.com',
+      'http://example*.com',
+    ];
+    invalidValues.forEach(v => expect(() => validatePattern('CORS origin', STACK_CORS_PATTERN, v)).toThrow(ClickStreamBadRequestError));
   });
 
   it('Mutil CORS origin cover to stack input', async () => {

--- a/src/ingestion-server/server/parameter.ts
+++ b/src/ingestion-server/server/parameter.ts
@@ -25,7 +25,7 @@ import {
 } from '../../common/constant';
 
 import { Parameters, SubnetParameterType } from '../../common/parameters';
-import { CORS_PATTERN } from '../../control-plane/backend/lambda/api/common/constants-ln';
+import { STACK_CORS_PATTERN } from '../../control-plane/backend/lambda/api/common/constants-ln';
 
 export function createStackParameters(scope: Construct, props: {deliverToKinesis: boolean; deliverToKafka: boolean; deliverToS3: boolean}) {
   // CfnParameter
@@ -71,8 +71,8 @@ export function createStackParameters(scope: Construct, props: {deliverToKinesis
     description: 'Server CORS origin',
     type: 'String',
     default: '',
-    allowedPattern: CORS_PATTERN,
-    constraintDescription: `ServerCorsOrigin must match pattern ${CORS_PATTERN}`,
+    allowedPattern: STACK_CORS_PATTERN,
+    constraintDescription: `ServerCorsOrigin must match pattern ${STACK_CORS_PATTERN}`,
   });
 
   const protocolParam = new CfnParameter(scope, 'Protocol', {

--- a/test/ingestion-server/server/ingestion-server-stack.test.ts
+++ b/test/ingestion-server/server/ingestion-server-stack.test.ts
@@ -206,12 +206,11 @@ test('ServerCorsOrigin pattern', () => {
     const pattern = param.AllowedPattern;
     const regex = new RegExp(`${pattern}`);
     const validValues = [
-      '',
-      '*',
-      'http://*.test.com',
-      'http://abc.test.com',
-      'http://abc1.test.com, http://abc2.test.com, http://abc3.test.com',
-      'http://abc1.test.com,http://abc2.test.com',
+      '.*',
+      'http://.*\\.test\\.com',
+      'http://abc\\.test\\.com',
+      'http://abc1\\.test\\.com|http://abc2\\.test\\.com|http://abc3\\.test\\.com',
+      'http://abc1\\.test\\.com|http://abc2\\.test\\.com',
     ];
 
     for (const v of validValues) {


### PR DESCRIPTION
…on server stack


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Add stack cors pattern to check ServerCorsOrigin parameter of ingestion server stack

## Implementation highlights

1. Add stack cors pattern to check ServerCorsOrigin parameter of ingestion server stack
2. Add Unit test cases
3. Verify below input from Ingestion stack:

- .*
- ''
- http://abc1\.test\.com|http://abc2\.test\.com|https://abc3\.test\.com|http://localhost|http://127.0.0.1|http://.*\.example\.com
- http://localhost:8002

## Test checklist

- [x] add new test cases
- [x] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [x] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [x] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend