### PR TITLE
fix: fix domain name pattern

### DIFF
--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -195,7 +195,7 @@ export const SUBNETS_PATTERN = 'subnet-[a-f0-9]+,(subnet-[a-f0-9]+,?)+';
 export const SECURITY_GROUP_PATTERN = 'sg-[a-f0-9]+';
 export const MUTIL_SECURITY_GROUP_PATTERN = `${SECURITY_GROUP_PATTERN}(,${SECURITY_GROUP_PATTERN})*`;
 export const DOMAIN_NAME_PATTERN =
-  '[a-z0-9A-Z#$&@_%~\\*\\.\\-]+\\.[a-zA-Z0-9]{2,6}';
+  '[a-z0-9A-Z#$&@_%~\\*\\.\\-]+\\.[a-zA-Z]{2,63}';
 export const IP_PATTERN =
   '((2(5[0-5]|[0-4]\\d))|[0-1]?\\d{1,2})(\\.((2(5[0-5]|[0-4]\\d))|[0-1]?\\d{1,2})){3}';
 export const HOST_ZONE_ID_PATTERN = '^Z[A-Z0-9]+$';

--- a/src/control-plane/backend/lambda/api/test/api/utils.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/utils.test.ts
@@ -133,6 +133,7 @@ describe('Utils test', () => {
   it('Domain Name valid', async () => {
     const validValues = [
       'fake.example.com',
+      'test.immobilien',
       'example.com',
     ];
 

--- a/test/ingestion-server/server/ingestion-server-stack.test.ts
+++ b/test/ingestion-server/server/ingestion-server-stack.test.ts
@@ -149,6 +149,9 @@ test('domainName pattern', () => {
     const validValues = [
       'abc.com',
       'test.abc.com',
+      'example.services',
+      'test.example.graphics',
+      '123.test.clickstream.management',
       '123.test.abc.com',
       'a123#~&%.test-2.a_bc.com',
     ];


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

fix domain name pattern

## Implementation highlights

fix domain name pattern to match TLD standard
Deploy ingestion stack as below DomainName parameter:

DomainName: example.services
DomainName: cs-3.us1.xxx.xxx.solutions.aws.a2z.org.cn

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [x] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [x] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend