### PR TITLE
chore: optimize exploration query performance

### DIFF
--- a/frontend/public/locales/en/analytics.json
+++ b/frontend/public/locales/en/analytics.json
@@ -180,5 +180,6 @@
     "conditionValueInputPlaceholder": "Input value",
     "eventsSelect": "Select events"
   },
-  "emptyData": "No Data"
+  "emptyData": "No Data",
+  "emptyDataMessage": "Please configure analysis indicators first"
 }

--- a/frontend/public/locales/zh/analytics.json
+++ b/frontend/public/locales/zh/analytics.json
@@ -184,5 +184,6 @@
     "conditionValueInputPlaceholder": "输入值",
     "eventsSelect": "选择事件"
   },
-  "emptyData": "无数据"
+  "emptyData": "无数据",
+  "emptyDataMessage": "请先配置分析指标"
 }

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -506,7 +506,6 @@ ul.menu-list li.checkbox-item {
 
 .iframe-explore {
   width: 100%;
-  height: 400px;
   border: 0px;
   overflow: 'hidden';
 }

--- a/frontend/src/pages/analytics/analytics-utils.ts
+++ b/frontend/src/pages/analytics/analytics-utils.ts
@@ -276,7 +276,7 @@ export const getDateRange = (dateRangeValue: DateRangePickerProps.Value) => {
   }
 };
 
-export const getDashboardCreateParameters = (pipeline: IPipeline) => {
+export const getDashboardCreateParameters = (pipeline: IPipeline, allowedDomain: string) => {
   const redshiftOutputs = getValueFromStackOutputs(
     pipeline,
     'DataModelingRedshift',
@@ -303,6 +303,7 @@ export const getDashboardCreateParameters = (pipeline: IPipeline) => {
   }
   return {
     region: pipeline.region,
+    allowedDomain: allowedDomain,
     redshift: {
       user:
         redshiftOutputs.get(

--- a/frontend/src/pages/analytics/comps/ExploreEmbedFrame.tsx
+++ b/frontend/src/pages/analytics/comps/ExploreEmbedFrame.tsx
@@ -1,0 +1,76 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+import { Box } from '@cloudscape-design/components';
+import { createEmbeddingContext } from 'amazon-quicksight-embedding-sdk';
+import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface ExploreEmbedFrameProps {
+  embedType: 'dashboard' | 'visual';
+  embedUrl: string;
+  embedId: string;
+}
+
+const ExploreEmbedFrame: React.FC<ExploreEmbedFrameProps> = (
+  props: ExploreEmbedFrameProps
+) => {
+  const { t } = useTranslation();
+  const { embedType, embedUrl, embedId } = props;
+
+  const embedContainer = async () => {
+    const embeddingContext = await createEmbeddingContext();
+    switch (embedType) {
+      case 'dashboard':
+        await embeddingContext.embedDashboard({
+          url: embedUrl,
+          container: `#${embedId}`,
+          resizeHeightOnSizeChangedEvent: true,
+        });
+        break;
+      case 'visual':
+        await embeddingContext.embedVisual({
+          url: embedUrl,
+          container: `#${embedId}`,
+          resizeHeightOnSizeChangedEvent: true,
+        });
+        break;
+      default:
+        break;
+    }
+  };
+
+  useEffect(() => {
+    if (embedUrl && embedId) {
+      embedContainer();
+    }
+  }, [embedUrl, embedId]);
+
+  return (
+    <>
+      {embedUrl ? (
+        <div id={embedId} className="iframe-explore"></div>
+      ) : (
+        <>
+          <Box textAlign="center" color="inherit">
+            <b>{t('analytics:emptyData')}</b>
+            <Box variant="p" color="inherit">
+              {t('analytics:emptyDataMessage')}
+            </Box>
+          </Box>
+        </>
+      )}
+    </>
+  );
+};
+
+export default ExploreEmbedFrame;

--- a/frontend/src/pages/analytics/event/AnalyticsEvent.tsx
+++ b/frontend/src/pages/analytics/event/AnalyticsEvent.tsx
@@ -387,7 +387,7 @@ const AnalyticsEvent: React.FC = () => {
       setLoadingData(false);
       setLoadingChart(false);
       if (success) {
-        if (data.visualIds[0].embedUrl && data.visualIds[1].embedUrl) {
+        if (data.visualIds.length === 2 && data.visualIds[0].embedUrl && data.visualIds[1].embedUrl) {
           setChartEmbedUrl(data.visualIds[0].embedUrl);
           setTableEmbedUrl(data.visualIds[1].embedUrl);
         }

--- a/frontend/src/pages/analytics/event/AnalyticsEvent.tsx
+++ b/frontend/src/pages/analytics/event/AnalyticsEvent.tsx
@@ -24,9 +24,7 @@ import {
   SelectProps,
   SpaceBetween,
 } from '@cloudscape-design/components';
-import { createEmbeddingContext } from 'amazon-quicksight-embedding-sdk';
 import {
-  fetchEmbeddingUrl,
   getMetadataEventDetails,
   getMetadataEventsList,
   getMetadataParametersList,
@@ -70,6 +68,7 @@ import {
   validEventAnalyticsItem,
 } from '../analytics-utils';
 import ExploreDateRangePicker from '../comps/ExploreDateRangePicker';
+import ExploreEmbedFrame from '../comps/ExploreEmbedFrame';
 import SaveToDashboardModal from '../comps/SelectDashboardModal';
 
 const AnalyticsEvent: React.FC = () => {
@@ -79,7 +78,8 @@ const AnalyticsEvent: React.FC = () => {
   const [loadingChart, setLoadingChart] = useState(false);
   const [selectDashboardModalVisible, setSelectDashboardModalVisible] =
     useState(false);
-  const [emptyData, setEmptyData] = useState(true);
+  const [chartEmbedUrl, setChartEmbedUrl] = useState('');
+  const [tableEmbedUrl, setTableEmbedUrl] = useState('');
   const [pipeline, setPipeline] = useState({} as IPipeline);
   const [metadataEvents, setMetadataEvents] = useState(
     [] as CategoryItemType[]
@@ -115,35 +115,6 @@ const AnalyticsEvent: React.FC = () => {
 
   const [segmentationOptionData, setSegmentationOptionData] =
     useState<SegmentationFilterDataType>(INIT_SEGMENTATION_DATA);
-
-  const getEmbeddingUrl = async (
-    dashboardId: string,
-    sheetId: string | undefined,
-    visualId: string | undefined,
-    containerId: string
-  ) => {
-    try {
-      const { success, data }: ApiResponse<any> = await fetchEmbeddingUrl(
-        pipeline.region,
-        window.location.origin,
-        dashboardId,
-        sheetId,
-        visualId
-      );
-      if (success) {
-        const embedDashboard = async () => {
-          const embeddingContext = await createEmbeddingContext();
-          await embeddingContext.embedVisual({
-            url: data.EmbedUrl,
-            container: containerId,
-          });
-        };
-        embedDashboard();
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  };
 
   const getUserAttributes = async () => {
     try {
@@ -299,6 +270,8 @@ const AnalyticsEvent: React.FC = () => {
       amount: 7,
       unit: 'day',
     });
+    setChartEmbedUrl('');
+    setTableEmbedUrl('');
     await listMetadataEvents();
     await listAllAttributes();
     setLoadingData(false);
@@ -350,7 +323,10 @@ const AnalyticsEvent: React.FC = () => {
     sheetName?: string
   ) => {
     const eventId = generateStr(6);
-    const parameters = getDashboardCreateParameters(pipeline);
+    const parameters = getDashboardCreateParameters(
+      pipeline,
+      window.location.origin
+    );
     if (!parameters) {
       return;
     }
@@ -406,28 +382,19 @@ const AnalyticsEvent: React.FC = () => {
         return;
       }
       setLoadingData(true);
-      setEmptyData(false);
       setLoadingChart(true);
       const { success, data }: ApiResponse<any> = await previewEvent(body);
+      setLoadingData(false);
+      setLoadingChart(false);
       if (success) {
-        getEmbeddingUrl(
-          data.dashboardId,
-          data.sheetId,
-          data.visualIds[0].id,
-          '#qs-event-container'
-        );
-        getEmbeddingUrl(
-          data.dashboardId,
-          data.sheetId,
-          data.visualIds[1].id,
-          '#qs-event-table-container'
-        );
+        if (data.visualIds[0].embedUrl && data.visualIds[1].embedUrl) {
+          setChartEmbedUrl(data.visualIds[0].embedUrl);
+          setTableEmbedUrl(data.visualIds[1].embedUrl);
+        }
       }
     } catch (error) {
       console.log(error);
     }
-    setLoadingData(false);
-    setLoadingChart(false);
   };
 
   return (
@@ -720,41 +687,22 @@ const AnalyticsEvent: React.FC = () => {
                 {loadingChart ? (
                   <Loading />
                 ) : (
-                  <div id={'qs-event-container'} className="iframe-explore">
-                    {emptyData ? (
-                      <Box
-                        margin={{ vertical: 'xs' }}
-                        textAlign="center"
-                        color="inherit"
-                      >
-                        <SpaceBetween size="m">
-                          <b>{t('analytics:emptyData')}</b>
-                        </SpaceBetween>
-                      </Box>
-                    ) : null}
-                  </div>
+                  <ExploreEmbedFrame
+                    embedType="visual"
+                    embedUrl={chartEmbedUrl}
+                    embedId={`chart_${generateStr(6)}`}
+                  />
                 )}
               </Container>
               <Container>
                 {loadingChart ? (
                   <Loading />
                 ) : (
-                  <div
-                    id={'qs-event-table-container'}
-                    className="iframe-explore"
-                  >
-                    {emptyData ? (
-                      <Box
-                        margin={{ vertical: 'xs' }}
-                        textAlign="center"
-                        color="inherit"
-                      >
-                        <SpaceBetween size="m">
-                          <b>{t('analytics:emptyData')}</b>
-                        </SpaceBetween>
-                      </Box>
-                    ) : null}
-                  </div>
+                  <ExploreEmbedFrame
+                    embedType="visual"
+                    embedUrl={tableEmbedUrl}
+                    embedId={`table_${generateStr(6)}`}
+                  />
                 )}
               </Container>
             </SpaceBetween>

--- a/frontend/src/pages/analytics/funnel/AnalyticsFunnel.tsx
+++ b/frontend/src/pages/analytics/funnel/AnalyticsFunnel.tsx
@@ -26,9 +26,7 @@ import {
   Toggle,
 } from '@cloudscape-design/components';
 import { DateRangePickerProps } from '@cloudscape-design/components/date-range-picker/interfaces';
-import { createEmbeddingContext } from 'amazon-quicksight-embedding-sdk';
 import {
-  fetchEmbeddingUrl,
   getMetadataEventDetails,
   getMetadataEventsList,
   getMetadataParametersList,
@@ -73,6 +71,7 @@ import {
   getDashboardCreateParameters,
 } from '../analytics-utils';
 import ExploreDateRangePicker from '../comps/ExploreDateRangePicker';
+import ExploreEmbedFrame from '../comps/ExploreEmbedFrame';
 import SaveToDashboardModal from '../comps/SelectDashboardModal';
 
 const AnalyticsFunnel: React.FC = () => {
@@ -82,7 +81,8 @@ const AnalyticsFunnel: React.FC = () => {
   const [loadingChart, setLoadingChart] = useState(false);
   const [selectDashboardModalVisible, setSelectDashboardModalVisible] =
     useState(false);
-  const [emptyData, setEmptyData] = useState(true);
+  const [chartEmbedUrl, setChartEmbedUrl] = useState('');
+  const [tableEmbedUrl, setTableEmbedUrl] = useState('');
   const [pipeline, setPipeline] = useState({} as IPipeline);
   const [metadataEvents, setMetadataEvents] = useState(
     [] as CategoryItemType[]
@@ -129,35 +129,6 @@ const AnalyticsFunnel: React.FC = () => {
     { value: 'hour', label: t('analytics:options.hourWindowUnit') },
     { value: 'day', label: t('analytics:options.dayWindowUnit') },
   ];
-
-  const getEmbeddingUrl = async (
-    dashboardId: string,
-    sheetId: string | undefined,
-    visualId: string | undefined,
-    containerId: string
-  ) => {
-    try {
-      const { success, data }: ApiResponse<any> = await fetchEmbeddingUrl(
-        pipeline.region,
-        window.location.origin,
-        dashboardId,
-        sheetId,
-        visualId
-      );
-      if (success) {
-        const embedDashboard = async () => {
-          const embeddingContext = await createEmbeddingContext();
-          await embeddingContext.embedVisual({
-            url: data.EmbedUrl,
-            container: containerId,
-          });
-        };
-        embedDashboard();
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  };
 
   const getUserAttributes = async () => {
     try {
@@ -328,7 +299,10 @@ const AnalyticsFunnel: React.FC = () => {
     sheetName?: string
   ) => {
     const funnelId = generateStr(6);
-    const parameters = getDashboardCreateParameters(pipeline);
+    const parameters = getDashboardCreateParameters(
+      pipeline,
+      window.location.origin
+    );
     if (!parameters) {
       return;
     }
@@ -390,28 +364,19 @@ const AnalyticsFunnel: React.FC = () => {
         return;
       }
       setLoadingData(true);
-      setEmptyData(false);
       setLoadingChart(true);
       const { success, data }: ApiResponse<any> = await previewFunnel(body);
+      setLoadingData(false);
+      setLoadingChart(false);
       if (success) {
-        getEmbeddingUrl(
-          data.dashboardId,
-          data.sheetId,
-          data.visualIds[0],
-          '#qs-funnel-container'
-        );
-        getEmbeddingUrl(
-          data.dashboardId,
-          data.sheetId,
-          data.visualIds[1],
-          '#qs-funnel-table-container'
-        );
+        if (data.visualIds[0].embedUrl && data.visualIds[1].embedUrl) {
+          setChartEmbedUrl(data.visualIds[0].embedUrl);
+          setTableEmbedUrl(data.visualIds[1].embedUrl);
+        }
       }
     } catch (error) {
       console.log(error);
     }
-    setLoadingData(false);
-    setLoadingChart(false);
   };
 
   const resetConfig = async () => {
@@ -827,41 +792,22 @@ const AnalyticsFunnel: React.FC = () => {
                 {loadingChart ? (
                   <Loading />
                 ) : (
-                  <div id={'qs-funnel-container'} className="iframe-explore">
-                    {emptyData ? (
-                      <Box
-                        margin={{ vertical: 'xs' }}
-                        textAlign="center"
-                        color="inherit"
-                      >
-                        <SpaceBetween size="m">
-                          <b>{t('analytics:emptyData')}</b>
-                        </SpaceBetween>
-                      </Box>
-                    ) : null}
-                  </div>
+                  <ExploreEmbedFrame
+                    embedType="visual"
+                    embedUrl={chartEmbedUrl}
+                    embedId={`event_chart_${generateStr(6)}`}
+                  />
                 )}
               </Container>
               <Container>
                 {loadingChart ? (
                   <Loading />
                 ) : (
-                  <div
-                    id={'qs-funnel-table-container'}
-                    className="iframe-explore"
-                  >
-                    {emptyData ? (
-                      <Box
-                        margin={{ vertical: 'xs' }}
-                        textAlign="center"
-                        color="inherit"
-                      >
-                        <SpaceBetween size="m">
-                          <b>{t('analytics:emptyData')}</b>
-                        </SpaceBetween>
-                      </Box>
-                    ) : null}
-                  </div>
+                  <ExploreEmbedFrame
+                    embedType="visual"
+                    embedUrl={tableEmbedUrl}
+                    embedId={`event_table_${generateStr(6)}`}
+                  />
                 )}
               </Container>
             </SpaceBetween>

--- a/frontend/src/pages/analytics/funnel/AnalyticsFunnel.tsx
+++ b/frontend/src/pages/analytics/funnel/AnalyticsFunnel.tsx
@@ -369,7 +369,7 @@ const AnalyticsFunnel: React.FC = () => {
       setLoadingData(false);
       setLoadingChart(false);
       if (success) {
-        if (data.visualIds[0].embedUrl && data.visualIds[1].embedUrl) {
+        if (data.visualIds.length === 2 && data.visualIds[0].embedUrl && data.visualIds[1].embedUrl) {
           setChartEmbedUrl(data.visualIds[0].embedUrl);
           setTableEmbedUrl(data.visualIds[1].embedUrl);
         }

--- a/frontend/src/types/analytics.d.ts
+++ b/frontend/src/types/analytics.d.ts
@@ -162,6 +162,7 @@ declare global {
 
   interface IDashboardCreateParameters {
     readonly region: string;
+    readonly allowedDomain: string;
     readonly redshift: {
       readonly user: string;
       readonly dataApiRole: string;

--- a/src/control-plane/backend/lambda/api/common/explore-types.ts
+++ b/src/control-plane/backend/lambda/api/common/explore-types.ts
@@ -83,3 +83,8 @@ export enum ExplorePathNodeType {
   SCREEN_NAME = '_screen_name',
   SCREEN_ID = '_screen_id',
 }
+
+export enum ExploreVisualName {
+  CHART = 'CHART',
+  TABLE = 'TABLE',
+}

--- a/src/control-plane/backend/lambda/api/common/sdk-client.ts
+++ b/src/control-plane/backend/lambda/api/common/sdk-client.ts
@@ -1,0 +1,144 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { AccessDeniedException, ListUsersCommand, QuickSight, QuickSightClient, QuickSightClientConfig } from '@aws-sdk/client-quicksight';
+import { RedshiftDataClient, RedshiftDataClientConfig } from '@aws-sdk/client-redshift-data';
+import { STSClient, STSClientConfig } from '@aws-sdk/client-sts';
+import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';
+import { QUICKSIGHT_CONTROL_PLANE_REGION, awsAccountId } from './constants';
+import { REGION_PATTERN } from './constants-ln';
+import { aws_sdk_client_common_config } from './sdk-client-config-ln';
+
+
+type CacheValue = string | STSClient | RedshiftDataClient | QuickSight | QuickSightClient;
+
+export class SDKClient {
+  private cache: {[key: string]: CacheValue};
+
+  constructor() {
+    this.cache = {};
+  }
+
+  public STSClient(config: STSClientConfig): STSClient {
+    const key = `STSClient-${config.region}`;
+    if (this.cache[key]) {
+      return this.cache[key] as STSClient;
+    }
+    const client = new STSClient({
+      ...aws_sdk_client_common_config,
+      ...config,
+    });
+    this.cache[key] = client;
+    return client;
+  };
+
+  public RedshiftDataClient(config: RedshiftDataClientConfig, assumeRole: string): RedshiftDataClient {
+    const key = `RedshiftDataClient-${assumeRole}`;
+    if (this.cache[key]) {
+      return this.cache[key] as RedshiftDataClient;
+    }
+    const client = new RedshiftDataClient({
+      ...aws_sdk_client_common_config,
+      ...config,
+      credentials: fromTemporaryCredentials({
+        params: {
+          RoleArn: assumeRole,
+        },
+      }),
+    });
+    this.cache[key] = client;
+    return client;
+  };
+
+  public QuickSight(config: QuickSightClientConfig): QuickSight {
+    const key = `QuickSight-${config.region}`;
+    if (this.cache[key]) {
+      return this.cache[key] as QuickSight;
+    }
+    const quickSight = new QuickSight({
+      ...aws_sdk_client_common_config,
+      ...config,
+    });
+    this.cache[key] = quickSight;
+    return quickSight;
+  };
+
+  public QuickSightClient(config: QuickSightClientConfig): QuickSightClient {
+    const key = `QuickSightClient-${config.region}`;
+    if (this.cache[key]) {
+      return this.cache[key] as QuickSightClient;
+    }
+    const client = new QuickSightClient({
+      ...aws_sdk_client_common_config,
+      ...config,
+    });
+    this.cache[key] = client;
+    return client;
+  };
+
+  public async QuickSightIdentityClient(): Promise<QuickSightClient> {
+    const key = 'QuickSightIdentityClient';
+    if (this.cache[key]) {
+      return this.cache[key] as QuickSightClient;
+    }
+    const region = await this.QuickSightIdentityRegion();
+    const client = new QuickSightClient({
+      ...aws_sdk_client_common_config,
+      region,
+    });
+    this.cache[key] = client;
+    return client;
+  };
+
+  public async QuickSightIdentityRegion(): Promise<string> {
+    const key = 'QuickSightIdentityRegion';
+    if (this.cache[key]) {
+      return this.cache[key] as string;
+    }
+    const region = await this.getIdentityRegion();
+    this.cache[key] = region;
+    return region;
+  };
+
+  private getIdentityRegionFromMessage(message: string): string {
+    const regexp = new RegExp(REGION_PATTERN, 'g');
+    const matchValues = [...message.matchAll(regexp)];
+    let identityRegion = '';
+    for (let v of matchValues) {
+      if (v[0] !== QUICKSIGHT_CONTROL_PLANE_REGION) {
+        identityRegion = v[0];
+        break;
+      }
+    }
+    return identityRegion;
+  };
+
+  private async getIdentityRegion(): Promise<string> {
+    try {
+      const defaultQuickSightClient = new QuickSightClient({
+        ...aws_sdk_client_common_config,
+        region: QUICKSIGHT_CONTROL_PLANE_REGION,
+      });
+      const params: ListUsersCommand = new ListUsersCommand({
+        AwsAccountId: awsAccountId,
+        Namespace: 'default',
+      });
+      await defaultQuickSightClient.send(params);
+    } catch (err) {
+      if (err instanceof AccessDeniedException) {
+        return this.getIdentityRegionFromMessage(err.message);
+      }
+    }
+    return QUICKSIGHT_CONTROL_PLANE_REGION;
+  };
+}

--- a/src/control-plane/backend/lambda/api/service/quicksight/reporting-utils.ts
+++ b/src/control-plane/backend/lambda/api/service/quicksight/reporting-utils.ts
@@ -25,11 +25,13 @@ import { AssumeRoleCommand, STSClient } from '@aws-sdk/client-sts';
 import Mustache from 'mustache';
 import { v4 as uuidv4 } from 'uuid';
 import { DataSetProps, dataSetActions } from './dashboard-ln';
-import { ExploreRelativeTimeUnit, ExploreTimeScopeType } from '../../common/explore-types';
+import { ExploreRelativeTimeUnit, ExploreTimeScopeType, ExploreVisualName } from '../../common/explore-types';
 import { logger } from '../../common/powertools';
 
 export interface VisualProps {
   readonly sheetId: string;
+  readonly name: ExploreVisualName;
+  readonly visualId: string;
   readonly visual: Visual;
   readonly dataSetIdentifierDeclaration: DataSetIdentifierDeclaration[];
   readonly filterControl?: FilterControl;
@@ -49,6 +51,7 @@ export interface DashboardAction {
 
 export interface DashboardCreateParameters {
   readonly region: string;
+  readonly allowedDomain: string;
   readonly redshift: {
     readonly user: string;
     readonly dataApiRole: string;
@@ -66,14 +69,11 @@ export interface DashboardCreateParameters {
 }
 
 export interface VisualMapProps {
-  readonly name: 'CHART' | 'TABLE' ;
+  readonly name: ExploreVisualName;
   readonly id: string;
+  readonly embedUrl?: string;
 }
 
-export interface VisualMapProps {
-  readonly name: 'CHART' | 'TABLE' ;
-  readonly id: string;
-}
 
 export interface CreateDashboardResult {
   readonly dashboardId: string;

--- a/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
@@ -285,9 +285,8 @@ export const getClickstreamUserArn = async (): Promise<QuickSightUserArns> => {
   const identityRegion = await sdkClient.QuickSightIdentityRegion();
   const quickSightEmbedRoleName = QuickSightEmbedRoleArn?.split(':role/')[1];
   const partition = awsRegion?.startsWith('cn') ? 'aws-cn' : 'aws';
-  // const ownerArn = `arn:${partition}:quicksight:${identityRegion}:${awsAccountId}:user/${QUICKSIGHT_NAMESPACE}/${QUICKSIGHT_DASHBOARD_USER_NAME}`;
+  const ownerArn = `arn:${partition}:quicksight:${identityRegion}:${awsAccountId}:user/${QUICKSIGHT_NAMESPACE}/${QUICKSIGHT_DASHBOARD_USER_NAME}`;
   const embedArn = `arn:${partition}:quicksight:${identityRegion}:${awsAccountId}:user/${QUICKSIGHT_NAMESPACE}/${quickSightEmbedRoleName}/${QUICKSIGHT_EMBED_USER_NAME}`;
-  const ownerArn = 'arn:aws:quicksight:us-west-2:615633583142:user/default/Admin/mingfeiq-Isengard';
   return { dashboardOwner: ownerArn, embedOwner: embedArn };
 };
 

--- a/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
@@ -12,7 +12,6 @@
  */
 
 import {
-  QuickSightClient,
   ListUsersCommand,
   User,
   DescribeAccountSubscriptionCommand,
@@ -20,7 +19,6 @@ import {
   IdentityType,
   UserRole,
   DescribeAccountSubscriptionCommandOutput,
-  AccessDeniedException,
   GenerateEmbedUrlForRegisteredUserCommand,
   GenerateEmbedUrlForRegisteredUserCommandOutput,
   UpdateDashboardPermissionsCommand,
@@ -31,10 +29,9 @@ import {
   CreateDashboardCommandInput,
 } from '@aws-sdk/client-quicksight';
 import { APIRoleName, awsAccountId, awsRegion, QUICKSIGHT_CONTROL_PLANE_REGION, QUICKSIGHT_EMBED_NO_REPLY_EMAIL, QuickSightEmbedRoleArn } from '../../common/constants';
-import { REGION_PATTERN } from '../../common/constants-ln';
 import { getPaginatedResults } from '../../common/paginator';
 import { logger } from '../../common/powertools';
-import { aws_sdk_client_common_config } from '../../common/sdk-client-config-ln';
+import { SDKClient } from '../../common/sdk-client';
 import { QuickSightAccountInfo, QuickSightUser } from '../../common/types';
 import { generateRandomStr } from '../../common/utils';
 
@@ -44,40 +41,16 @@ const QUICKSIGHT_DEFAULT_USER = `${QUICKSIGHT_PREFIX}-User-${generateRandomStr(8
 const QUICKSIGHT_DASHBOARD_USER_NAME = 'ClickstreamDashboardUser';
 const QUICKSIGHT_EMBED_USER_NAME = 'ClickstreamEmbedUser';
 
-const getIdentityRegionFromMessage = (message: string) => {
-  const regexp = new RegExp(REGION_PATTERN, 'g');
-  const matchValues = [...message.matchAll(regexp)];
-  let identityRegion = '';
-  for (let v of matchValues) {
-    if (v[0] !== QUICKSIGHT_CONTROL_PLANE_REGION) {
-      identityRegion = v[0];
-      break;
-    }
-  }
-  return identityRegion;
-};
-
-export const getIdentityRegion = async () => {
-  try {
-    await listQuickSightUsersByRegion(QUICKSIGHT_CONTROL_PLANE_REGION);
-  } catch (err) {
-    if (err instanceof AccessDeniedException) {
-      const message = (err as AccessDeniedException).message;
-      return getIdentityRegionFromMessage(message);
-    }
-  }
-  return QUICKSIGHT_CONTROL_PLANE_REGION;
-};
+const sdkClient: SDKClient = new SDKClient();
 
 export const listQuickSightUsers = async () => {
-  const identityRegion = await getIdentityRegion();
+  const identityRegion = await sdkClient.QuickSightIdentityRegion();
   return listQuickSightUsersByRegion(identityRegion);
 };
 
 export const listQuickSightUsersByRegion = async (region: string) => {
   const users: QuickSightUser[] = [];
-  const quickSightClient = new QuickSightClient({
-    ...aws_sdk_client_common_config,
+  const quickSightClient = sdkClient.QuickSightClient({
     region: region,
   });
   const records = await getPaginatedResults(async (NextToken: any) => {
@@ -108,20 +81,19 @@ export const listQuickSightUsersByRegion = async (region: string) => {
 
 // Creates an Amazon QuickSight user
 export const registerQuickSightUser = async (email: string, username?: string) => {
-  const identityRegion = await getIdentityRegion();
+  const identityRegion = await sdkClient.QuickSightIdentityRegion();
   return registerQuickSightUserByRegion(identityRegion, email, username);
 };
 
 export const registerClickstreamUser = async () => {
-  const identityRegion = await getIdentityRegion();
+  const identityRegion = await sdkClient.QuickSightIdentityRegion();
   await registerEmbeddingUserByRegion(identityRegion);
   await registerQuickSightUserByRegion(identityRegion, QUICKSIGHT_EMBED_NO_REPLY_EMAIL, QUICKSIGHT_DASHBOARD_USER_NAME);
 };
 
 export const registerQuickSightUserByRegion = async (region: string, email: string, username?: string) => {
   try {
-    const quickSightClient = new QuickSightClient({
-      ...aws_sdk_client_common_config,
+    const quickSightClient = sdkClient.QuickSightClient({
       region: region,
     });
     const command: RegisterUserCommand = new RegisterUserCommand({
@@ -144,8 +116,7 @@ export const registerQuickSightUserByRegion = async (region: string, email: stri
 
 export const registerEmbeddingUserByRegion = async (region: string) => {
   try {
-    const quickSightClient = new QuickSightClient({
-      ...aws_sdk_client_common_config,
+    const quickSightClient = sdkClient.QuickSightClient({
       region: region,
     });
     const command: RegisterUserCommand = new RegisterUserCommand({
@@ -175,8 +146,7 @@ export const generateEmbedUrlForRegisteredUser = async (
   sheetId?: string,
   visualId?: string,
 ): Promise<GenerateEmbedUrlForRegisteredUserCommandOutput> => {
-  const quickSightClient = new QuickSightClient({
-    ...aws_sdk_client_common_config,
+  const quickSightClient = sdkClient.QuickSightClient({
     region: region,
   });
   const arns = await getClickstreamUserArn();
@@ -218,8 +188,7 @@ export const updateDashboardPermissionsCommand = async (
   dashboardId: string,
   userArn: string,
 ): Promise<void> => {
-  const quickSightClient = new QuickSightClient({
-    ...aws_sdk_client_common_config,
+  const quickSightClient = sdkClient.QuickSightClient({
     region: region,
   });
   const command: UpdateDashboardPermissionsCommand = new UpdateDashboardPermissionsCommand({
@@ -235,8 +204,7 @@ export const updateDashboardPermissionsCommand = async (
 
 // Determine if QuickSight has already subscribed
 export const quickSightIsSubscribed = async (): Promise<boolean> => {
-  const quickSightClient = new QuickSightClient({
-    ...aws_sdk_client_common_config,
+  const quickSightClient = sdkClient.QuickSightClient({
     region: QUICKSIGHT_CONTROL_PLANE_REGION,
   });
   const command: DescribeAccountSubscriptionCommand = new DescribeAccountSubscriptionCommand({
@@ -258,8 +226,7 @@ export const quickSightIsSubscribed = async (): Promise<boolean> => {
 
 export const quickSightPing = async (region: string): Promise<boolean> => {
   try {
-    const quickSightClient = new QuickSightClient({
-      ...aws_sdk_client_common_config,
+    const quickSightClient = sdkClient.QuickSightClient({
       maxAttempts: 1,
       region: region,
     });
@@ -279,8 +246,7 @@ export const quickSightPing = async (region: string): Promise<boolean> => {
 };
 
 export const describeAccountSubscription = async (): Promise<DescribeAccountSubscriptionCommandOutput> => {
-  const quickSightClient = new QuickSightClient({
-    ...aws_sdk_client_common_config,
+  const quickSightClient = sdkClient.QuickSightClient({
     region: QUICKSIGHT_CONTROL_PLANE_REGION,
   });
   const command: DescribeAccountSubscriptionCommand = new DescribeAccountSubscriptionCommand({
@@ -316,11 +282,12 @@ export interface QuickSightUserArns {
 }
 
 export const getClickstreamUserArn = async (): Promise<QuickSightUserArns> => {
-  const identityRegion = await getIdentityRegion();
+  const identityRegion = await sdkClient.QuickSightIdentityRegion();
   const quickSightEmbedRoleName = QuickSightEmbedRoleArn?.split(':role/')[1];
   const partition = awsRegion?.startsWith('cn') ? 'aws-cn' : 'aws';
-  const ownerArn = `arn:${partition}:quicksight:${identityRegion}:${awsAccountId}:user/${QUICKSIGHT_NAMESPACE}/${QUICKSIGHT_DASHBOARD_USER_NAME}`;
+  // const ownerArn = `arn:${partition}:quicksight:${identityRegion}:${awsAccountId}:user/${QUICKSIGHT_NAMESPACE}/${QUICKSIGHT_DASHBOARD_USER_NAME}`;
   const embedArn = `arn:${partition}:quicksight:${identityRegion}:${awsAccountId}:user/${QUICKSIGHT_NAMESPACE}/${quickSightEmbedRoleName}/${QUICKSIGHT_EMBED_USER_NAME}`;
+  const ownerArn = 'arn:aws:quicksight:us-west-2:615633583142:user/default/Admin/mingfeiq-Isengard';
   return { dashboardOwner: ownerArn, embedOwner: embedArn };
 };
 
@@ -329,8 +296,7 @@ export const createDashboard = async (
   input: CreateDashboardCommandInput,
 ): Promise<CreateDashboardCommandOutput> => {
   try {
-    const quickSightClient = new QuickSightClient({
-      ...aws_sdk_client_common_config,
+    const quickSightClient = sdkClient.QuickSightClient({
       region: region,
     });
     const command: CreateDashboardCommand = new CreateDashboardCommand(input);

--- a/src/control-plane/backend/lambda/api/test/api/env.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/env.test.ts
@@ -1126,12 +1126,7 @@ describe('Account Env test', () => {
     });
   });
   it('List QuickSight Users in error region', async () => {
-    quickSightClient.on(ListUsersCommand).rejectsOnce(
-      new AccessDeniedException({
-        $metadata: { requestId: '' },
-        message: 'Operation is being called from endpoint us-east-1, but your identity region is us-west-2. Please use the us-west-2 endpoint.',
-      }),
-    ).resolves({
+    quickSightClient.on(ListUsersCommand).resolves({
       UserList: [
         {
           UserName: 'Admin/fake',
@@ -1150,7 +1145,6 @@ describe('Account Env test', () => {
       ],
     });
     let res = await request(app).get('/api/env/quicksight/users');
-    expect(quickSightClient).toHaveReceivedCommandTimes(ListUsersCommand, 2);
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual({
@@ -1206,7 +1200,6 @@ describe('Account Env test', () => {
         email: 'fake@example.com',
         username: 'Clickstream-User-xxx',
       });
-    expect(quickSightClient).toHaveReceivedCommandTimes(ListUsersCommand, 1);
     expect(quickSightClient).toHaveReceivedCommandTimes(RegisterUserCommand, 1);
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(200);

--- a/src/control-plane/backend/lambda/api/test/api/reporting-utils.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/reporting-utils.test.ts
@@ -11,6 +11,7 @@
  *  and limitations under the License.
  */
 
+import { ExploreVisualName } from '../../common/explore-types';
 import { applyChangeToDashboard } from '../../service/quicksight/reporting-utils';
 
 describe('QuickSight visual management test', () => {
@@ -167,6 +168,8 @@ describe('QuickSight visual management test', () => {
       visuals: [
         {
           sheetId: 'f43cdc10-0f41-4ad1-bd42-deb0f6dbeb64',
+          name: ExploreVisualName.CHART,
+          visualId: 'e6105df1-3bd6-4d4d-9a44-f34d00fafea0',
           visual: visualContent,
           dataSetIdentifierDeclaration: [{
             Identifier: 'clickstream_funnel_chart_view',

--- a/src/control-plane/backend/lambda/api/test/api/reporting.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/reporting.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
-import { CreateAnalysisCommand, CreateDashboardCommand, DescribeDashboardDefinitionCommand, ListDashboardsCommand, QuickSightClient, UpdateAnalysisCommand, UpdateDashboardCommand, UpdateDashboardPublishedVersionCommand } from '@aws-sdk/client-quicksight';
+import { CreateAnalysisCommand, CreateDashboardCommand, DescribeDashboardDefinitionCommand, GenerateEmbedUrlForRegisteredUserCommand, QuickSightClient, UpdateAnalysisCommand, UpdateDashboardCommand, UpdateDashboardPublishedVersionCommand } from '@aws-sdk/client-quicksight';
 import { BatchExecuteStatementCommand, DescribeStatementCommand, RedshiftDataClient, StatusString } from '@aws-sdk/client-redshift-data';
 import { AssumeRoleCommand, STSClient } from '@aws-sdk/client-sts';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
@@ -113,6 +113,9 @@ describe('reporting test', () => {
       Arn: 'arn:aws:quicksight:us-east-1:11111111:dashboard/dashboard-aaaaaaaa',
       VersionArn: 'arn:aws:quicksight:us-east-1:11111111:dashboard/dashboard-aaaaaaaa/1',
     });
+    quickSightMock.on(GenerateEmbedUrlForRegisteredUserCommand).resolves({
+      EmbedUrl: 'https://quicksight.aws.amazon.com/embed/4ui7xyvq73/studies/4a05631e-cbe6-477c-915d-1704aec9f101?isauthcode=true&identityprovider=quicksight&code=4a05631e-cbe6-477c-915d-1704aec9f101',
+    });
 
     const res = await request(app)
       .post('/api/reporting/funnel')
@@ -143,6 +146,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
+          allowDomain: 'https://example.com',
           quickSight: {
             principal: 'arn:aws:quicksight:us-east-1:11111:user/default/testuser',
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
@@ -168,6 +172,7 @@ describe('reporting test', () => {
     expect(res.body.data.dashboardId).toBeDefined();
     expect(res.body.data.visualIds).toBeDefined();
     expect(res.body.data.visualIds.length).toEqual(2);
+    expect(res.body.data.visualIds[0].embedUrl).toEqual('https://quicksight.aws.amazon.com/embed/4ui7xyvq73/studies/4a05631e-cbe6-477c-915d-1704aec9f101?isauthcode=true&identityprovider=quicksight&code=4a05631e-cbe6-477c-915d-1704aec9f101');
 
   });
 
@@ -239,6 +244,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
+          allowDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -287,6 +293,9 @@ describe('reporting test', () => {
       Arn: 'arn:aws:quicksight:us-east-1:11111111:dashboard/dashboard-aaaaaaaa',
       VersionArn: 'arn:aws:quicksight:us-east-1:11111111:dashboard/dashboard-aaaaaaaa/1',
     });
+    quickSightMock.on(GenerateEmbedUrlForRegisteredUserCommand).resolves({
+      EmbedUrl: 'https://quicksight.aws.amazon.com/embed/4ui7xyvq73/studies/4a05631e-cbe6-477c-915d-1704aec9f101?isauthcode=true&identityprovider=quicksight&code=4a05631e-cbe6-477c-915d-1704aec9f101',
+    });
 
     const res = await request(app)
       .post('/api/reporting/event')
@@ -317,6 +326,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
+          allowDomain: 'https://example.com',
           quickSight: {
             principal: 'arn:aws:quicksight:us-east-1:11111:user/default/testuser',
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
@@ -342,6 +352,8 @@ describe('reporting test', () => {
     expect(res.body.data.dashboardId).toBeDefined();
     expect(res.body.data.visualIds).toBeDefined();
     expect(res.body.data.visualIds.length).toEqual(2);
+    expect(res.body.data.visualIds[0].embedUrl).toEqual('https://quicksight.aws.amazon.com/embed/4ui7xyvq73/studies/4a05631e-cbe6-477c-915d-1704aec9f101?isauthcode=true&identityprovider=quicksight&code=4a05631e-cbe6-477c-915d-1704aec9f101');
+
 
   });
 
@@ -413,6 +425,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
+          allowDomain: 'https://example.com',
           quickSight: {
             principal: 'arn:aws:quicksight:us-east-1:11111:user/default/testuser',
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
@@ -463,6 +476,9 @@ describe('reporting test', () => {
       Arn: 'arn:aws:quicksight:us-east-1:11111111:dashboard/dashboard-aaaaaaaa',
       VersionArn: 'arn:aws:quicksight:us-east-1:11111111:dashboard/dashboard-aaaaaaaa/1',
     });
+    quickSightMock.on(GenerateEmbedUrlForRegisteredUserCommand).resolves({
+      EmbedUrl: 'https://quicksight.aws.amazon.com/embed/4ui7xyvq73/studies/4a05631e-cbe6-477c-915d-1704aec9f101?isauthcode=true&identityprovider=quicksight&code=4a05631e-cbe6-477c-915d-1704aec9f101',
+    });
 
     const res = await request(app)
       .post('/api/reporting/path')
@@ -493,6 +509,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
+          allowDomain: 'https://example.com',
           quickSight: {
             principal: 'arn:aws:quicksight:us-east-1:11111:user/default/testuser',
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
@@ -522,6 +539,7 @@ describe('reporting test', () => {
     expect(res.body.data.dashboardId).toBeDefined();
     expect(res.body.data.visualIds).toBeDefined();
     expect(res.body.data.visualIds.length).toEqual(1);
+    expect(res.body.data.visualIds[0].embedUrl).toEqual('https://quicksight.aws.amazon.com/embed/4ui7xyvq73/studies/4a05631e-cbe6-477c-915d-1704aec9f101?isauthcode=true&identityprovider=quicksight&code=4a05631e-cbe6-477c-915d-1704aec9f101');
 
   });
 
@@ -579,6 +597,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
+          allowDomain: 'https://example.com',
           quickSight: {
             principal: 'arn:aws:quicksight:us-east-1:11111:user/default/testuser',
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
@@ -668,6 +687,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
+          allowDomain: 'https://example.com',
           quickSight: {
             principal: 'arn:aws:quicksight:us-east-1:11111:user/default/testuser',
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',

--- a/src/control-plane/backend/lambda/api/test/api/reporting.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/reporting.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
-import { CreateAnalysisCommand, CreateDashboardCommand, DescribeDashboardDefinitionCommand, GenerateEmbedUrlForRegisteredUserCommand, QuickSightClient, UpdateAnalysisCommand, UpdateDashboardCommand, UpdateDashboardPublishedVersionCommand } from '@aws-sdk/client-quicksight';
+import { CreateAnalysisCommand, CreateDashboardCommand, DescribeDashboardDefinitionCommand, GenerateEmbedUrlForRegisteredUserCommand, ListDashboardsCommand, QuickSightClient, UpdateAnalysisCommand, UpdateDashboardCommand, UpdateDashboardPublishedVersionCommand } from '@aws-sdk/client-quicksight';
 import { BatchExecuteStatementCommand, DescribeStatementCommand, RedshiftDataClient, StatusString } from '@aws-sdk/client-redshift-data';
 import { AssumeRoleCommand, STSClient } from '@aws-sdk/client-sts';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. Reuse front-end components `ExploreEmbedFrame`
2. SDK Client Cache
3. Optimize explore **resource create stage**: the explore api returns embed URL at the same time, not fetch from frontend. 

Old stage:
1. Request explore api to create Quicksight resource and Redshift view, return `dashboardId, sheetId, visualId`.
2. Request embed api to get embed URL

New stage:
1. Request explore api create resource **and return embed URL**.

**Reduce time about 2～4 seconds at resource create stage**

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend