### PR TITLE
feat: refactor user management with new spec

### DIFF
--- a/.viperlightignore
+++ b/.viperlightignore
@@ -99,7 +99,7 @@ src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:57
 src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:58
 src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:59
 src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:60
-src/control-plane/backend/lambda/api/common/constants.ts:65
+src/control-plane/backend/lambda/api/common/constants.ts:14
 
 [node-yarnoutdated]
 @types/node=16.18.36

--- a/.viperlightignore
+++ b/.viperlightignore
@@ -99,7 +99,7 @@ src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:57
 src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:58
 src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:59
 src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:60
-src/control-plane/backend/lambda/api/common/constants.ts:66
+src/control-plane/backend/lambda/api/common/constants.ts:65
 
 [node-yarnoutdated]
 @types/node=16.18.36

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -13,7 +13,8 @@
     "plugins": "Plugins",
     "createPlugin": "Create Plugin",
     "registerApp": "Register Application",
-    "alarms": "Alarms"
+    "alarms": "Alarms",
+    "users": "Users"
   },
   "nav": {
     "home": "Home",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -128,6 +128,7 @@
   },
   "button": {
     "cancel": "Cancel",
+    "settings": "Settings",
     "createProject": "Create Project",
     "createPipeline": "Create Pipeline",
     "remove": "Remove",

--- a/frontend/public/locales/en/user.json
+++ b/frontend/public/locales/en/user.json
@@ -17,7 +17,14 @@
     "createUserRole": "Role",
     "deleteTitle": "Delete User",
     "deleteTip1": "Are you sure you want to delete the user ",
-    "deleteTip2": " delete the user may result in the user being unable to log in."
+    "deleteTip2": " delete the user may result in the user being unable to log in.",
+    "userSetting": "User Setting",
+    "settingUserRoleJsonPath": "User Role Json Path",
+    "settingUserRoleJsonPathDesc": "Obtain user role or group information from id_token, for example: $.realm_access.roles",
+    "settingUserOperatorRoleNames": "Operator Role Names",
+    "settingUserOperatorRoleNamesDesc": "The roles in OIDC are mapped to operators in Click stream, with multiple role names separated by commas, for example: operator,others",
+    "settingUserAnalystRoleNames": "Analyst Role Names",
+    "settingUserAnalystRoleNamesDesc": "The roles in OIDC are mapped to analyst in Click stream, with multiple role names separated by commas, for example: analyst,others"
   },
   "options": {
     "admin": "Administrator",

--- a/frontend/public/locales/en/user.json
+++ b/frontend/public/locales/en/user.json
@@ -8,13 +8,25 @@
     "tableEmpty": "No users",
     "tableLoading": "Loading",
     "filteringAriaLabel": "Find users",
-    "filteringPlaceholder": "Find users"
+    "filteringPlaceholder": "Find users",
+    "createTitle": "Create user",
+    "createUserEmail": "Email",
+    "createUserEmailPlaceholder": "example@example.com",
+    "createUserName": "User name",
+    "createUserNamePlaceholder": "Input user name",
+    "createUserRole": "Role",
+    "deleteTitle": "Delete User",
+    "deleteTip1": "Are you sure you want to delete the user ",
+    "deleteTip2": " delete the user may result in the user being unable to log in."
   },
   "options": {
     "admin": "Administrator",
     "operator": "Operator",
     "analyst": "Analyst",
     "noIdentity": "NoIdentity"
+  },
+  "valid": {
+    "userEmailEmptyError": "Email can not be empty"
   },
   "emptyData": "No Data"
 }

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -13,7 +13,8 @@
     "plugins": "插件",
     "createPlugin": "创建插件",
     "registerApp": "注册应用程序",
-    "alarms": "告警"
+    "alarms": "告警",
+    "users": "用户"
   },
   "nav": {
     "home": "主页",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -127,6 +127,7 @@
   },
   "button": {
     "cancel": "取消",
+    "settings": "设置",
     "createProject": "创建项目",
     "createPipeline": "创建数据管道",
     "remove": "移除",

--- a/frontend/public/locales/zh/user.json
+++ b/frontend/public/locales/zh/user.json
@@ -8,13 +8,25 @@
     "tableEmpty": "没有用户",
     "tableLoading": "加载中",
     "filteringAriaLabel": "查找用户",
-    "filteringPlaceholder": "查找用户"
+    "filteringPlaceholder": "查找用户",
+    "createTitle": "创建用户",
+    "createUserEmail": "Email",
+    "createUserEmailPlaceholder": "example@example.com",
+    "createUserName": "用户名",
+    "createUserNamePlaceholder": "请输入用户名",
+    "createUserRole": "角色",
+    "deleteTitle": "删除用户",
+    "deleteTip1": "是否确实要删除该用户 ",
+    "deleteTip2": " 删除用户可能导致用户无法登录。"
   },
   "options": {
     "admin": "管理员",
     "operator": "IT运维",
     "analyst": "分析师",
     "noIdentity": "无身份"
+  },
+  "valid": {
+    "userEmailEmptyError": "电子邮件不能为空"
   },
   "emptyData": "没有数据"
 }

--- a/frontend/public/locales/zh/user.json
+++ b/frontend/public/locales/zh/user.json
@@ -17,7 +17,14 @@
     "createUserRole": "角色",
     "deleteTitle": "删除用户",
     "deleteTip1": "是否确实要删除该用户 ",
-    "deleteTip2": " 删除用户可能导致用户无法登录。"
+    "deleteTip2": " 删除用户可能导致用户无法登录。",
+    "userSetting": "用户设置",
+    "settingUserRoleJsonPath": "获取用户角色的JsonPath",
+    "settingUserRoleJsonPathDesc": "从id_token中获取用户角色或者组信息的JsonPath，例如：$.realm_access.roles",
+    "settingUserOperatorRoleNames": "操作员角色名称",
+    "settingUserOperatorRoleNamesDesc": "OIDC中的角色映射为Click stream中的操作员，多个角色名称用逗号分隔，例如：operator,operator2",
+    "settingUserAnalystRoleNames": "分析员角色名称",
+    "settingUserAnalystRoleNamesDesc": "OIDC中的角色映射为Click stream中的分析员，多个角色名称用逗号分隔，例如：analyst,analyst2"
   },
   "options": {
     "admin": "管理员",

--- a/frontend/src/apis/user.ts
+++ b/frontend/src/apis/user.ts
@@ -37,3 +37,13 @@ export const getUserDetails = async (uid: string) => {
   const result: any = await apiRequest('get', `/user/details?id=${uid}`);
   return result;
 };
+
+export const getUserSettings = async () => {
+  const result: any = await apiRequest('get', `/user/settings`);
+  return result;
+};
+
+export const updateUserSettings = async (userSettings: IUserSettings) => {
+  const result: any = await apiRequest('post', `/user/settings`, userSettings);
+  return result;
+};

--- a/frontend/src/apis/user.ts
+++ b/frontend/src/apis/user.ts
@@ -18,12 +18,22 @@ export const getAllUsers = async () => {
   return result;
 };
 
+export const addUser = async (user: IUser) => {
+  const result: any = await apiRequest('post', `/user`, user);
+  return result;
+};
+
 export const updateUser = async (user: IUser) => {
-  const result: any = await apiRequest('put', `/user/${user.uid}`, user);
+  const result: any = await apiRequest('put', `/user/${user.id}`, user);
+  return result;
+};
+
+export const deleteUser = async (uid: string) => {
+  const result: any = await apiRequest('delete', `/user/${uid}`);
   return result;
 };
 
 export const getUserDetails = async (uid: string) => {
-  const result: any = await apiRequest('get', `/user/details?uid=${uid}`);
+  const result: any = await apiRequest('get', `/user/details?id=${uid}`);
   return result;
 };

--- a/frontend/src/context/UserContext.ts
+++ b/frontend/src/context/UserContext.ts
@@ -14,9 +14,11 @@
 import { createContext } from 'react';
 import { IUserRole } from 'ts/const';
 export const UserContext = createContext<IUser | undefined>({
-  uid: '',
+  id: '',
+  type: 'USER',
+  prefix: 'USER',
   name: '',
-  role: IUserRole.OPERATOR,
+  role: IUserRole.NO_IDENTITY,
   createAt: 0,
   updateAt: 0,
   operator: '',

--- a/frontend/src/pages/user/CreateUser.tsx
+++ b/frontend/src/pages/user/CreateUser.tsx
@@ -1,0 +1,170 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import {
+  Box,
+  Button,
+  FormField,
+  Input,
+  Modal,
+  Select,
+  SelectProps,
+  SpaceBetween,
+} from '@cloudscape-design/components';
+import { addUser } from 'apis/user';
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { IUserRole } from 'ts/const';
+
+interface CreateUserProps {
+  openModel: boolean;
+  closeModel: () => void;
+  refreshPage: () => void;
+}
+
+const CreateUser: React.FC<CreateUserProps> = (props: CreateUserProps) => {
+  const { t } = useTranslation();
+  const { openModel, closeModel, refreshPage } = props;
+  const [loadingCreate, setLoadingCreate] = useState(false);
+  const [visible, setVisible] = useState(openModel);
+  const defaultUser = {
+    id: '',
+    name: '',
+    role: IUserRole.NO_IDENTITY,
+  } as IUser;
+  const [curUser, setCurUser] = useState<IUser>(defaultUser);
+
+  const [userEmailRequiredError, setUserEmailRequiredError] = useState(false);
+  const [roleOption, setRoleOption] = useState<SelectProps.Option | null>({
+    value: IUserRole.NO_IDENTITY,
+    label: t('user:options.noIdentity') ?? '',
+  });
+
+  const roleOptions: SelectProps.Options = [
+    { value: IUserRole.ADMIN, label: t('user:options.admin') ?? '' },
+    { value: IUserRole.OPERATOR, label: t('user:options.operator') ?? '' },
+    { value: IUserRole.ANALYST, label: t('user:options.analyst') ?? '' },
+    { value: IUserRole.NO_IDENTITY, label: t('user:options.noIdentity') ?? '' },
+  ];
+
+  useEffect(() => {
+    setUserEmailRequiredError(false);
+    setVisible(openModel);
+    setCurUser(defaultUser);
+  }, [openModel]);
+
+  const confirmCreateUser = async () => {
+    setLoadingCreate(true);
+    try {
+      const { success, data }: ApiResponse<ResponseCreate> = await addUser(
+        curUser
+      );
+      if (success && data.id) {
+        closeModel();
+        refreshPage();
+      }
+      setLoadingCreate(false);
+    } catch (error) {
+      setLoadingCreate(false);
+    }
+  };
+
+  return (
+    <Modal
+      onDismiss={() => {
+        closeModel();
+      }}
+      visible={visible}
+      footer={
+        <Box float="right">
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button
+              variant="link"
+              onClick={() => {
+                closeModel();
+              }}
+            >
+              {t('button.cancel')}
+            </Button>
+            <Button
+              loading={loadingCreate}
+              variant="primary"
+              onClick={() => {
+                if (!curUser.id.trim()) {
+                  setUserEmailRequiredError(true);
+                  return false;
+                }
+                confirmCreateUser();
+              }}
+            >
+              {t('button.create')}
+            </Button>
+          </SpaceBetween>
+        </Box>
+      }
+      header={t('user:labels.createTitle')}
+    >
+      <FormField
+        label={t('user:labels.createUserEmail')}
+        errorText={
+          userEmailRequiredError ? t('user:valid.userEmailEmptyError') : ''
+        }
+      >
+        <Input
+          placeholder={t('user:labels.createUserEmailPlaceholder') ?? ''}
+          value={curUser.id ?? ''}
+          onChange={(e) => {
+            setUserEmailRequiredError(false);
+            setCurUser((prev) => {
+              return {
+                ...prev,
+                id: e.detail.value,
+              };
+            });
+          }}
+        />
+      </FormField>
+      <FormField label={t('user:labels.createUserName')}>
+        <Input
+          placeholder={t('user:labels.createUserNamePlaceholder') ?? ''}
+          value={curUser.name ?? ''}
+          onChange={(e) => {
+            setCurUser((prev) => {
+              return {
+                ...prev,
+                name: e.detail.value,
+              };
+            });
+          }}
+        />
+      </FormField>
+      <FormField label={t('user:labels.createUserRole')}>
+        <Select
+          options={roleOptions}
+          onChange={(e) => {
+            setRoleOption(e.detail.selectedOption);
+            setCurUser((prev) => {
+              return {
+                ...prev,
+                role: e.detail.selectedOption.value as IUserRole,
+              };
+            });
+          }}
+          selectedOption={roleOption}
+        />
+      </FormField>
+    </Modal>
+  );
+};
+
+export default CreateUser;

--- a/frontend/src/pages/user/CreateUser.tsx
+++ b/frontend/src/pages/user/CreateUser.tsx
@@ -37,11 +37,17 @@ const CreateUser: React.FC<CreateUserProps> = (props: CreateUserProps) => {
   const { openModel, closeModel, refreshPage } = props;
   const [loadingCreate, setLoadingCreate] = useState(false);
   const [visible, setVisible] = useState(openModel);
-  const defaultUser = {
+  const defaultUser: IUser = {
     id: '',
+    type: 'USER',
+    prefix: 'USER',
     name: '',
     role: IUserRole.NO_IDENTITY,
-  } as IUser;
+    createAt: 0,
+    updateAt: 0,
+    operator: '',
+    deleted: false,
+  };
   const [curUser, setCurUser] = useState<IUser>(defaultUser);
 
   const [userEmailRequiredError, setUserEmailRequiredError] = useState(false);

--- a/frontend/src/pages/user/SettingUser.tsx
+++ b/frontend/src/pages/user/SettingUser.tsx
@@ -1,0 +1,159 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import {
+  Box,
+  Button,
+  FormField,
+  Input,
+  Modal,
+  SpaceBetween,
+} from '@cloudscape-design/components';
+import { getUserSettings, updateUserSettings } from 'apis/user';
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface SettingUserProps {
+  openModel: boolean;
+  closeModel: () => void;
+}
+
+const SettingUser: React.FC<SettingUserProps> = (props: SettingUserProps) => {
+  const { t } = useTranslation();
+  const { openModel, closeModel } = props;
+  const [loadingCreate, setLoadingCreate] = useState(false);
+  const defaultUserSetting = {
+    roleJsonPath: '',
+    operatorRoleNames: '',
+    analystRoleNames: '',
+  } as IUserSettings;
+  const [curUserSetting, setCurUserSetting] =
+    useState<IUserSettings>(defaultUserSetting);
+
+  useEffect(() => {
+    getSettingUser();
+  }, [openModel]);
+
+  const getSettingUser = async () => {
+    setLoadingCreate(true);
+    try {
+      const { success, data }: ApiResponse<IUserSettings> =
+        await getUserSettings();
+      if (success) {
+        setCurUserSetting(data);
+      }
+      setLoadingCreate(false);
+    } catch (error) {
+      setLoadingCreate(false);
+    }
+  };
+
+  const confirmSettingUser = async () => {
+    setLoadingCreate(true);
+    try {
+      const { success }: ApiResponse<ResponseCreate> = await updateUserSettings(
+        curUserSetting
+      );
+      if (success) {
+        closeModel();
+      }
+      setLoadingCreate(false);
+    } catch (error) {
+      setLoadingCreate(false);
+    }
+  };
+
+  return (
+    <Modal
+      onDismiss={() => {
+        closeModel();
+      }}
+      visible={openModel}
+      footer={
+        <Box float="right">
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button
+              variant="link"
+              onClick={() => {
+                closeModel();
+              }}
+            >
+              {t('button.cancel')}
+            </Button>
+            <Button
+              loading={loadingCreate}
+              variant="primary"
+              onClick={() => {
+                confirmSettingUser();
+              }}
+            >
+              {t('button.save')}
+            </Button>
+          </SpaceBetween>
+        </Box>
+      }
+      header={t('user:labels.userSetting')}
+    >
+      <FormField
+        label={t('user:labels.settingUserRoleJsonPath')}
+        description={t('user:labels.settingUserRoleJsonPathDesc')}
+      >
+        <Input
+          value={curUserSetting.roleJsonPath ?? ''}
+          onChange={(e) => {
+            setCurUserSetting((prev) => {
+              return {
+                ...prev,
+                roleJsonPath: e.detail.value,
+              };
+            });
+          }}
+        />
+      </FormField>
+      <FormField
+        label={t('user:labels.settingUserOperatorRoleNames')}
+        description={t('user:labels.settingUserOperatorRoleNamesDesc')}
+      >
+        <Input
+          value={curUserSetting.operatorRoleNames ?? ''}
+          onChange={(e) => {
+            setCurUserSetting((prev) => {
+              return {
+                ...prev,
+                operatorRoleNames: e.detail.value,
+              };
+            });
+          }}
+        />
+      </FormField>
+      <FormField
+        label={t('user:labels.settingUserAnalystRoleNames')}
+        description={t('user:labels.settingUserAnalystRoleNamesDesc')}
+      >
+        <Input
+          value={curUserSetting.analystRoleNames ?? ''}
+          onChange={(e) => {
+            setCurUserSetting((prev) => {
+              return {
+                ...prev,
+                analystRoleNames: e.detail.value,
+              };
+            });
+          }}
+        />
+      </FormField>
+    </Modal>
+  );
+};
+
+export default SettingUser;

--- a/frontend/src/pages/user/UserList.tsx
+++ b/frontend/src/pages/user/UserList.tsx
@@ -11,7 +11,12 @@
  *  and limitations under the License.
  */
 
-import { AppLayout, Input, Select } from '@cloudscape-design/components';
+import {
+  AppLayout,
+  Input,
+  Select,
+  SelectProps,
+} from '@cloudscape-design/components';
 import { getAllUsers, updateUser } from 'apis/user';
 import Navigation from 'components/layouts/Navigation';
 import moment from 'moment';
@@ -24,11 +29,11 @@ import UserTable from './UserTable';
 const UserList: React.FC = () => {
   const { t } = useTranslation();
 
-  const roleOptions = [
-    { value: IUserRole.ADMIN, label: t('user:options.admin') },
-    { value: IUserRole.OPERATOR, label: t('user:options.operator') },
-    { value: IUserRole.ANALYST, label: t('user:options.analyst') },
-    { value: IUserRole.NO_IDENTITY, label: t('user:options.noIdentity') },
+  const roleOptions: SelectProps.Options = [
+    { value: IUserRole.ADMIN, label: t('user:options.admin') ?? '' },
+    { value: IUserRole.OPERATOR, label: t('user:options.operator') ?? '' },
+    { value: IUserRole.ANALYST, label: t('user:options.analyst') ?? '' },
+    { value: IUserRole.NO_IDENTITY, label: t('user:options.noIdentity') ?? '' },
   ];
 
   const getRoleName = (role: string) => {
@@ -46,10 +51,10 @@ const UserList: React.FC = () => {
 
   const COLUMN_DEFINITIONS = [
     {
-      id: 'uid',
+      id: 'id',
       header: t('user:labels.tableColumnUserId'),
-      cell: (e: { uid: string }) => {
-        return e.uid;
+      cell: (e: { id: string }) => {
+        return e.id;
       },
     },
     {
@@ -87,7 +92,10 @@ const UserList: React.FC = () => {
       header: t('user:labels.tableColumnRole'),
       minWidth: 200,
       editConfig: {
-        editingCell: (item: { role: any }, { setValue, currentValue }: any) => {
+        editingCell: (
+          item: { role: IUserRole },
+          { setValue, currentValue }: any
+        ) => {
           return (
             <Select
               autoFocus={true}
@@ -98,7 +106,8 @@ const UserList: React.FC = () => {
               }}
               selectedOption={
                 roleOptions.find(
-                  (option) => option.value === (currentValue ?? item.role)
+                  (option: SelectProps.Option) =>
+                    option.value === (currentValue ?? item.role)
                 ) ?? roleOptions[0]
               }
             />
@@ -119,7 +128,7 @@ const UserList: React.FC = () => {
   ];
 
   const CONTENT_DISPLAY = [
-    { id: 'uid', visible: true },
+    { id: 'id', visible: true },
     { id: 'name', visible: true },
     { id: 'role', visible: true },
     { id: 'createAt', visible: true },
@@ -128,7 +137,7 @@ const UserList: React.FC = () => {
   const FILTERING_PROPERTIES = [
     {
       propertyLabel: t('user:labels.tableColumnUserId'),
-      key: 'uid',
+      key: 'id',
       groupValuesLabel: t('user:labels.tableColumnUserId'),
       operators: [':', '!:', '=', '!='],
     },

--- a/frontend/src/pages/user/UserList.tsx
+++ b/frontend/src/pages/user/UserList.tsx
@@ -18,6 +18,7 @@ import {
   SelectProps,
 } from '@cloudscape-design/components';
 import { getAllUsers, updateUser } from 'apis/user';
+import CustomBreadCrumb from 'components/layouts/CustomBreadCrumb';
 import Navigation from 'components/layouts/Navigation';
 import moment from 'moment';
 import React from 'react';
@@ -179,6 +180,17 @@ const UserList: React.FC = () => {
     }
   };
 
+  const breadcrumbItems = [
+    {
+      text: t('breadCrumb.name'),
+      href: '/',
+    },
+    {
+      text: t('breadCrumb.users'),
+      href: '/user',
+    },
+  ];
+
   return (
     <AppLayout
       toolsHide
@@ -206,6 +218,7 @@ const UserList: React.FC = () => {
         ></UserTable>
       }
       headerSelector="#header"
+      breadcrumbs={<CustomBreadCrumb breadcrumbItems={breadcrumbItems} />}
       navigation={<Navigation activeHref={'/user'} />}
     />
   );

--- a/frontend/src/pages/user/UserTable.tsx
+++ b/frontend/src/pages/user/UserTable.tsx
@@ -195,7 +195,7 @@ const UserTable: React.FC<UserTableProps> = (props: UserTableProps) => {
                 : `(${data.length})`
             }
             user={collectionProps.selectedItems?.[0]}
-            refreshPage={function (): void {
+            refreshPage={() => {
               collectionProps.selectedItems = [];
               fetchData();
             }}

--- a/frontend/src/pages/user/UserTable.tsx
+++ b/frontend/src/pages/user/UserTable.tsx
@@ -168,8 +168,8 @@ const UserTable: React.FC<UserTableProps> = (props: UserTableProps) => {
       <Table
         {...tableCollectionProps}
         variant="full-page"
-        stickyHeader={true}
         resizableColumns={true}
+        selectionType="single"
         loading={loadingData}
         items={itemsSnap.length > 0 ? itemsSnap : items}
         loadingText={tableI18nStrings.loadingText}
@@ -186,7 +186,6 @@ const UserTable: React.FC<UserTableProps> = (props: UserTableProps) => {
         }
         header={
           <UserTableHeader
-            title={tableI18nStrings.headerTitle}
             selectedItemsCount={collectionProps.selectedItems?.length ?? 0}
             counter={
               !loadingData &&
@@ -195,6 +194,14 @@ const UserTable: React.FC<UserTableProps> = (props: UserTableProps) => {
                 ? `(${collectionProps.selectedItems.length}/${data.length})`
                 : `(${data.length})`
             }
+            user={collectionProps.selectedItems?.[0]}
+            refreshPage={function (): void {
+              collectionProps.selectedItems = [];
+              fetchData();
+            }}
+            setSelectItemEmpty={() => {
+              collectionProps.selectedItems = [];
+            }}
           />
         }
         filter={

--- a/frontend/src/pages/user/UserTableHeader.tsx
+++ b/frontend/src/pages/user/UserTableHeader.tsx
@@ -22,6 +22,7 @@ import { deleteUser } from 'apis/user';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import CreateUser from './CreateUser';
+import SettingUser from './SettingUser';
 
 interface UserTableHeaderProps extends HeaderProps {
   selectedItemsCount: number;
@@ -39,6 +40,7 @@ export function UserTableHeader({
   const [loadingDelete, setLoadingDelete] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showSettingModal, setShowSettingModal] = useState(false);
 
   const confirmDeleteUser = async () => {
     setLoadingDelete(true);
@@ -62,6 +64,12 @@ export function UserTableHeader({
           setShowCreateModal(false);
         }}
         refreshPage={refreshPage}
+      />
+      <SettingUser
+        openModel={showSettingModal}
+        closeModel={() => {
+          setShowSettingModal(false);
+        }}
       />
       <Modal
         onDismiss={() => setShowDeleteModal(false)}
@@ -108,7 +116,7 @@ export function UserTableHeader({
             </Button>
             <Button
               onClick={() => {
-                console.log('setting');
+                setShowSettingModal(true);
               }}
               iconName="settings"
             >

--- a/frontend/src/pages/user/UserTableHeader.tsx
+++ b/frontend/src/pages/user/UserTableHeader.tsx
@@ -11,35 +11,124 @@
  *  and limitations under the License.
  */
 import {
+  Box,
+  Button,
   Header,
   HeaderProps,
+  Modal,
   SpaceBetween,
 } from '@cloudscape-design/components';
-import React from 'react';
+import { deleteUser } from 'apis/user';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import CreateUser from './CreateUser';
 
 interface UserTableHeaderProps extends HeaderProps {
-  title?: string;
-  extraActions?: React.ReactNode;
   selectedItemsCount: number;
+  user?: IUser;
+  refreshPage: () => void;
+  setSelectItemEmpty: () => void;
 }
 
 export function UserTableHeader({
-  title = '',
-  extraActions = null,
   selectedItemsCount,
   ...props
 }: UserTableHeaderProps) {
-  return (
-    <Header
-      variant="awsui-h1-sticky"
-      actions={
-        <SpaceBetween size="xs" direction="horizontal">
-          {extraActions}
-        </SpaceBetween>
+  const { t } = useTranslation();
+  const { user, refreshPage, setSelectItemEmpty } = props;
+  const [loadingDelete, setLoadingDelete] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showCreateModal, setShowCreateModal] = useState(false);
+
+  const confirmDeleteUser = async () => {
+    setLoadingDelete(true);
+    try {
+      const resData: ApiResponse<null> = await deleteUser(user?.id ?? '');
+      if (resData.success) {
+        refreshPage();
+        setLoadingDelete(false);
+        setShowDeleteModal(false);
+        setSelectItemEmpty();
       }
-      {...props}
-    >
-      {title}
-    </Header>
+    } catch (error) {
+      setLoadingDelete(false);
+    }
+  };
+  return (
+    <div>
+      <CreateUser
+        openModel={showCreateModal}
+        closeModel={() => {
+          setShowCreateModal(false);
+        }}
+        refreshPage={refreshPage}
+      />
+      <Modal
+        onDismiss={() => setShowDeleteModal(false)}
+        visible={showDeleteModal}
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button
+                onClick={() => {
+                  setShowDeleteModal(false);
+                }}
+                variant="link"
+              >
+                {t('button.cancel')}
+              </Button>
+              <Button
+                variant="primary"
+                onClick={() => {
+                  confirmDeleteUser();
+                }}
+                loading={loadingDelete}
+              >
+                {t('button.confirm')}
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+        header={t('user:labels.deleteTitle')}
+      >
+        {t('user:labels.deleteTip1')} <b>{user?.id}</b>,
+        {t('user:labels.deleteTip2')}
+      </Modal>
+      <Header
+        variant="awsui-h1-sticky"
+        actions={
+          <SpaceBetween size="xs" direction="horizontal">
+            <Button
+              disabled={!user?.id}
+              onClick={() => {
+                setShowDeleteModal(true);
+              }}
+            >
+              {t('button.delete')}
+            </Button>
+            <Button
+              onClick={() => {
+                console.log('setting');
+              }}
+              iconName="settings"
+            >
+              {t('button.settings')}
+            </Button>
+            <Button
+              variant="primary"
+              iconName="add-plus"
+              onClick={() => {
+                setShowCreateModal(true);
+              }}
+            >
+              {t('button.create')}
+            </Button>
+          </SpaceBetween>
+        }
+        {...props}
+      >
+        {t('user:labels.title')}
+      </Header>
+    </div>
   );
 }

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -28,4 +28,9 @@ declare global {
     readonly operator: string;
     readonly deleted: boolean;
   }
+  interface IUserSettings {
+    readonly roleJsonPath: string;
+    readonly operatorRoleNames: string;
+    readonly analystRoleNames: string;
+  }
 }

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -16,7 +16,9 @@ import { IUserRole } from 'ts/const';
 export {};
 declare global {
   interface IUser {
-    readonly uid: string;
+    readonly id: string;
+    readonly type: string;
+    readonly prefix: string;
 
     readonly name?: string;
     readonly role: IUserRole;

--- a/src/control-plane/backend/click-stream-api.ts
+++ b/src/control-plane/backend/click-stream-api.ts
@@ -172,17 +172,6 @@ export class ClickStreamApiConstruct extends Construct {
       },
     });
 
-    const userTable = new Table(this, 'ClickstreamUser', {
-      partitionKey: {
-        name: 'uid',
-        type: AttributeType.STRING,
-      },
-      billingMode: BillingMode.PAY_PER_REQUEST,
-      removalPolicy: RemovalPolicy.DESTROY,
-      pointInTimeRecovery: true,
-      encryption: TableEncryption.AWS_MANAGED,
-    });
-
     // Dictionary data init
     this.batchInsertDDBCustomResource = new BatchInsertDDBCustomResource(this, 'BatchInsertDDBCustomResource', {
       table: dictionaryTable,
@@ -193,7 +182,7 @@ export class ClickStreamApiConstruct extends Construct {
     // Add admin user
     this.addAdminUserCustomResource = new AddAdminUser(this, 'AddAdminUserCustomResource', {
       uid: props.adminUserEmail,
-      userTable: userTable,
+      userTable: clickStreamTable,
     });
 
     let apiFunctionProps = {};
@@ -385,7 +374,6 @@ export class ClickStreamApiConstruct extends Construct {
         AWS_LAMBDA_EXEC_WRAPPER: '/opt/bootstrap',
         CLICK_STREAM_TABLE_NAME: clickStreamTable.tableName,
         DICTIONARY_TABLE_NAME: dictionaryTable.tableName,
-        USER_TABLE_NAME: userTable.tableName,
         ANALYTICS_METADATA_TABLE_NAME: analyticsMetadataTable.tableName,
         STACK_ACTION_SATE_MACHINE: stackActionStateMachine.stateMachine.stateMachineArn,
         STACK_WORKFLOW_SATE_MACHINE: stackWorkflowStateMachine.stackWorkflowMachine.stateMachineArn,
@@ -414,7 +402,6 @@ export class ClickStreamApiConstruct extends Construct {
     dictionaryTable.grantReadWriteData(this.clickStreamApiFunction);
     clickStreamTable.grantReadWriteData(this.clickStreamApiFunction);
     analyticsMetadataTable.grantReadWriteData(this.clickStreamApiFunction);
-    userTable.grantReadWriteData(this.clickStreamApiFunction);
     if (props.authProps?.authorizerTable) {
       props.authProps?.authorizerTable.grantReadWriteData(this.clickStreamApiFunction);
     }

--- a/src/control-plane/backend/insert-admin-user.ts
+++ b/src/control-plane/backend/insert-admin-user.ts
@@ -37,7 +37,9 @@ export class AddAdminUser extends Construct {
       parameters: {
         TableName: props.userTable.tableName,
         Item: {
-          uid: { S: props.uid },
+          id: { S: props.uid },
+          type: { S: 'USER' },
+          prefix: { S: 'USER' },
           role: { S: 'Admin' },
           createAt: { N: Date.now().toString() },
           updateAt: { N: Date.now().toString() },
@@ -55,17 +57,20 @@ export class AddAdminUser extends Construct {
       parameters: {
         TableName: props.userTable.tableName,
         Key: {
-          uid: { S: props.uid },
+          id: { S: props.uid },
+          type: { S: 'USER' },
         },
-        UpdateExpression: 'SET #role = :role, #createAt = :createAt, #updateAt = :updateAt, #operator = :operator, #deleted = :deleted',
+        UpdateExpression: 'SET #role = :role, #prefix = :prefix, #createAt = :createAt, #updateAt = :updateAt, #operator = :operator, #deleted = :deleted',
         ExpressionAttributeNames: {
           '#role': 'role',
           '#createAt': 'createAt',
           '#updateAt': 'updateAt',
           '#operator': 'operator',
           '#deleted': 'deleted',
+          '#prefix': 'prefix',
         },
         ExpressionAttributeValues: {
+          ':prefix': { S: 'USER' },
           ':role': { S: 'Admin' },
           ':createAt': { N: Date.now().toString() },
           ':updateAt': { N: Date.now().toString() },
@@ -82,7 +87,8 @@ export class AddAdminUser extends Construct {
       parameters: {
         TableName: props.userTable.tableName,
         Key: {
-          uid: { S: props.uid },
+          id: { S: props.uid },
+          type: { S: 'USER' },
         },
         ConditionExpression: 'attribute_exists(uid)',
       },

--- a/src/control-plane/backend/lambda/api/common/constants.ts
+++ b/src/control-plane/backend/lambda/api/common/constants.ts
@@ -14,7 +14,6 @@
 // Get the DynamoDB table name from environment variables
 const clickStreamTableName = process.env.CLICK_STREAM_TABLE_NAME;
 const dictionaryTableName = process.env.DICTIONARY_TABLE_NAME;
-const userTableName = process.env.USER_TABLE_NAME;
 const analyticsMetadataTable = process.env.ANALYTICS_METADATA_TABLE_NAME;
 const stackActionStateMachineArn = process.env.STACK_ACTION_SATE_MACHINE;
 const stackWorkflowStateMachineArn = process.env.STACK_WORKFLOW_SATE_MACHINE;
@@ -68,7 +67,6 @@ const QUICKSIGHT_EMBED_NO_REPLY_EMAIL = 'quicksight-embedding-no-reply@amazon.co
 export {
   clickStreamTableName,
   dictionaryTableName,
-  userTableName,
   analyticsMetadataTable,
   stackActionStateMachineArn,
   stackWorkflowStateMachineArn,

--- a/src/control-plane/backend/lambda/api/common/constants.ts
+++ b/src/control-plane/backend/lambda/api/common/constants.ts
@@ -64,6 +64,10 @@ const PIPELINE_SUPPORTED_REGIONS = [
 
 const QUICKSIGHT_EMBED_NO_REPLY_EMAIL = 'quicksight-embedding-no-reply@amazon.com';
 
+const DEFAULT_ROLE_JSON_PATH = '$.payload.cognito:groups';
+const DEFAULT_OPERATOR_ROLE_NAMES = 'ClickstreamOperator';
+const DEFAULT_ANALYST_ROLE_NAMES = 'ClickstreamAnalyst';
+
 export {
   clickStreamTableName,
   dictionaryTableName,
@@ -87,4 +91,7 @@ export {
   PIPELINE_SUPPORTED_REGIONS,
   ALLOW_UPLOADED_FILE_TYPES,
   QUICKSIGHT_EMBED_NO_REPLY_EMAIL,
+  DEFAULT_ROLE_JSON_PATH,
+  DEFAULT_OPERATOR_ROLE_NAMES,
+  DEFAULT_ANALYST_ROLE_NAMES,
 };

--- a/src/control-plane/backend/lambda/api/common/constants.ts
+++ b/src/control-plane/backend/lambda/api/common/constants.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-// Get the DynamoDB table name from environment variables
+const QUICKSIGHT_EMBED_NO_REPLY_EMAIL = 'quicksight-embedding-no-reply@amazon.com';
 const clickStreamTableName = process.env.CLICK_STREAM_TABLE_NAME;
 const dictionaryTableName = process.env.DICTIONARY_TABLE_NAME;
 const analyticsMetadataTable = process.env.ANALYTICS_METADATA_TABLE_NAME;
@@ -61,8 +61,6 @@ const PIPELINE_SUPPORTED_REGIONS = [
   'cn-north-1',
   'cn-northwest-1',
 ];
-
-const QUICKSIGHT_EMBED_NO_REPLY_EMAIL = 'quicksight-embedding-no-reply@amazon.com';
 
 const DEFAULT_ROLE_JSON_PATH = '$.payload.cognito:groups';
 const DEFAULT_OPERATOR_ROLE_NAMES = 'ClickstreamOperator';

--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -186,8 +186,8 @@ function mapToRole(userSettings: IUserSettings, oidcRoles: string[]) {
   if (isEmpty(oidcRoles)) {
     return IUserRole.NO_IDENTITY;
   }
-  const operatorRoleNames = userSettings.operatorRoleNames.split(',');
-  const analystRoleNames = userSettings.analystRoleNames.split(',');
+  const operatorRoleNames = userSettings.operatorRoleNames.split(',').map(role => role.trim());
+  const analystRoleNames = userSettings.analystRoleNames.split(',').map(role => role.trim());
 
   if (oidcRoles.some(role => operatorRoleNames.includes(role)) && oidcRoles.some(role => analystRoleNames.includes(role))) {
     return IUserRole.ADMIN;

--- a/src/control-plane/backend/lambda/api/middle-ware/auth-role.ts
+++ b/src/control-plane/backend/lambda/api/middle-ware/auth-role.ts
@@ -15,7 +15,7 @@ import express from 'express';
 import { JwtPayload } from 'jsonwebtoken';
 import { logger } from '../common/powertools';
 import { ApiFail, IUserRole } from '../common/types';
-import { getTokenFromRequest, getUidFromTokenPayload } from '../common/utils';
+import { getRoleFromToken, getTokenFromRequest, getUidFromTokenPayload } from '../common/utils';
 import { ClickStreamStore } from '../store/click-stream-store';
 import { DynamoDbStore } from '../store/dynamodb/dynamodb-store';
 
@@ -82,6 +82,8 @@ export async function authRole(req: express.Request, res: express.Response, next
     let userRole = IUserRole.NO_IDENTITY;
     if (user && user.role) {
       userRole = user.role;
+    } else {
+      userRole = await getRoleFromToken(token);
     }
 
     const requestKey = `${req.method} ${req.path}`;

--- a/src/control-plane/backend/lambda/api/model/user.ts
+++ b/src/control-plane/backend/lambda/api/model/user.ts
@@ -14,7 +14,9 @@
 import { IUserRole } from '../common/types';
 
 export interface IUser {
-  readonly uid: string;
+  readonly id: string;
+  readonly type: string;
+  readonly prefix: string;
 
   readonly name?: string;
   readonly role: IUserRole;

--- a/src/control-plane/backend/lambda/api/model/user.ts
+++ b/src/control-plane/backend/lambda/api/model/user.ts
@@ -26,3 +26,9 @@ export interface IUser {
   readonly operator: string;
   readonly deleted: boolean;
 }
+
+export interface IUserSettings {
+  readonly roleJsonPath: string;
+  readonly operatorRoleNames: string;
+  readonly analystRoleNames: string;
+}

--- a/src/control-plane/backend/lambda/api/router/user.ts
+++ b/src/control-plane/backend/lambda/api/router/user.ts
@@ -60,6 +60,18 @@ router_user.delete(
     return userServ.delete(req, res, next);
   });
 
+router_user.get(
+  '/settings',
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return userServ.getSettings(req, res, next);
+  });
+
+router_user.post(
+  '/settings',
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return userServ.updateSettings(req, res, next);
+  });
+
 export {
   router_user,
 };

--- a/src/control-plane/backend/lambda/api/router/user.ts
+++ b/src/control-plane/backend/lambda/api/router/user.ts
@@ -43,18 +43,18 @@ router_user.get(
   });
 
 router_user.put(
-  '/:uid',
+  '/:id',
   validate([
-    body('uid').custom(isUserValid),
+    body('id').custom(isUserValid),
   ]),
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     return userServ.update(req, res, next);
   });
 
 router_user.delete(
-  '/:uid',
+  '/:id',
   validate([
-    param('uid').custom(isUserValid),
+    param('id').custom(isUserValid),
   ]),
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     return userServ.delete(req, res, next);

--- a/src/control-plane/backend/lambda/api/store/click-stream-store.ts
+++ b/src/control-plane/backend/lambda/api/store/click-stream-store.ts
@@ -61,6 +61,7 @@ export interface ClickStreamStore {
   deleteUser: (uid: string, operator: string) => Promise<void>;
 
   getDictionary: (name: string) => Promise<IDictionary | undefined>;
+  updateDictionary: (dictionary: IDictionary) => Promise<void>;
   listDictionary: () => Promise<IDictionary[]>;
 
   isRequestIdExisted: (id: string) => Promise<boolean>;

--- a/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-store.ts
+++ b/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-store.ts
@@ -766,6 +766,24 @@ export class DynamoDbStore implements ClickStreamStore {
     return result.Item as IDictionary;
   };
 
+  public async updateDictionary(dictionary: IDictionary): Promise<void> {
+    const params: UpdateCommand = new UpdateCommand({
+      TableName: dictionaryTableName,
+      Key: {
+        name: dictionary.name,
+      },
+      UpdateExpression: 'SET #data =:data',
+      ExpressionAttributeNames: {
+        '#data': 'data',
+      },
+      ExpressionAttributeValues: {
+        ':data': dictionary.data,
+      },
+      ReturnValues: 'ALL_NEW',
+    });
+    await docClient.send(params);
+  };
+
   public async listDictionary(): Promise<IDictionary[]> {
     const input: ScanCommandInput = {
       TableName: dictionaryTableName,

--- a/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-store.ts
+++ b/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-store.ts
@@ -21,9 +21,9 @@ import {
   QueryCommandInput,
 } from '@aws-sdk/lib-dynamodb';
 import { marshall } from '@aws-sdk/util-dynamodb';
-import { clickStreamTableName, dictionaryTableName, prefixTimeGSIName, userTableName } from '../../common/constants';
+import { clickStreamTableName, dictionaryTableName, prefixTimeGSIName } from '../../common/constants';
 import { docClient, marshallOptions, query, scan } from '../../common/dynamodb-client';
-import { IUserRole, KeyVal, PipelineStatusType } from '../../common/types';
+import { KeyVal, PipelineStatusType } from '../../common/types';
 import { isEmpty } from '../../common/utils';
 import { IApplication } from '../../model/application';
 import { IDictionary } from '../../model/dictionary';
@@ -1006,11 +1006,13 @@ export class DynamoDbStore implements ClickStreamStore {
 
   public async addUser(user: IUser): Promise<string> {
     const params: PutCommand = new PutCommand({
-      TableName: userTableName,
+      TableName: clickStreamTableName,
       Item: {
-        uid: user.uid,
+        id: user.id,
+        type: 'USER',
+        prefix: 'USER',
         name: user.name ?? '',
-        role: user.role ?? IUserRole.OPERATOR,
+        role: user.role,
         createAt: Date.now(),
         updateAt: Date.now(),
         operator: user.operator?? '',
@@ -1018,14 +1020,15 @@ export class DynamoDbStore implements ClickStreamStore {
       },
     });
     await docClient.send(params);
-    return user.uid;
+    return user.id;
   };
 
-  public async getUser(uid: string): Promise<IUser | undefined> {
+  public async getUser(id: string): Promise<IUser | undefined> {
     const params: GetCommand = new GetCommand({
-      TableName: userTableName,
+      TableName: clickStreamTableName,
       Key: {
-        uid: uid,
+        id: id,
+        type: 'USER',
       },
     });
     const result: GetCommandOutput = await docClient.send(params);
@@ -1055,9 +1058,10 @@ export class DynamoDbStore implements ClickStreamStore {
       expressionAttributeNames['#role'] = 'role';
     }
     const params: UpdateCommand = new UpdateCommand({
-      TableName: userTableName,
+      TableName: clickStreamTableName,
       Key: {
-        uid: user.uid,
+        id: user.id,
+        type: 'USER',
       },
       // Define expressions for the new or updated attributes
       UpdateExpression: updateExpression,
@@ -1069,22 +1073,29 @@ export class DynamoDbStore implements ClickStreamStore {
   };
 
   public async listUser(): Promise<IUser[]> {
-    const input: ScanCommandInput = {
-      TableName: userTableName,
+    const input: QueryCommandInput = {
+      TableName: clickStreamTableName,
+      IndexName: prefixTimeGSIName,
+      KeyConditionExpression: '#prefix= :prefix',
       FilterExpression: 'deleted = :d',
+      ExpressionAttributeNames: {
+        '#prefix': 'prefix',
+      },
       ExpressionAttributeValues: {
         ':d': false,
+        ':prefix': 'USER',
       },
     };
-    const records = await scan(input);
+    const records = await query(input);
     return records as IUser[];
   };
 
-  public async deleteUser(uid: string, operator: string): Promise<void> {
+  public async deleteUser(id: string, operator: string): Promise<void> {
     const params: UpdateCommand = new UpdateCommand({
-      TableName: userTableName,
+      TableName: clickStreamTableName,
       Key: {
-        uid: uid,
+        id: id,
+        type: 'USER',
       },
       // Define expressions for the new or updated attributes
       UpdateExpression: 'SET deleted= :d, #operator= :operator',

--- a/src/control-plane/backend/lambda/api/test/api/auth.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/auth.test.ts
@@ -193,6 +193,18 @@ describe('Validate role middleware test', () => {
     expect(ddbMock).toHaveReceivedCommandTimes(UpdateCommand, 0);
   });
 
+  it('User role is analyst in DDB and operator role map from token.', async () => {
+    userMock(ddbMock, 'fake@example.com', IUserRole.ANALYST, true);
+    const res = await request(app)
+      .get('/api/user/details?id=fake@example.com')
+      .set(amznRequestContextHeader, context);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.role).toEqual(IUserRole.ANALYST);
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 2);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(UpdateCommand, 0);
+  });
+
   it('User in DDB and group in token.', async () => {
     userMock(ddbMock, 'fake@example.com', IUserRole.ADMIN, true);
     const res = await request(app)

--- a/src/control-plane/backend/lambda/api/test/api/auth.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/auth.test.ts
@@ -17,7 +17,7 @@ import {
   DynamoDBDocumentClient,
   GetCommand,
   PutCommand,
-  ScanCommand,
+  QueryCommand,
   UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -84,7 +84,7 @@ describe('Validate role middleware test', () => {
 
   it('Validate right role with operator in request context.', async () => {
     userMock(ddbMock, 'fake@example.com', IUserRole.ADMIN, true);
-    ddbMock.on(ScanCommand).resolvesOnce({
+    ddbMock.on(QueryCommand).resolvesOnce({
       Items: [{
         uid: 'fake@example.com',
         role: IUserRole.ADMIN,
@@ -94,7 +94,7 @@ describe('Validate role middleware test', () => {
       .get('/api/user')
       .set(amznRequestContextHeader, context);
     expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
-    expect(ddbMock).toHaveReceivedCommandTimes(ScanCommand, 1);
+    expect(ddbMock).toHaveReceivedCommandTimes(QueryCommand, 1);
     expect(res.statusCode).toBe(200);
     expect(res.body.success).toEqual(true);
     expect(res.body.message).toEqual('');
@@ -109,7 +109,7 @@ describe('Validate role middleware test', () => {
     expect(res.body.success).toEqual(false);
     expect(res.body.message).toEqual('Insufficient permissions to access the API.');
     expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
-    expect(ddbMock).toHaveReceivedCommandTimes(ScanCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(QueryCommand, 0);
   });
 
   it('User not in DDB and no group in token.', async () => {

--- a/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
@@ -28,7 +28,7 @@ import { GetBucketPolicyCommand } from '@aws-sdk/client-s3';
 import { GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
 import { StartExecutionCommand } from '@aws-sdk/client-sfn';
 import { GetCommand, GetCommandInput, QueryCommand, QueryCommandInput } from '@aws-sdk/lib-dynamodb';
-import { analyticsMetadataTable, clickStreamTableName, dictionaryTableName, prefixTimeGSIName, userTableName } from '../../common/constants';
+import { analyticsMetadataTable, clickStreamTableName, dictionaryTableName, prefixTimeGSIName } from '../../common/constants';
 import { IUserRole, ProjectEnvironment } from '../../common/types';
 import { IPipeline } from '../../model/pipeline';
 
@@ -63,21 +63,23 @@ export const AllowIAMUserPutObejectPolicyInApSouthEast1 = '{"Version":"2012-10-1
 function userMock(ddbMock: any, userId: string, role: IUserRole, existed?: boolean): any {
   if (!existed) {
     return ddbMock.on(GetCommand, {
-      TableName: userTableName,
+      TableName: clickStreamTableName,
       Key: {
-        uid: userId,
+        id: userId,
+        type: 'USER',
       },
     }, true).resolves({});
   }
 
   return ddbMock.on(GetCommand, {
-    TableName: userTableName,
+    TableName: clickStreamTableName,
     Key: {
-      uid: userId,
+      id: userId,
+      type: 'USER',
     },
   }, true).resolves({
     Item: {
-      uid: userId,
+      id: userId,
       role: role,
       deleted: false,
     },

--- a/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
@@ -28,7 +28,7 @@ import { GetBucketPolicyCommand } from '@aws-sdk/client-s3';
 import { GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
 import { StartExecutionCommand } from '@aws-sdk/client-sfn';
 import { GetCommand, GetCommandInput, QueryCommand, QueryCommandInput } from '@aws-sdk/lib-dynamodb';
-import { analyticsMetadataTable, clickStreamTableName, dictionaryTableName, prefixTimeGSIName } from '../../common/constants';
+import { DEFAULT_ANALYST_ROLE_NAMES, DEFAULT_OPERATOR_ROLE_NAMES, DEFAULT_ROLE_JSON_PATH, analyticsMetadataTable, clickStreamTableName, dictionaryTableName, prefixTimeGSIName } from '../../common/constants';
 import { IUserRole, ProjectEnvironment } from '../../common/types';
 import { IPipeline } from '../../model/pipeline';
 
@@ -342,6 +342,23 @@ function dictionaryMock(ddbMock: any, name?: string): any {
           target: 'feature-rel/main',
           prefix: 'default/',
           version: MOCK_SOLUTION_VERSION,
+        },
+      },
+    });
+  }
+  if (!name || name === 'UserSettings') {
+    ddbMock.on(GetCommand, {
+      TableName: dictionaryTableName,
+      Key: {
+        name: 'UserSettings',
+      },
+    }).resolves({
+      Item: {
+        name: 'UserSettings',
+        data: {
+          roleJsonPath: DEFAULT_ROLE_JSON_PATH,
+          operatorRoleNames: DEFAULT_OPERATOR_ROLE_NAMES,
+          analystRoleNames: DEFAULT_ANALYST_ROLE_NAMES,
         },
       },
     });

--- a/src/control-plane/backend/lambda/api/test/api/user.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/user.test.ts
@@ -15,7 +15,7 @@ import {
   DynamoDBDocumentClient,
   GetCommand,
   PutCommand,
-  ScanCommand,
+  QueryCommand,
   UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -37,16 +37,16 @@ describe('User test', () => {
 
   it('List user', async () => {
     tokenMock(ddbMock, false);
-    ddbMock.on(ScanCommand).resolvesOnce({
+    ddbMock.on(QueryCommand).resolvesOnce({
       Items: [
         {
-          uid: 'uid-01',
+          id: 'uid-01',
           role: IUserRole.ADMIN,
           operator: 'operator-01',
           deleted: false,
         },
         {
-          uid: 'uid-02',
+          id: 'uid-02',
           role: IUserRole.OPERATOR,
           operator: 'operator-02',
           deleted: false,
@@ -57,8 +57,8 @@ describe('User test', () => {
       .get('/api/user');
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual({ data: { items: [{ deleted: false, operator: 'operator-01', role: 'Admin', uid: 'uid-01' }, { deleted: false, operator: 'operator-02', role: 'Operator', uid: 'uid-02' }], totalCount: 2 }, message: '', success: true });
-    expect(ddbMock).toHaveReceivedCommandTimes(ScanCommand, 1);
+    expect(res.body).toEqual({ data: { items: [{ deleted: false, operator: 'operator-01', role: 'Admin', id: 'uid-01' }, { deleted: false, operator: 'operator-02', role: 'Operator', id: 'uid-02' }], totalCount: 2 }, message: '', success: true });
+    expect(ddbMock).toHaveReceivedCommandTimes(QueryCommand, 1);
   });
 
   it('Add user', async () => {

--- a/src/control-plane/backend/lambda/api/test/api/user.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/user.test.ts
@@ -316,8 +316,8 @@ describe('User test', () => {
         name: 'UserSettings',
         data: {
           roleJsonPath: '$.payload.any_keys.roles',
-          operatorRoleNames: `${DEFAULT_OPERATOR_ROLE_NAMES},Operator1,Operator2`,
-          analystRoleNames: `${DEFAULT_ANALYST_ROLE_NAMES},Analyst1,Analyst2`,
+          operatorRoleNames: `${DEFAULT_OPERATOR_ROLE_NAMES} , Operator1 , Operator2 `,
+          analystRoleNames: `${DEFAULT_ANALYST_ROLE_NAMES} , Analyst1 , Analyst2 `,
         },
       },
     });

--- a/src/control-plane/backend/lambda/api/test/api/user.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/user.test.ts
@@ -20,8 +20,8 @@ import {
 } from '@aws-sdk/lib-dynamodb';
 import { mockClient } from 'aws-sdk-client-mock';
 import request from 'supertest';
-import { MOCK_TOKEN, MOCK_USER_ID, tokenMock } from './ddb-mock';
-import { amznRequestContextHeader } from '../../common/constants';
+import { MOCK_TOKEN, MOCK_USER_ID, dictionaryMock, tokenMock } from './ddb-mock';
+import { DEFAULT_ANALYST_ROLE_NAMES, DEFAULT_OPERATOR_ROLE_NAMES, amznRequestContextHeader, clickStreamTableName, dictionaryTableName } from '../../common/constants';
 import { DEFAULT_SOLUTION_OPERATOR } from '../../common/constants-ln';
 import { IUserRole } from '../../common/types';
 import { getRoleFromToken } from '../../common/utils';
@@ -40,13 +40,13 @@ describe('User test', () => {
     ddbMock.on(QueryCommand).resolvesOnce({
       Items: [
         {
-          id: 'uid-01',
+          id: 'id-01',
           role: IUserRole.ADMIN,
           operator: 'operator-01',
           deleted: false,
         },
         {
-          id: 'uid-02',
+          id: 'id-02',
           role: IUserRole.OPERATOR,
           operator: 'operator-02',
           deleted: false,
@@ -57,21 +57,26 @@ describe('User test', () => {
       .get('/api/user');
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual({ data: { items: [{ deleted: false, operator: 'operator-01', role: 'Admin', id: 'uid-01' }, { deleted: false, operator: 'operator-02', role: 'Operator', id: 'uid-02' }], totalCount: 2 }, message: '', success: true });
+    expect(res.body).toEqual({ data: { items: [{ deleted: false, operator: 'operator-01', role: 'Admin', id: 'id-01' }, { deleted: false, operator: 'operator-02', role: 'Operator', id: 'id-02' }], totalCount: 2 }, message: '', success: true });
     expect(ddbMock).toHaveReceivedCommandTimes(QueryCommand, 1);
   });
 
   it('Add user', async () => {
     tokenMock(ddbMock, false);
+    ddbMock.on(GetCommand, {
+      TableName: clickStreamTableName,
+      Key: {
+        id: 'id-02',
+        type: 'USER',
+      },
+    }).resolves({});
     ddbMock.on(PutCommand).resolvesOnce({});
     const res = await request(app)
       .post('/api/user')
       .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
       .send({
-        uid: 'uid-02',
+        id: 'id-02',
         role: IUserRole.OPERATOR,
-        operator: 'operator-02',
-        deleted: false,
       });
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(201);
@@ -84,7 +89,7 @@ describe('User test', () => {
     tokenMock(ddbMock, false);
     ddbMock.on(GetCommand).resolvesOnce({
       Item: {
-        uid: MOCK_USER_ID,
+        id: MOCK_USER_ID,
         deleted: false,
       },
     });
@@ -93,7 +98,7 @@ describe('User test', () => {
       .put(`/api/user/${MOCK_USER_ID}`)
       .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
       .send({
-        uid: MOCK_USER_ID,
+        id: MOCK_USER_ID,
         name: 'name-02',
         role: IUserRole.OPERATOR,
         operator: 'operator-02',
@@ -112,7 +117,7 @@ describe('User test', () => {
     tokenMock(ddbMock, false);
     ddbMock.on(GetCommand).resolvesOnce({
       Item: {
-        uid: MOCK_USER_ID,
+        id: MOCK_USER_ID,
         deleted: false,
       },
     });
@@ -121,7 +126,7 @@ describe('User test', () => {
       .put(`/api/user/${MOCK_USER_ID}`)
       .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
       .send({
-        uid: MOCK_USER_ID,
+        id: MOCK_USER_ID,
         name: 'name-02',
         role: IUserRole.OPERATOR,
         operator: DEFAULT_SOLUTION_OPERATOR,
@@ -139,7 +144,7 @@ describe('User test', () => {
     tokenMock(ddbMock, false);
     ddbMock.on(GetCommand).resolvesOnce({
       Item: {
-        uid: MOCK_USER_ID,
+        id: MOCK_USER_ID,
         deleted: false,
       },
     });
@@ -160,16 +165,16 @@ describe('User test', () => {
     tokenMock(ddbMock, false);
     ddbMock.on(GetCommand).resolves({
       Item: {
-        uid: MOCK_USER_ID,
+        id: MOCK_USER_ID,
         role: IUserRole.OPERATOR,
         deleted: false,
       },
     });
     const res = await request(app)
-      .get(`/api/user/details?uid=${MOCK_USER_ID}`);
+      .get(`/api/user/details?id=${MOCK_USER_ID}`);
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual({ data: { deleted: false, role: 'Operator', uid: 'user-0000' }, message: '', success: true });
+    expect(res.body).toEqual({ data: { deleted: false, role: 'Operator', id: 'user-0000' }, message: '', success: true });
     expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
   });
 
@@ -177,7 +182,7 @@ describe('User test', () => {
     tokenMock(ddbMock, false);
     ddbMock.on(GetCommand).resolves({});
     const res = await request(app)
-      .get(`/api/user/details?uid=${MOCK_USER_ID}`);
+      .get(`/api/user/details?id=${MOCK_USER_ID}`);
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(200);
     expect(res.body.data.role).toEqual(IUserRole.NO_IDENTITY);
@@ -187,20 +192,20 @@ describe('User test', () => {
   it('Get details of user that is not exist and token in context', async () => {
     tokenMock(ddbMock, false);
     ddbMock.on(GetCommand).resolves({});
-    ddbMock.on(PutCommand).resolves({});
     const TOKEN = 'Bearer eyJraWQiOiJkVE5hTUhKTWw2d094c2ZhdHRONXBUQmJFZ2dOQTkzUDRYNVVtam1yMG1rPSIsImFsZyI6IlJTMjU2In0.eyJhdF9oYXNoIjoiNEJyUTZGRndLVUdWcE1jSkI1RGl3USIsInN1YiI6ImY0NjhiNDQ4LWYwNDEtNzA3OS01Y2VhLTk5ODIyYjMyMzAzNiIsImNvZ25pdG86Z3JvdXBzIjpbIkNsaWNrc3RyZWFtT3BlcmF0b3IiXSwiZW1haWxfdmVyaWZpZWQiOnRydWUsImlzcyI6Imh0dHBzOi8vY29nbml0by1pZHAudXMtZWFzdC0xLmFtYXpvbmF3cy5jb20vdXMtZWFzdC0xX25vZUVSeDZBVyIsImNvZ25pdG86dXNlcm5hbWUiOiJmNDY4YjQ0OC1mMDQxLTcwNzktNWNlYS05OTgyMmIzMjMwMzYiLCJvcmlnaW5fanRpIjoiNzk3Y2FlOTktN2U4OC00YzVkLWEzMDEtNWZlNDc5NjhkMDU5IiwiYXVkIjoiNzVvajdjaDRsczNsbmhoaWdsdDBidTI3azgiLCJ0b2tlbl91c2UiOiJpZCIsImF1dGhfdGltZSI6MTY5NDE0MDU0MywiZXhwIjoxNjk0MTQ0MTQzLCJpYXQiOjE2OTQxNDA1NDMsImp0aSI6IjM1NjFlNWI1LTQwOGYtNGRkNS04ZWQ5LTcxN2ExYmU0NWNmZCIsImVtYWlsIjoiZmFrZUBleGFtcGxlLmNvbSJ9.H-XTyDrwSGZyhP0C99zZYhEUy4FxhRaNnTW4vrlgw0DBFdjH-HuZIthgw_uVo74bYXQ4NVPDU2W4vtPS5mWPMXFdgrwsQfeV1MP8cDZZFRWG_zcy9AJaXvN2wUnncW5pJA-Bq69_wTxf0m4sFQiKVABJsMUuRPMJ1G1ceEgeEmHE5fLITvhYFF5L2aaKeirrG8ENCeIN7B-eKGZCWvoymObX2e6DDQYEt_yVFdRP3ef9nkOdgM0JdZwmmXsyAFjlRv20rPxZVUGFUl4eyuatHQSFSpaPcPU91aDiOZ3XZQehtkNtOcMYRWs7kNnFQiykbe3KnIW22xfaISxiGS_9OQ';
     const context = `{\"accountId\":\"555555555555\",\"resourceId\":\"0my3dw\",\"operationName\":null,\"stage\":\"api\",\"domainName\":\"xxx.execute-api.us-east-1.amazonaws.com\",\"domainPrefix\":\"4ui7xyvq73\",\"requestId\":\"b1633b83-991d-4ca1-a393-4cb18c1db184\",\"protocol\":\"HTTP/1.1\",\"identity\":{\"cognitoIdentityPoolId\":null,\"accountId\":null,\"cognitoIdentityId\":null,\"caller\":null,\"apiKey\":null,\"apiKeyId\":null,\"accessKey\":null,\"sourceIp\":\"0.0.0.0\",\"cognitoAuthenticationType\":null,\"cognitoAuthenticationProvider\":null,\"userArn\":null,\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36\",\"user\":null},\"resourcePath\":\"/{proxy+}\",\"path\":\"/api/api/project\",\"authorizer\":{\"principalId\":\"4a05631e-cbe6-477c-915d-1704aec9f101\",\"integrationLatency\":253,\"email\":\"${MOCK_USER_ID}\",\"authorizationToken\":\"${TOKEN}\"},\"httpMethod\":\"POST\",\"requestTime\":\"01/May/2023:11:38:14 +0000\",\"requestTimeEpoch\":1682941094910,\"apiId\":\"4ui7xyvq73\"}`;
     const res = await request(app)
-      .get(`/api/user/details?uid=${MOCK_USER_ID}`)
+      .get(`/api/user/details?id=${MOCK_USER_ID}`)
       .set(amznRequestContextHeader, context);
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(200);
     expect(res.body.data.role).toEqual(IUserRole.OPERATOR);
-    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
-    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 2);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
   });
 
   it('Get role from cognito decoded token', async () => {
+    dictionaryMock(ddbMock);
     const operator = ['ClickstreamOperator'];
     const analyst = ['ClickstreamAnalyst'];
     const admin = ['ClickstreamOperator', 'ClickstreamAnalyst'];
@@ -244,13 +249,28 @@ describe('User test', () => {
         'cognito:groups': admin,
       },
     };
-    expect(getRoleFromToken(cognitoDecodedToken)).toEqual(IUserRole.NO_IDENTITY);
-    expect(getRoleFromToken(cognitoDecodedTokenOperator)).toEqual(IUserRole.OPERATOR);
-    expect(getRoleFromToken(cognitoDecodedTokenAnalyst)).toEqual(IUserRole.ANALYST);
-    expect(getRoleFromToken(cognitoDecodedTokenAdmin)).toEqual(IUserRole.ADMIN);
+    expect(await getRoleFromToken(cognitoDecodedToken)).toEqual(IUserRole.NO_IDENTITY);
+    expect(await getRoleFromToken(cognitoDecodedTokenOperator)).toEqual(IUserRole.OPERATOR);
+    expect(await getRoleFromToken(cognitoDecodedTokenAnalyst)).toEqual(IUserRole.ANALYST);
+    expect(await getRoleFromToken(cognitoDecodedTokenAdmin)).toEqual(IUserRole.ADMIN);
   });
 
   it('Get role from others decoded token', async () => {
+    ddbMock.on(GetCommand, {
+      TableName: dictionaryTableName,
+      Key: {
+        name: 'UserSettings',
+      },
+    }).resolves({
+      Item: {
+        name: 'UserSettings',
+        data: {
+          roleJsonPath: '$.payload.any_keys.roles',
+          operatorRoleNames: DEFAULT_OPERATOR_ROLE_NAMES,
+          analystRoleNames: DEFAULT_ANALYST_ROLE_NAMES,
+        },
+      },
+    });
     const operator = ['ClickstreamOperator'];
     const decodedToken = {
       header: { kid: 'dTNaMHJMl6wOxsfattN5pTBbEggNA93P4X5Umjmr0mk=', alg: 'RS256' },
@@ -282,8 +302,90 @@ describe('User test', () => {
         },
       },
     };
-    process.env.OIDC_ROLE_PATH = '$.payload.any_keys.roles';
-    expect(getRoleFromToken(decodedTokenOperator)).toEqual(IUserRole.OPERATOR);
+    expect(await getRoleFromToken(decodedTokenOperator)).toEqual(IUserRole.OPERATOR);
+  });
+
+  it('Get role from others decoded token with map mutil role name', async () => {
+    ddbMock.on(GetCommand, {
+      TableName: dictionaryTableName,
+      Key: {
+        name: 'UserSettings',
+      },
+    }).resolves({
+      Item: {
+        name: 'UserSettings',
+        data: {
+          roleJsonPath: '$.payload.any_keys.roles',
+          operatorRoleNames: `${DEFAULT_OPERATOR_ROLE_NAMES},Operator1,Operator2`,
+          analystRoleNames: `${DEFAULT_ANALYST_ROLE_NAMES},Analyst1,Analyst2`,
+        },
+      },
+    });
+    const decodedToken = {
+      header: { kid: 'dTNaMHJMl6wOxsfattN5pTBbEggNA93P4X5Umjmr0mk=', alg: 'RS256' },
+      payload: {
+        'at_hash': '4BrQ6FFwKUGVpMcJB5DiwQ',
+        'sub': 'f468b448-f041-7079-5cea-99822b323036',
+        'any_keys': {
+          roles: [],
+        },
+        'email_verified': true,
+        'cognito:username': 'f468b448-f041-7079-5cea-99822b323036',
+        'origin_jti': '797cae99-7e88-4c5d-a301-5fe47968d059',
+        'aud': '75oj7ch4ls3lnhhiglt0bu27k8',
+        'token_use': 'id',
+        'auth_time': 1694140543,
+        'exp': 1694144143,
+        'iat': 1694140543,
+        'jti': '3561e5b5-408f-4dd5-8ed9-717a1be45cfd',
+        'email': 'fake@example.com',
+      },
+      signature: 'uatHQSFSpaPcPU91aDiOZ3XZQehtkNtOcMYRWs7kNnFQiykbe3',
+    };
+    const noIdentity = ['others'];
+    const decodedTokenNoIdentity = {
+      ...decodedToken,
+      payload: {
+        ...decodedToken.payload,
+        any_keys: {
+          roles: noIdentity,
+        },
+      },
+    };
+    expect(await getRoleFromToken(decodedTokenNoIdentity)).toEqual(IUserRole.NO_IDENTITY);
+    const operator = ['Operator1', 'others'];
+    const decodedTokenOperator = {
+      ...decodedToken,
+      payload: {
+        ...decodedToken.payload,
+        any_keys: {
+          roles: operator,
+        },
+      },
+    };
+    expect(await getRoleFromToken(decodedTokenOperator)).toEqual(IUserRole.OPERATOR);
+    const analyst = ['Analyst2', 'others'];
+    const decodedTokenAnalyst = {
+      ...decodedToken,
+      payload: {
+        ...decodedToken.payload,
+        any_keys: {
+          roles: analyst,
+        },
+      },
+    };
+    expect(await getRoleFromToken(decodedTokenAnalyst)).toEqual(IUserRole.ANALYST);
+    const admin = ['Analyst2', 'Operator2', 'others'];
+    const decodedTokenAdmin = {
+      ...decodedToken,
+      payload: {
+        ...decodedToken.payload,
+        any_keys: {
+          roles: admin,
+        },
+      },
+    };
+    expect(await getRoleFromToken(decodedTokenAdmin)).toEqual(IUserRole.ADMIN);
   });
 
   afterAll((done) => {

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -23,7 +23,6 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
         'testClickStreamALBApiClickstreamDictionary0A1156B6',
         'testClickStreamALBApiClickstreamMetadataA721B303',
         'testClickStreamALBApiClickstreamAnalyticsMetadataA20F6663',
-        'testClickStreamALBApiClickstreamUser54DFA2EE',
       ]);
 
     newALBApiStackTemplate.hasResourceProperties('AWS::DynamoDB::Table', {
@@ -595,34 +594,6 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
                     '/index/*',
                   ],
                 ],
-              },
-            ],
-          },
-          {
-            Action: [
-              'dynamodb:BatchGetItem',
-              'dynamodb:GetRecords',
-              'dynamodb:GetShardIterator',
-              'dynamodb:Query',
-              'dynamodb:GetItem',
-              'dynamodb:Scan',
-              'dynamodb:ConditionCheckItem',
-              'dynamodb:BatchWriteItem',
-              'dynamodb:PutItem',
-              'dynamodb:UpdateItem',
-              'dynamodb:DeleteItem',
-              'dynamodb:DescribeTable',
-            ],
-            Effect: 'Allow',
-            Resource: [
-              {
-                'Fn::GetAtt': [
-                  'testClickStreamALBApiClickstreamUser54DFA2EE',
-                  'Arn',
-                ],
-              },
-              {
-                Ref: 'AWS::NoValue',
               },
             ],
           },

--- a/test/jestEnv.js
+++ b/test/jestEnv.js
@@ -26,7 +26,6 @@ process.env.PREFIX_TIME_GSI_NAME = 'prefix-time-gsi-name'
 process.env.CLICK_STREAM_TABLE_NAME = 'click-stream-table-name'
 process.env.ANALYTICS_METADATA_TABLE_NAME = 'analytics-metadata-table-name'
 process.env.DICTIONARY_TABLE_NAME = 'dictionary-table-name'
-process.env.USER_TABLE_NAME = 'user-table-name'
 
 // controlplane bundling
 process.env.IS_SKIP_ASSET_BUNDLE = 'true'


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. Delete User DDB table, move user data to metadata table.
2. Add create/delete user button on frontend.
3. Role in DDB overwrite role in token.
4. Add user settings at frontend.
<img width="1130" alt="截屏2023-09-17 18 45 36" src="https://github.com/awslabs/clickstream-analytics-on-aws/assets/18416040/c4a47905-d86a-4de7-a283-5568c7a95f70">


## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend