### PR TITLE
fix: fail deploy ingestion stack with insufficient permission

### DIFF
--- a/src/control-plane/backend/stack-action-state-machine-construct.ts
+++ b/src/control-plane/backend/stack-action-state-machine-construct.ts
@@ -115,12 +115,14 @@ export class StackActionStateMachine extends Construct {
             'iam:ListPolicies',
             'iam:ListRoles',
             'iam:UpdateRoleDescription',
+            'iam:CreateServiceLinkedRole',
           ],
           resources: [
             `arn:${Aws.PARTITION}:iam::${Aws.ACCOUNT_ID}:role/Clickstream*`,
             `arn:${Aws.PARTITION}:iam::${Aws.ACCOUNT_ID}:policy/Clickstream*`,
             `arn:${Aws.PARTITION}:iam::${Aws.ACCOUNT_ID}:instance-profile/Clickstream*`,
             `arn:${Aws.PARTITION}:iam::${Aws.ACCOUNT_ID}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService`,
+            `arn:${Aws.PARTITION}:iam::${Aws.ACCOUNT_ID}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling`,
           ],
         }),
         // This list of actions is to ensure the call stack can be create/update/delete successfully.

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -724,6 +724,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
               'iam:ListPolicies',
               'iam:ListRoles',
               'iam:UpdateRoleDescription',
+              'iam:CreateServiceLinkedRole',
             ],
             Effect: 'Allow',
             Resource: [
@@ -788,6 +789,22 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
                       Ref: 'AWS::AccountId',
                     },
                     ':role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService',
+                  ],
+                ],
+              },
+              {
+                'Fn::Join': [
+                  '',
+                  [
+                    'arn:',
+                    {
+                      Ref: 'AWS::Partition',
+                    },
+                    ':iam::',
+                    {
+                      Ref: 'AWS::AccountId',
+                    },
+                    ':role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling',
                   ],
                 ],
               },


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

#226 

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend