### PR TITLE
feat: add workflow for scaning event metadata in redshift then persist to DDB

### DIFF
--- a/src/analytics/lambdas/scan-metadata-workflow/check-scan-metadata-status.ts
+++ b/src/analytics/lambdas/scan-metadata-workflow/check-scan-metadata-status.ts
@@ -52,7 +52,7 @@ export const handler = async (event: CheckScanMetadataStatusEvent) => {
       },
     };
   } else if (response.Status == StatusString.FAILED || response.Status == StatusString.ABORTED) {
-    logger.info(`Executing ${queryId} status of statement is ${response.Status}`);
+    logger.error(`Executing ${queryId} status of statement is ${response.Status}`);
     const queryResult = await queryScanMetadataLog(appId);
     return {
       detail: {

--- a/src/analytics/lambdas/scan-metadata-workflow/check-scan-metadata-status.ts
+++ b/src/analytics/lambdas/scan-metadata-workflow/check-scan-metadata-status.ts
@@ -1,0 +1,113 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { StatusString } from '@aws-sdk/client-redshift-data';
+import { logger } from '../../../common/powertools';
+import { SP_SCAN_METADATA } from '../../private/constant';
+import { CheckScanMetadataStatusEventDetail } from '../../private/model';
+import { describeStatement, executeStatementsWithWait, getRedshiftClient, getRedshiftProps, getStatementResult } from '../redshift-data';
+
+const REDSHIFT_DATA_API_ROLE_ARN = process.env.REDSHIFT_DATA_API_ROLE!;
+const REDSHIFT_DATABASE = process.env.REDSHIFT_DATABASE!;
+
+// Create an Amazon service client object.
+const redshiftDataApiClient = getRedshiftClient(REDSHIFT_DATA_API_ROLE_ARN);
+
+export interface CheckScanMetadataStatusEvent {
+  detail: CheckScanMetadataStatusEventDetail;
+}
+
+/**
+ * The lambda function get scan metadata status in Redshift by query_id.
+ * @param event CheckScanMetadataStatusEvent.
+ * @returns The scan metadata results of query_id.
+ */
+export const handler = async (event: CheckScanMetadataStatusEvent) => {
+  logger.debug('request event:', JSON.stringify(event));
+
+  const queryId = event.detail.id;
+  const appId = event.detail.appId;
+  logger.debug(`query_id:${queryId}`);
+  // There is a scan metadata job need to check result.
+  const response = await describeStatement(redshiftDataApiClient, queryId);
+
+  if (response.Status == StatusString.FINISHED) {
+    logger.info('Scan metadata success.');
+    const queryResult = await queryScanMetadataLog(appId);
+    return {
+      detail: {
+        appId: appId,
+        status: response.Status,
+        message: queryResult.detail.message,
+      },
+    };
+  } else if (response.Status == StatusString.FAILED || response.Status == StatusString.ABORTED) {
+    logger.info(`Executing ${queryId} status of statement is ${response.Status}`);
+    const queryResult = await queryScanMetadataLog(appId);
+    return {
+      detail: {
+        id: queryId,
+        appId: appId,
+        status: response.Status,
+        message: 'Error:' + response.Error + '\nLog:' + queryResult.detail.message,
+      },
+    };
+  } else {
+    logger.info(`Executing ${queryId} status of statement is ${response.Status}`);
+    return {
+      detail: {
+        id: queryId,
+        appId: appId,
+        status: response.Status,
+      },
+    };
+  }
+};
+
+export const queryScanMetadataLog = async (appId: string) => {
+  const redshiftProps = getRedshiftProps(
+    process.env.REDSHIFT_MODE!,
+    REDSHIFT_DATABASE,
+    REDSHIFT_DATA_API_ROLE_ARN,
+    process.env.REDSHIFT_DB_USER!,
+    process.env.REDSHIFT_SERVERLESS_WORKGROUP_NAME!,
+    process.env.REDSHIFT_CLUSTER_IDENTIFIER!,
+  );
+
+  const schema = appId;
+  try {
+    const querySqlStatement = `SELECT * FROM ${schema}.clickstream_log WHERE log_name='${SP_SCAN_METADATA}' ORDER BY log_date, id`;
+    const queryId = await executeStatementsWithWait(
+      redshiftDataApiClient, [querySqlStatement], redshiftProps.serverlessRedshiftProps, redshiftProps.provisionedRedshiftProps);
+
+    const response = await getStatementResult(redshiftDataApiClient, queryId!);
+
+    logger.info('Scan metadata log response:', { response });
+
+    const delSqlStatement = `DELETE FROM ${schema}.clickstream_log WHERE log_name='${SP_SCAN_METADATA}'`;
+    await executeStatementsWithWait(
+      redshiftDataApiClient, [delSqlStatement], redshiftProps.serverlessRedshiftProps, redshiftProps.provisionedRedshiftProps);
+    return {
+      detail: {
+        appId: schema,
+        message: response.Records,
+      },
+    };
+
+  } catch (err) {
+    if (err instanceof Error) {
+      logger.error('Error when query scan metadata log.', err);
+    }
+    throw err;
+  }
+};

--- a/src/analytics/lambdas/scan-metadata-workflow/scan-metadata.ts
+++ b/src/analytics/lambdas/scan-metadata-workflow/scan-metadata.ts
@@ -1,0 +1,73 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { logger } from '../../../common/powertools';
+import { ScanMetadataBody } from '../../private/model';
+import { getRedshiftClient, executeStatements, getRedshiftProps } from '../redshift-data';
+
+const REDSHIFT_DATA_API_ROLE_ARN = process.env.REDSHIFT_DATA_API_ROLE!;
+const REDSHIFT_DATABASE = process.env.REDSHIFT_DATABASE!;
+
+// Create an Amazon service client object.
+const redshiftDataApiClient = getRedshiftClient(REDSHIFT_DATA_API_ROLE_ARN);
+
+export interface ScanMetadataEvent {
+  detail: ScanMetadataBody;
+}
+
+/**
+ * The lambda function submit a SQL statement to scan metadata.
+ * @param event ScanMetadataEvent, the JSON format is as follows:
+ {
+    "detail": {
+      "appId": app1
+    }
+  }
+  @returns The query_id and relevant properties.
+ */
+export const handler = async (event: ScanMetadataEvent) => {
+  const redshiftProps = getRedshiftProps(
+    process.env.REDSHIFT_MODE!,
+    REDSHIFT_DATABASE,
+    REDSHIFT_DATA_API_ROLE_ARN,
+    process.env.REDSHIFT_DB_USER!,
+    process.env.REDSHIFT_SERVERLESS_WORKGROUP_NAME!,
+    process.env.REDSHIFT_CLUSTER_IDENTIFIER!,
+  );
+
+  const schema = event.detail.appId;
+  const sqlStatements : string[] = [];
+  const topFrequentPropertiesLimit = process.env.TOP_FREQUENT_PROPERTIES_LIMIT;
+  const dayRange = process.env.DAY_RANGE;
+
+  sqlStatements.push(`CALL ${schema}.sp_scan_metadata(${topFrequentPropertiesLimit}, ${dayRange})`);
+
+  try {
+    const queryId = await executeStatements(
+      redshiftDataApiClient, sqlStatements, redshiftProps.serverlessRedshiftProps, redshiftProps.provisionedRedshiftProps);
+
+    logger.info('Scan metadata response:', { queryId });
+    return {
+      detail: {
+        appId: schema,
+        id: queryId,
+      },
+    };
+
+  } catch (err) {
+    if (err instanceof Error) {
+      logger.error('Error when scan metadata.', err);
+    }
+    throw err;
+  }
+};

--- a/src/analytics/lambdas/scan-metadata-workflow/store-metadata-into-ddb.ts
+++ b/src/analytics/lambdas/scan-metadata-workflow/store-metadata-into-ddb.ts
@@ -237,11 +237,9 @@ function parseDynamoDBTableARN(ddbArn: string) {
 }
 
 function convertToDDBList(inputString?: string) {
-  let listData = [];
+  let listData: any[] = [];
   if (inputString) {
-    const formattedString = inputString.replace(/^\[|\]$/g, '').split(',').map(item => `"${item}"`).join(',');
-    const jsonArray = `[${formattedString}]`;
-    listData = JSON.parse(jsonArray);
+    listData = inputString.split('#');
   }
   return listData;
 }

--- a/src/analytics/lambdas/scan-metadata-workflow/store-metadata-into-ddb.ts
+++ b/src/analytics/lambdas/scan-metadata-workflow/store-metadata-into-ddb.ts
@@ -1,0 +1,242 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import {
+  DynamoDBClient,
+  BatchWriteItemCommand,
+  BatchWriteItemCommandInput,
+} from '@aws-sdk/client-dynamodb';
+import { logger } from '../../../common/powertools';
+import { aws_sdk_client_common_config } from '../../../common/sdk-client-config';
+import { StoreMetadataBody } from '../../private/model';
+import { getRedshiftClient, executeStatementsWithWait, getRedshiftProps, getStatementResult } from '../redshift-data';
+
+const REDSHIFT_DATA_API_ROLE_ARN = process.env.REDSHIFT_DATA_API_ROLE!;
+const REDSHIFT_DATABASE = process.env.REDSHIFT_DATABASE!;
+
+const { ddb_region, ddb_table_name } = parseDynamoDBTableARN(process.env.METADATA_DDB_TABLE_ARN!);
+
+// Create an Amazon service client object.
+const redshiftDataApiClient = getRedshiftClient(REDSHIFT_DATA_API_ROLE_ARN);
+
+export interface StoreMetadataEvent {
+  detail: StoreMetadataBody;
+}
+
+// Create an Amazon DynamoDB service client object.
+const ddbClient = new DynamoDBClient({
+  ...aws_sdk_client_common_config,
+  region: ddb_region,
+});
+
+/**
+ * The lambda function to get event metadata and properties metadata from redshift. And store them into DDB
+ * @param event StoreMetadataEvent.
+ * @returns.
+ */
+export const handler = async (event: StoreMetadataEvent) => {
+  logger.debug('request event:', JSON.stringify(event));
+
+  const metadataItems: any[] = [];
+  const appId = event.detail.appId;
+  try {
+    await handleEventMetadata(appId, metadataItems);
+
+    await handlePropertiesMetadata(appId, metadataItems);
+
+    await batchWriteIntoDDB(metadataItems);
+
+    return {
+      detail: {
+        appId: appId,
+        status: 'SUCCEED',
+        message: 'store metadata into ddb successfully',
+      },
+    };
+  } catch (err) {
+    if (err instanceof Error) {
+      logger.error('Error when query metadata.', err);
+    }
+    return {
+      detail: {
+        appId: appId,
+        status: 'FAILED',
+        message: 'store metadata into ddb failed',
+      },
+    };
+  }
+};
+
+async function handleEventMetadata(appId: string, metadataItems: any[]) {
+
+  const inputSql = `SELECT id, type, prefix, project_id, app_id, event_name, metadata_source, data_volumel_last_day, platform FROM ${appId}.event_metadata;`;
+
+  const response = await queryMetadata(inputSql);
+
+  // Transform data to DynamoDB format
+  const items = response.Records!.map(record => ({
+    PutRequest: {
+      Item: {
+        id: { S: record[0].stringValue },
+        type: { S: record[1].stringValue },
+        prefix: { S: record[2].stringValue },
+        projectId: { S: record[3].stringValue },
+        appId: { S: record[4].stringValue },
+        name: { S: record[5].stringValue },
+        displayName: { S: '' },
+        description: { S: '' },
+        hasData: { BOOL: true },
+        metadataSource: { S: record[6].stringValue },
+        dataVolumeLastDay: { N: record[7].stringValue },
+        platform: { L: convertToDDBList(record[8].stringValue) },
+        updateAt: { N: Date.now().toString() },
+        createAt: { N: Date.now().toString() },
+        operator: { S: '' },
+        deleted: { BOOL: false },
+        ttl: { N: (Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60).toString() },
+      },
+    },
+  }));
+
+  items.forEach(item => {
+    metadataItems.push({
+      PutRequest: {
+        Item: item.PutRequest.Item,
+      },
+    });
+  });
+}
+
+async function handlePropertiesMetadata(appId: string, metadataItems: any[]) {
+  const inputSql =
+    `SELECT id, type, prefix, event_name, project_id, app_id, category, metadata_source, property_type, property_name, property_id, value_type, value_enum, platform FROM ${appId}.event_properties_metadata;`;
+
+  const response = await queryMetadata(inputSql);
+
+  // Transform data to DynamoDB format
+  const items = response.Records!.map(record => ({
+    PutRequest: {
+      Item: {
+        id: { S: record[0].stringValue },
+        type: { S: record[1].stringValue },
+        prefix: { S: record[2].stringValue },
+        eventName: { S: record[3].stringValue },
+        projectId: { S: record[4].stringValue },
+        appId: { S: record[5].stringValue },
+        category: { S: record[6].stringValue },
+        metadataSource: { S: record[7].stringValue },
+        parameterType: { S: record[8].stringValue },
+        name: { S: record[9].stringValue },
+        parameterId: { S: record[10].stringValue },
+        valueType: { S: record[11].stringValue },
+        valueEnum: { L: convertToDDBList(record[12].stringValue) },
+        platform: { L: convertToDDBList(record[13].stringValue) },
+        eventDescription: { S: '' },
+        eventDisplayName: { S: '' },
+        displayName: { S: '' },
+        description: { S: '' },
+        hasData: { BOOL: true },
+        updateAt: { N: Date.now().toString() },
+        createAt: { N: Date.now().toString() },
+        operator: { S: '' },
+        deleted: { BOOL: false },
+        ttl: { N: (Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60).toString() },
+      },
+    },
+  }));
+
+  items.forEach(item => {
+    metadataItems.push({
+      PutRequest: {
+        Item: item.PutRequest.Item,
+      },
+    });
+  });
+}
+
+async function batchWriteIntoDDB(metadataItems: any[]) {
+  const chunkedMetadataItems = chunkArray(metadataItems, 20);
+
+  for (const itemsChunk of chunkedMetadataItems) {
+    const inputPara: BatchWriteItemCommandInput = {
+      RequestItems: {
+        [ddb_table_name]: itemsChunk,
+      },
+    };
+    await ddbClient.send(new BatchWriteItemCommand(inputPara));
+  }
+}
+
+function chunkArray(inputArray: any[], chunkSize: number) {
+  const chunks = [];
+  for (let i = 0; i < inputArray.length; i += chunkSize) {
+    chunks.push(inputArray.slice(i, i + chunkSize));
+  }
+  return chunks;
+};
+
+async function queryMetadata(inputSql: string) {
+  const redshiftProps = getRedshiftProps(
+    process.env.REDSHIFT_MODE!,
+    REDSHIFT_DATABASE,
+    REDSHIFT_DATA_API_ROLE_ARN,
+    process.env.REDSHIFT_DB_USER!,
+    process.env.REDSHIFT_SERVERLESS_WORKGROUP_NAME!,
+    process.env.REDSHIFT_CLUSTER_IDENTIFIER!,
+  );
+  const sqlStatements : string[] = [];
+
+  sqlStatements.push(inputSql);
+  try {
+    const queryId = await executeStatementsWithWait(
+      redshiftDataApiClient, sqlStatements, redshiftProps.serverlessRedshiftProps, redshiftProps.provisionedRedshiftProps);
+
+    if (!queryId) {
+      throw new Error(`Query failed with sqls: ${sqlStatements}`);
+    }
+
+    logger.info('query metadata response:', { queryId });
+
+    // Fetch results
+    const response = await getStatementResult(redshiftDataApiClient, queryId);
+
+    return response;
+  } catch (err) {
+    if (err instanceof Error) {
+      logger.error('Error when query metadata.', err);
+    }
+    throw err;
+  }
+}
+
+function parseDynamoDBTableARN(ddbArn: string) {
+  const arnComponents = ddbArn.split(':');
+  const region = arnComponents[3];
+  const table_name = arnComponents[5].split('/')[1];
+
+  return {
+    ddb_region: region,
+    ddb_table_name: table_name,
+  };
+}
+
+function convertToDDBList(inputString?: string) {
+  let listData = [];
+  if (inputString) {
+    const formattedString = inputString.replace(/^\[|\]$/g, '').split(',').map(item => `"${item}"`).join(',');
+    const jsonArray = `[${formattedString}]`;
+    listData = JSON.parse(jsonArray);
+  }
+
+  return listData.map( (item: string) => ({ S: item }));
+}

--- a/src/analytics/private/constant.ts
+++ b/src/analytics/private/constant.ts
@@ -23,10 +23,12 @@ export const REDSHIFT_ODS_TABLE_NAME = 'ods_events';
 export const REDSHIFT_DUPLICATE_DATE_INTERVAL = 3; // Days
 
 export const SP_UPSERT_USERS = 'sp_upsert_users';
+export const SP_SCAN_METADATA = 'scan_metadata';
 export const SP_CLEAR_EXPIRED_EVENTS = 'sp_clear_expired_events';
 
 export const SQL_TEMPLATE_PARAMETER = {
   sp_upsert_users: 'sp_upsert_users',
+  sp_scan_metadata: 'sp_scan_metadata',
   table_ods_users: 'ods_users',
   table_dim_users: 'dim_users',
   sp_clickstream_log: 'sp_clickstream_log',

--- a/src/analytics/private/metircs-redshift-cluster.ts
+++ b/src/analytics/private/metircs-redshift-cluster.ts
@@ -23,9 +23,11 @@ export function createMetricsWidgetForRedshiftCluster(scope: Construct, props: {
   projectId: string;
   dataProcessingCronOrRateExpression: string;
   upsertUsersCronOrRateExpression: string;
+  scanMetadataCronOrRateExpression: string;
   redshiftClusterIdentifier: string;
   loadEventsWorkflow: IStateMachine;
   upsertUsersWorkflow: IStateMachine;
+  scanMetadataWorkflow: IStateMachine;
   clearExpiredEventsWorkflow: IStateMachine;
 }) {
 

--- a/src/analytics/private/metircs-redshift-serverless.ts
+++ b/src/analytics/private/metircs-redshift-serverless.ts
@@ -23,10 +23,12 @@ export function createMetricsWidgetForRedshiftServerless(scope: Construct, id: s
   projectId: string;
   dataProcessingCronOrRateExpression: string;
   upsertUsersCronOrRateExpression: string;
+  scanMetadataCronOrRateExpression: string;
   redshiftServerlessNamespace?: string;
   redshiftServerlessWorkgroupName: string;
   loadEventsWorkflow: IStateMachine;
   upsertUsersWorkflow: IStateMachine;
+  scanMetadataWorkflow: IStateMachine;
   clearExpiredEventsWorkflow: IStateMachine;
 }) {
 

--- a/src/analytics/private/model.ts
+++ b/src/analytics/private/model.ts
@@ -34,6 +34,12 @@ export type UpsertUsersWorkflowData = {
   readonly scheduleExpression: string;
 }
 
+export type ScanMetadataWorkflowData = {
+  readonly scheduleExpression: string;
+  readonly clickstreamAnalyticsMetadataDdbArn: string;
+  readonly topFrequentPropertiesLimit: string;
+}
+
 export type ClearExpiredEventsWorkflowData = {
   readonly scheduleExpression: string;
   readonly retentionRangeDays: number;
@@ -137,7 +143,21 @@ export interface UpsertUsersBody {
   readonly appId: string;
 }
 
+export interface ScanMetadataBody {
+  readonly appId: string;
+}
+
+export interface StoreMetadataBody {
+  readonly appId: string;
+}
+
 export type CheckUpsertStatusEventDetail = {
+  id: string;
+  appId: string;
+  status: string;
+}
+
+export type CheckScanMetadataStatusEventDetail = {
   id: string;
   appId: string;
   status: string;
@@ -162,6 +182,7 @@ export type MustacheParamType = {
   schema: string;
   table_ods_events: string;
   sp_upsert_users: string;
+  sp_scan_metadata: string;
   table_ods_users: string;
   table_dim_users: string;
   sp_clickstream_log: string;

--- a/src/analytics/private/scan-metadata-workflow.ts
+++ b/src/analytics/private/scan-metadata-workflow.ts
@@ -255,7 +255,7 @@ export class ScanMetadataWorkflow extends Construct {
       ),
       handler: 'handler',
       memorySize: 1024,
-      timeout: Duration.minutes(13),
+      timeout: Duration.minutes(15),
       logRetention: RetentionDays.ONE_WEEK,
       reservedConcurrentExecutions: 1,
       role: createLambdaRole(this, 'StoreMetadataIntoDDBRole', true, policyStatements),

--- a/src/analytics/private/scan-metadata-workflow.ts
+++ b/src/analytics/private/scan-metadata-workflow.ts
@@ -1,0 +1,274 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { join } from 'path';
+import { Duration } from 'aws-cdk-lib';
+import { IVpc, SubnetSelection } from 'aws-cdk-lib/aws-ec2';
+import { Rule, Schedule } from 'aws-cdk-lib/aws-events';
+import { SfnStateMachine } from 'aws-cdk-lib/aws-events-targets';
+import { IRole, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { IFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { StateMachine, LogLevel, IStateMachine, TaskInput, Wait, WaitTime, Succeed, Fail, Choice, Map, Condition, Pass, DefinitionBody } from 'aws-cdk-lib/aws-stepfunctions';
+import { LambdaInvoke } from 'aws-cdk-lib/aws-stepfunctions-tasks';
+import { Construct } from 'constructs';
+import { ExistingRedshiftServerlessCustomProps, ProvisionedRedshiftProps, ScanMetadataWorkflowData } from './model';
+import { createLambdaRole } from '../../common/lambda';
+import { createLogGroup } from '../../common/logs';
+import { REDSHIFT_MODE } from '../../common/model';
+import { POWERTOOLS_ENVS } from '../../common/powertools';
+import { createSGForEgressToAwsService } from '../../common/sg';
+import { SolutionNodejsFunction } from '../../private/function';
+
+export interface ScanMetadataWorkflowProps {
+  readonly appIds: string;
+  readonly networkConfig: {
+    readonly vpc: IVpc;
+    readonly vpcSubnets: SubnetSelection;
+  };
+  readonly serverlessRedshift?: ExistingRedshiftServerlessCustomProps;
+  readonly provisionedRedshift?: ProvisionedRedshiftProps;
+  readonly databaseName: string;
+  readonly dataAPIRole: IRole;
+  readonly scanMetadataWorkflowData: ScanMetadataWorkflowData;
+}
+
+export class ScanMetadataWorkflow extends Construct {
+  private readonly lambdaRootPath = __dirname + '/../lambdas/scan-metadata-workflow';
+  public readonly scanMetadataWorkflow: IStateMachine;
+
+  constructor(scope: Construct, id: string, props: ScanMetadataWorkflowProps) {
+    super(scope, id);
+
+    // create Step function workflow to orchestrate the workflow to scan metadata.
+    this.scanMetadataWorkflow = this.createWorkflow(props);
+
+    // Create an EventBridge Rule to trigger the workflow periodically
+    const rule = new Rule(scope, 'ScanMetadataScheduleRule', {
+      // schedule: Schedule.expression('cron(0 1 * * ? *)'),
+      schedule: Schedule.expression(props.scanMetadataWorkflowData.scheduleExpression),
+    });
+    rule.addTarget(new SfnStateMachine(this.scanMetadataWorkflow));
+  }
+
+  private createWorkflow(props: ScanMetadataWorkflowProps): IStateMachine {
+    const getJobList = new Pass(this, `${this.node.id} - Get app_id`, {
+      parameters: {
+        Payload: {
+          'appIdList.$': `States.StringSplit('${props.appIds}', ',')`,
+        },
+      },
+      outputPath: '$.Payload',
+    });
+
+    const scanMetadataFn = this.scanMetadataFn(props);
+    const scanMetadataJob = new LambdaInvoke(this, `${this.node.id} - Submit scan metadata job`, {
+      lambdaFunction: scanMetadataFn,
+      payload: TaskInput.fromObject({
+        detail: {
+          'appId.$': '$',
+        },
+      }),
+      outputPath: '$.Payload',
+    });
+
+    const checkScanMetadataStatusFn = this.checkScanMetadataStatusFn(props);
+    const checkScanMetadataStatusJob = new LambdaInvoke(this, `${this.node.id} - Check scan metadata job status`, {
+      lambdaFunction: checkScanMetadataStatusFn,
+      payload: TaskInput.fromObject({
+        'detail.$': '$.detail',
+      }),
+      outputPath: '$.Payload',
+    });
+
+    const waitX = new Wait(this, `${this.node.id} - Wait seconds`, {
+      /**
+         *  You can also implement with the path stored in the state like:
+         *  sfn.WaitTime.secondsPath('$.waitSeconds')
+      */
+      time: WaitTime.duration(Duration.seconds(30)),
+    });
+
+    const scanMetadataJobFailed = new Fail(this, `${this.node.id} - scan metadata job fails`, {
+      cause: 'ScanMetadata Job Failed',
+      error: 'DescribeJob returned FAILED',
+    });
+
+    const scanMetadataCompleted = new Succeed(this, `${this.node.id} - scan metadata job completes`);
+
+    const storeMetadataIntoDDBFn = this.storeMetadataIntoDDBFn(props);
+    const storeMetadataIntoDDBJob = new LambdaInvoke(this, `${this.node.id} - store scan metadata job status`, {
+      lambdaFunction: storeMetadataIntoDDBFn,
+      payload: TaskInput.fromObject({
+        'detail.$': '$.detail',
+      }),
+      outputPath: '$.Payload',
+    }).next(
+      new Choice(this, 'Check if store metadata completed')
+        .when(Condition.stringEquals('$.detail.status', 'SUCCEED'), scanMetadataCompleted)
+        .otherwise(scanMetadataJobFailed),
+    );
+
+    // Create sub chain
+    const subDefinition = scanMetadataJob
+      .next(waitX)
+      .next(checkScanMetadataStatusJob)
+      .next(
+        new Choice(this, `${this.node.id} - Check if scan metadata job completes`)
+          .when(Condition.stringEquals('$.detail.status', 'FAILED'), scanMetadataJobFailed)
+          .when(Condition.stringEquals('$.detail.status', 'ABORTED'), scanMetadataJobFailed)
+          .when(Condition.stringEquals('$.detail.status', 'FINISHED'), storeMetadataIntoDDBJob)
+          .when(Condition.stringEquals('$.detail.status', 'NO_JOBS'), scanMetadataCompleted)
+          .otherwise(waitX));
+
+    const doScanMetadataJob = new Map(
+      this,
+      `${this.node.id} - Do scanMetadata job`,
+      {
+        maxConcurrency: 1,
+        itemsPath: '$.appIdList',
+      },
+    );
+    doScanMetadataJob.iterator(subDefinition);
+
+    const doNothing = new Succeed(this, `${this.node.id} - Do Nothing`);
+    const checkJobExist = new Choice(this, `${this.node.id} - Check if job exists`)
+      .when(Condition.isNotPresent('$.appIdList'), doNothing)
+      .when(Condition.isPresent('$.appIdList'), doScanMetadataJob)
+      .otherwise(doNothing);
+
+    const definition = getJobList.next(checkJobExist);
+
+    // Create state machine
+    const scanMetadataStateMachine = new StateMachine(this, 'ScanMetadataStateMachine', {
+      definitionBody: DefinitionBody.fromChainable(definition),
+      logs: {
+        destination: createLogGroup(this,
+          {
+            prefix: '/aws/vendedlogs/states/Clickstream/ScanMetadataStateMachine',
+          },
+        ),
+        level: LogLevel.ALL,
+      },
+      tracingEnabled: true,
+    });
+
+    return scanMetadataStateMachine;
+  }
+
+  private scanMetadataFn(props: ScanMetadataWorkflowProps): IFunction {
+    const fnSG = createSGForEgressToAwsService(this, 'ScanMetadataFnSG', props.networkConfig.vpc);
+
+    const fn = new SolutionNodejsFunction(this, 'ScanMetadataFn', {
+      runtime: Runtime.NODEJS_18_X,
+      entry: join(
+        this.lambdaRootPath,
+        'scan-metadata.ts',
+      ),
+      handler: 'handler',
+      memorySize: 128,
+      timeout: Duration.minutes(3),
+      logRetention: RetentionDays.ONE_WEEK,
+      reservedConcurrentExecutions: 1,
+      role: createLambdaRole(this, 'ScanMetadataRole', true, []),
+      ...props.networkConfig,
+      securityGroups: [fnSG],
+      environment: {
+        ... this.toRedshiftEnvVariables(props),
+        REDSHIFT_DATA_API_ROLE: props.dataAPIRole.roleArn,
+        TOP_FREQUENT_PROPERTIES_LIMIT: props.scanMetadataWorkflowData.topFrequentPropertiesLimit,
+        DAY_RANGE: '1',
+        ... POWERTOOLS_ENVS,
+      },
+    });
+    props.dataAPIRole.grantAssumeRole(fn.grantPrincipal);
+    return fn;
+  }
+
+  private toRedshiftEnvVariables(props: ScanMetadataWorkflowProps) : {
+    [key: string]: string;
+  } {
+    return {
+      REDSHIFT_MODE: props.serverlessRedshift ? REDSHIFT_MODE.SERVERLESS : REDSHIFT_MODE.PROVISIONED,
+      REDSHIFT_SERVERLESS_WORKGROUP_NAME: props.serverlessRedshift?.workgroupName ?? '',
+      REDSHIFT_CLUSTER_IDENTIFIER: props.provisionedRedshift?.clusterIdentifier ?? '',
+      REDSHIFT_DATABASE: props.databaseName,
+      REDSHIFT_DB_USER: props.provisionedRedshift?.dbUser ?? '',
+    };
+  }
+
+  private checkScanMetadataStatusFn(props: ScanMetadataWorkflowProps): IFunction {
+    const fnSG = createSGForEgressToAwsService(this, 'CheckScanMetadataStatusFnSG', props.networkConfig.vpc);
+
+    const fn = new SolutionNodejsFunction(this, 'CheckScanMetadataStatusFn', {
+      runtime: Runtime.NODEJS_18_X,
+      entry: join(
+        this.lambdaRootPath,
+        'check-scan-metadata-status.ts',
+      ),
+      handler: 'handler',
+      memorySize: 128,
+      timeout: Duration.minutes(2),
+      logRetention: RetentionDays.ONE_WEEK,
+      reservedConcurrentExecutions: 1,
+      role: createLambdaRole(this, 'CheckScanMetadataStatusRole', true, []),
+      ...props.networkConfig,
+      securityGroups: [fnSG],
+      environment: {
+        ... this.toRedshiftEnvVariables(props),
+        REDSHIFT_DATA_API_ROLE: props.dataAPIRole.roleArn,
+        ... POWERTOOLS_ENVS,
+      },
+    });
+    props.dataAPIRole.grantAssumeRole(fn.grantPrincipal);
+    return fn;
+  }
+
+  private storeMetadataIntoDDBFn(props: ScanMetadataWorkflowProps): IFunction {
+    const fnSG = createSGForEgressToAwsService(this, 'StoreMetadataIntoDDBFnSG', props.networkConfig.vpc);
+
+    const policyStatements = [
+      new PolicyStatement({
+        actions: [
+          'dynamodb:BatchWriteItem',
+        ],
+        resources: [props.scanMetadataWorkflowData.clickstreamAnalyticsMetadataDdbArn],
+      }),
+    ];
+
+    const fn = new SolutionNodejsFunction(this, 'StoreMetadataIntoDDBFn', {
+      runtime: Runtime.NODEJS_18_X,
+      entry: join(
+        this.lambdaRootPath,
+        'store-metadata-into-ddb.ts',
+      ),
+      handler: 'handler',
+      memorySize: 1024,
+      timeout: Duration.minutes(13),
+      logRetention: RetentionDays.ONE_WEEK,
+      reservedConcurrentExecutions: 1,
+      role: createLambdaRole(this, 'StoreMetadataIntoDDBRole', true, policyStatements),
+      ...props.networkConfig,
+      securityGroups: [fnSG],
+      environment: {
+        ... this.toRedshiftEnvVariables(props),
+        REDSHIFT_DATA_API_ROLE: props.dataAPIRole.roleArn,
+        METADATA_DDB_TABLE_ARN: props.scanMetadataWorkflowData.clickstreamAnalyticsMetadataDdbArn,
+        ... POWERTOOLS_ENVS,
+      },
+    });
+    props.dataAPIRole.grantAssumeRole(fn.grantPrincipal);
+    return fn;
+  }
+
+}

--- a/src/analytics/private/scan-metadata-workflow.ts
+++ b/src/analytics/private/scan-metadata-workflow.ts
@@ -161,6 +161,7 @@ export class ScanMetadataWorkflow extends Construct {
         level: LogLevel.ALL,
       },
       tracingEnabled: true,
+      comment: 'This state machine is responsible for periodically aggregating events and parameters data and store the aggregated data in DynamoDB',
     });
 
     return scanMetadataStateMachine;

--- a/src/analytics/private/sql-def.ts
+++ b/src/analytics/private/sql-def.ts
@@ -91,6 +91,10 @@ export const schemaDefs: SQLDef[] = [
   },
   {
     updatable: 'true',
+    sqlFile: 'sp-scan-metadata.sql',
+  },
+  {
+    updatable: 'true',
     sqlFile: 'sp-clear-expired-events.sql',
   },
 

--- a/src/analytics/private/sqls/redshift/sp-scan-metadata.sql
+++ b/src/analytics/private/sqls/redshift/sp-scan-metadata.sql
@@ -1,0 +1,391 @@
+CREATE OR REPLACE PROCEDURE {{schema}}.sp_scan_metadata(top_frequent_properties_limit NUMERIC, day_range NUMERIC)
+AS $$ 
+DECLARE
+  rec RECORD;
+  query text;
+	log_name varchar(50) := 'sp_scan_metadata';
+BEGIN
+
+	-- Drop event_properties_metadata and event_metadata table, the data should be moved into DDB
+	DROP TABLE IF EXISTS {{schema}}.event_properties_metadata;
+	DROP TABLE IF EXISTS {{schema}}.event_metadata;
+
+  CREATE TABLE IF NOT EXISTS {{schema}}.event_properties_metadata (
+    id VARCHAR(255),
+    type VARCHAR(255),
+    prefix VARCHAR(255),
+    event_name VARCHAR(255),
+    project_id VARCHAR(255),
+    app_id VARCHAR(255),
+    category VARCHAR(255),
+		metadata_source VARCHAR(255),
+		property_type VARCHAR(255),
+    property_name VARCHAR(255),
+		property_id VARCHAR(255),
+    value_type VARCHAR(255),
+    value_enum VARCHAR(MAX),
+    platform VARCHAR(255)
+  );
+
+  CREATE TABLE IF NOT EXISTS {{schema}}.event_metadata (
+    id VARCHAR(255),
+    type VARCHAR(255),
+    prefix VARCHAR(255),
+    project_id VARCHAR(255),
+    app_id VARCHAR(255),
+    event_name VARCHAR(255),
+		metadata_source VARCHAR(255),
+		data_volumel_last_day VARCHAR(255),
+    platform VARCHAR(255)
+  );    	
+
+  CREATE TEMP TABLE IF NOT EXISTS properties_temp_table (
+    event_name VARCHAR(255),
+    project_id VARCHAR(255),
+    app_info_app_id VARCHAR(255),
+    property_category VARCHAR(20),
+    property_name VARCHAR(255),
+    property_value VARCHAR(255),
+    value_type VARCHAR(255),
+    platform VARCHAR(255)
+  );
+
+	-- Table is for setting the the column of including into metadata
+	CREATE TEMPORARY TABLE IF NOT EXISTS property_column_temp_table (column_name VARCHAR);
+
+	INSERT INTO 
+		property_column_temp_table (column_name) 
+	VALUES 
+		('platform'), 
+		('project_id');
+
+	-- Table is for setting the the column and the properties that should be included into metadata
+	CREATE TEMPORARY TABLE IF NOT EXISTS property_array_temp_table (column_name VARCHAR, property_name VARCHAR);
+
+	INSERT INTO 
+		property_array_temp_table (column_name, property_name) 
+	VALUES 
+		('app_info','app_id'), 
+		('app_info','install_source'), 
+		('app_info', 'id'), 
+		('app_info', 'version'), 
+		('device', 'mobile_brand_name'), 
+		('device', 'mobile_model_name'), 
+		('device', 'manufacturer'), 
+		('device', 'screen_width'), 
+		('device', 'screen_height'), 
+		('device', 'carrier'), 
+		('device', 'network_type'), 
+		('device', 'operating_system_version'), 
+		('device', 'operating_system'), 
+		('device', 'ua_browser'), 
+		('device', 'ua_browser_version'), 
+		('device', 'ua_os'), 
+		('device', 'ua_os_version'), 
+		('device', 'ua_device'), 
+		('device', 'ua_device_category'), 
+		('device', 'system_language'), 
+		('device', 'time_zone_offset_seconds'), 
+		('device', 'vendor_id'), 
+		('device', 'advertising_id'), 
+		('device', 'host_name'), 
+		('device', 'viewport_height'), 
+		('device', 'viewport_width'), 
+		('geo', 'city'), 
+		('geo', 'continent'), 
+		('geo', 'country'), 
+		('geo', 'metro'), 
+		('geo', 'region'),
+		('geo', 'sub_continent'), 
+		('geo', 'locale'), 
+		('traffic_source', 'medium'), 
+		('traffic_source', 'name'), 
+		('traffic_source', 'source');
+
+	CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'info', 'create temp table successfully.');
+
+	query := 'SELECT column_name FROM property_column_temp_table';
+	FOR rec IN EXECUTE query LOOP
+		EXECUTE 'INSERT INTO properties_temp_table (SELECT event_name, project_id, app_info.app_id::varchar AS app_info_app_id, ''other'' AS property_category, ''' || quote_ident(rec.column_name) || ''' AS property_name, ' || quote_ident(rec.column_name) || '::varchar AS property_values, ''String'' AS value_type, platform FROM {{schema}}.ods_events WHERE ingest_timestamp >= EXTRACT(epoch FROM DATE_TRUNC(''day'', GETDATE() - INTERVAL ''' || quote_ident(day_range) || ' day'')::timestamp)*1000::bigint AND ingest_timestamp < EXTRACT(epoch FROM DATE_TRUNC(''day'', GETDATE())::timestamp)*1000::bigint)';
+	END LOOP;
+
+	query := 'SELECT column_name, property_name FROM property_array_temp_table';
+	FOR rec IN EXECUTE query LOOP
+		EXECUTE 'INSERT INTO properties_temp_table (SELECT event_name, project_id, app_info.app_id::varchar AS app_info_app_id, ''' || quote_ident(rec.column_name) || ''' AS property_category, ' || quote_literal(rec.property_name) || ' AS property_name, ' || quote_ident(rec.column_name) || '.' || quote_ident(rec.property_name) || '::varchar AS property_values, CASE WHEN ''' || quote_ident(rec.property_name) || '''::varchar IN (''screen_height'', ''screen_width'', ''viewport_height'', ''viewport_width'', ''time_zone_offset_seconds'') THEN ''Integer'' ELSE ''String'' END AS value_type, platform FROM {{schema}}.ods_events WHERE ingest_timestamp >= EXTRACT(epoch FROM DATE_TRUNC(''day'', GETDATE() - INTERVAL ''' || quote_ident(day_range) || ' day'')::timestamp)*1000::bigint AND ingest_timestamp < EXTRACT(epoch FROM DATE_TRUNC(''day'', GETDATE())::timestamp)*1000::bigint)';
+	END LOOP;
+
+	INSERT INTO properties_temp_table (
+		SELECT
+			event_name,
+			project_id,
+			app_info.app_id::varchar AS app_info_app_id,
+			'event' AS property_category,
+			event_params.key::varchar AS property_name,
+			coalesce 
+				(nullif(event_params.value.string_value::varchar,'')
+			  	, nullif(event_params.value.int_value::varchar,'')
+			  	, nullif(event_params.value.float_value::varchar,'')
+			  	, nullif(event_params.value.double_value::varchar,'')) AS property_values,
+			CASE 
+				WHEN event_params.value.string_value::varchar IS NOT NULL THEN 'String'
+				WHEN event_params.value.int_value::varchar IS NOT NULL THEN 'Integer'
+				WHEN event_params.value.float_value::varchar IS NOT NULL THEN 'Float'
+				WHEN event_params.value.double_value::varchar IS NOT NULL THEN 'Double'
+			ELSE 'None'
+			END AS value_type,
+			platform
+		FROM {{schema}}.ods_events e, e.event_params AS event_params
+		WHERE 
+			property_name NOT LIKE '%timestamp%'
+			AND ingest_timestamp >= EXTRACT(epoch FROM DATE_TRUNC('day', GETDATE() - INTERVAL '1 day' * day_range)::timestamp)*1000::bigint
+			AND ingest_timestamp < EXTRACT(epoch FROM DATE_TRUNC('day', GETDATE())::timestamp)*1000::bigint
+	);
+
+	CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'info', 'Insert data into properties_temp_table table successfully.');		
+
+	INSERT INTO {{schema}}.event_properties_metadata (id, type, prefix, event_name, project_id, app_id, category, metadata_source, property_type, property_name, property_id, value_type, value_enum, platform) 
+	SELECT
+			project_id || '#' || app_info_app_id || '#' || event_name || '#' || property_name AS id,
+	  	'EVENT#' || project_id || '#' || app_info_app_id || '#' || event_name AS type,
+	  	'EVENT_PARAMETER#' || project_id || '#' || app_info_app_id AS prefix,    
+	  	event_name AS event_name,
+	  	project_id AS project_id,
+	  	app_info_app_id AS app_id,
+	  	property_category AS category,
+			CASE 
+				WHEN LEFT(property_name, 1) = '_' THEN 'Preset'
+				ELSE 'Custom'
+			END AS metadata_source,
+			CASE 
+				WHEN LEFT(property_name, 1) = '_' THEN 'Public'
+				ELSE 'Private'
+			END AS property_type,
+	  	property_name AS property_name,
+			event_name || '#' || property_name AS property_id,
+	  	value_type AS value_type,
+	  	property_values AS value_enum,
+			platform AS platform
+	FROM (
+		SELECT 
+			event_name, 
+			project_id, 
+			app_info_app_id, 
+			property_category, 
+			property_name, 
+			value_type, 
+			platform,
+			'[' || LISTAGG(property_value, ', ') WITHIN GROUP (ORDER BY property_value) || ']' AS property_values
+		FROM (
+      SELECT 
+        event_name, 
+        project_id, 
+        app_info_app_id, 
+        property_category, 
+        property_name, 
+        value_type,
+        property_value,
+          '[' || LISTAGG(platform, ', ') WITHIN GROUP (ORDER BY platform) || ']' AS platform
+      FROM (
+        SELECT 
+          event_name, 
+          project_id, 
+          app_info_app_id, 
+          property_category, 
+          property_name, 
+          property_value, 
+          value_type, 
+          platform, 
+          parameter_count
+        FROM (
+          SELECT 
+            event_name, 
+            project_id, 
+            app_info_app_id, 
+            property_category, 
+            property_name, 
+            property_value, 
+            value_type, 
+            platform, 
+            parameter_count,
+              ROW_NUMBER() OVER (PARTITION BY event_name, project_id, app_info_app_id, property_category, property_name ORDER BY parameter_count DESC) AS row_num
+          FROM (
+            SELECT 
+              event_name, 
+              project_id, 
+              app_info_app_id, 
+              property_category, 
+              property_name, 
+              property_value, 
+              platform, 
+              value_type, 
+              count(*) AS parameter_count 
+            FROM properties_temp_table
+            GROUP BY event_name, project_id, app_info_app_id, property_category, property_name, property_value, value_type, platform
+          )
+        )
+        WHERE 
+          row_num <= top_frequent_properties_limit OR
+          (event_name = '_page_view' AND property_name IN ('_page_title', '_page_url')) OR
+          (event_name = '_screen_view' and property_name IN ('_screen_name', '_screen_id'))
+        ORDER BY event_name, project_id, app_info_app_id      
+			)
+			GROUP By event_name, project_id, app_info_app_id, property_category, property_name, value_type, property_value
+		)
+		GROUP By event_name, project_id, app_info_app_id, property_category, property_name, value_type, platform
+	);
+
+	CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'info', 'Insert all parameters data into event_properties_metadata table successfully.');	
+
+  -- user attribute
+	INSERT INTO {{schema}}.event_properties_metadata (id, type, prefix, event_name, project_id, app_id, category, metadata_source, property_type, property_name, property_id, value_type, value_enum, platform) 
+	SELECT
+		project_id || '#' || app_info_app_id || '#' || event_name || '#' || property_name AS id,
+		'USER_ATTRIBUTE#' || project_id || '#' || app_info_app_id || '#' || property_name AS type,
+		'USER_PARAMETER#' || project_id || '#' || app_info_app_id AS prefix,
+		event_name AS event_name,
+		project_id AS project_id,
+		app_info_app_id AS app_id,
+		'user' AS category,
+		CASE 
+			WHEN LEFT(property_name, 1) = '_' THEN 'Preset'
+			ELSE 'Custom'
+		END AS metadata_source,	
+		CASE 
+			WHEN LEFT(property_name, 1) = '_' THEN 'Public'
+			ELSE 'Private'
+		END AS property_type,
+		property_name AS property_name,
+		event_name || '#' || property_name AS property_id,
+		value_type AS value_type,
+		property_values AS value_enum,
+		platform AS platform
+	FROM (
+		SELECT 
+			event_name, 
+			project_id, 
+			app_info_app_id, 
+			property_name, 
+			value_type, 
+			platform,
+			'[' || LISTAGG(property_value, ', ') WITHIN GROUP (ORDER BY property_value) || ']' AS property_values
+	  	FROM (
+	  		SELECT 
+	  			event_name, 
+	  			project_id, 
+	  			app_info_app_id, 
+	  			property_name, 
+	  			value_type,
+	  			property_value,
+	      		'[' || LISTAGG(platform, ', ') WITHIN GROUP (ORDER BY platform) || ']' AS platform
+	  		FROM (
+          SELECT 
+            event_name, 
+            project_id, 
+            app_info_app_id, 
+            property_name, 
+            property_value, 
+            value_type, 
+            platform, 
+            parameter_count
+          FROM (
+            SELECT 
+              event_name, 
+              project_id, 
+              app_info_app_id, 
+              property_name, 
+              property_value, 
+              value_type, 
+              platform, 
+              parameter_count,
+                ROW_NUMBER() OVER (PARTITION BY event_name, project_id ORDER BY parameter_count DESC) AS row_num
+            FROM (
+              SELECT 
+                event_name, 
+                project_id, 
+                app_info_app_id, 
+                property_name, 
+                property_value, 
+                platform, 
+                value_type, 
+                count(*) AS parameter_count 
+              FROM (
+                SELECT
+                  event_name,
+                  project_id,
+                  app_info.app_id::varchar AS app_info_app_id,
+                  user_properties.key::varchar AS property_name,
+                  coalesce 
+                  (
+                    nullif(user_properties.value.string_value::varchar,'')
+                    , nullif(user_properties.value.int_value::varchar,'')
+                    , nullif(user_properties.value.float_value::varchar,'')
+                    , nullif(user_properties.value.double_value::varchar,'')
+                  ) AS property_value,
+                  CASE 
+                    WHEN user_properties.value.string_value::varchar IS NOT NULL THEN 'String'
+                    WHEN user_properties.value.int_value::varchar IS NOT NULL THEN 'Integer'
+                    WHEN user_properties.value.float_value::varchar IS NOT NULL THEN 'Float'
+                    WHEN user_properties.value.double_value::varchar IS NOT NULL THEN 'Double'
+                  ELSE 'None'
+                  END AS value_type,
+                  platform
+                FROM {{schema}}.ods_events e, e.user_properties AS user_properties
+                WHERE 
+                  property_name NOT LIKE '%timestamp%'
+                  AND ingest_timestamp >= EXTRACT(epoch FROM DATE_TRUNC('day', GETDATE() - INTERVAL '1 day' * day_range)::timestamp)*1000::bigint
+                  AND ingest_timestamp < EXTRACT(epoch FROM DATE_TRUNC('day', GETDATE())::timestamp)*1000::bigint  							            
+              )
+              GROUP BY event_name, project_id, app_info_app_id, property_name, property_value, value_type, platform
+            )
+          )
+          WHERE row_num <= top_frequent_properties_limit
+          ORDER BY event_name, project_id, app_info_app_id
+	  		)
+	  		GROUP By event_name, project_id, app_info_app_id, property_name, value_type, property_value
+	  	)
+	  	GROUP By event_name, project_id, app_info_app_id, property_name, value_type, platform
+	);
+	CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'info', 'Insert all user attribute data into event_properties_metadata table successfully.');
+
+	INSERT INTO {{schema}}.event_metadata (id, type, prefix, project_id, app_id, event_name, metadata_source, data_volumel_last_day, platform)
+	SELECT 
+		project_id || '#' || app_info_app_id || '#' || event_name AS id,
+		'EVENT#' || project_id || '#' || app_info_app_id || '#' || event_name AS type,
+		'EVENT#' || project_id || '#' || app_info_app_id AS prefix,
+		project_id AS project_id,
+		app_info_app_id AS app_id,
+		event_name AS event_name,
+		CASE 
+			WHEN LEFT(event_name, 1) = '_' THEN 'Preset'
+			ELSE 'Custom'
+		END AS metadata_source,	
+		data_volumel_last_day AS data_volumel_last_day,
+		platform AS platform
+	FROM (   
+		SELECT 
+		  event_name,
+		  project_id,
+		  app_info_app_id,
+			data_volumel_last_day,
+		  '[' || LISTAGG(platform, ', ') WITHIN GROUP (ORDER BY platform) || ']' AS platform
+		FROM (
+			SELECT
+				event_name,
+				project_id,
+				app_info.app_id::varchar AS app_info_app_id,
+				platform,
+				count(*) AS data_volumel_last_day
+			FROM {{schema}}.ods_events
+			WHERE 
+				ingest_timestamp >= EXTRACT(epoch FROM DATE_TRUNC('day', GETDATE() - INTERVAL '1 day' * day_range)::timestamp)*1000::bigint
+				AND ingest_timestamp < EXTRACT(epoch FROM DATE_TRUNC('day', GETDATE())::timestamp)*1000::bigint
+				AND event_name != '_'
+			GROUP BY event_name, project_id, app_info_app_id, platform
+		)
+		GROUP BY event_name, project_id, app_info_app_id, data_volumel_last_day
+	);
+	CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'info', 'Insert all event data into event_metadata table successfully.');	
+EXCEPTION WHEN OTHERS THEN
+    CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'error', 'error message:' || SQLERRM);	
+END;
+$$ LANGUAGE plpgsql;

--- a/src/analytics/private/sqls/redshift/sp-scan-metadata.sql
+++ b/src/analytics/private/sqls/redshift/sp-scan-metadata.sql
@@ -190,7 +190,7 @@ BEGIN
 			property_name, 
 			value_type, 
 			platform,
-			'[' || LISTAGG(property_value, ', ') WITHIN GROUP (ORDER BY property_value) || ']' AS property_values
+			LISTAGG(property_value, '#') WITHIN GROUP (ORDER BY property_value) AS property_values
 		FROM (
       SELECT 
         event_name, 
@@ -200,7 +200,7 @@ BEGIN
         property_name, 
         value_type,
         property_value,
-          '[' || LISTAGG(platform, ', ') WITHIN GROUP (ORDER BY platform) || ']' AS platform
+          LISTAGG(platform, '#') WITHIN GROUP (ORDER BY platform) AS platform
       FROM (
         SELECT 
           event_name, 
@@ -280,7 +280,7 @@ BEGIN
 			property_name, 
 			value_type, 
 			platform,
-			'[' || LISTAGG(property_value, ', ') WITHIN GROUP (ORDER BY property_value) || ']' AS property_values
+			LISTAGG(property_value, '#') WITHIN GROUP (ORDER BY property_value) AS property_values
 	  	FROM (
 	  		SELECT 
 	  			project_id, 
@@ -288,7 +288,7 @@ BEGIN
 	  			property_name, 
 	  			value_type,
 	  			property_value,
-	      		'[' || LISTAGG(platform, ', ') WITHIN GROUP (ORDER BY platform) || ']' AS platform
+	      	LISTAGG(platform, '#') WITHIN GROUP (ORDER BY platform) AS platform
 	  		FROM (
           SELECT 
             project_id, 
@@ -375,7 +375,7 @@ BEGIN
 		  project_id,
 		  app_info_app_id,
 			data_volumel_last_day,
-		  '[' || LISTAGG(platform, ', ') WITHIN GROUP (ORDER BY platform) || ']' AS platform
+		  LISTAGG(platform, '#') WITHIN GROUP (ORDER BY platform) AS platform
 		FROM (
 			SELECT
 				event_name,

--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -229,6 +229,8 @@ export const REDSHIFT_DB_USER_NAME_PATTERN = '^([a-zA-Z][a-zA-Z0-9-_]{1,63})?$';
 export const REDSHIFT_CLUSTER_IDENTIFIER_PATTERN = '^([a-zA-Z][a-zA-Z0-9-_]{1,63})?$';
 export const SECRETS_MANAGER_ARN_PATTERN =
   '^$|^arn:aws(-cn|-us-gov)?:secretsmanager:[a-z0-9-]+:[0-9]{12}:secret:[a-zA-Z0-9-\/]+$';
+export const DDB_TABLE_ARN_PATTERN =
+  '^arn:aws(-cn|-us-gov)?:dynamodb:[a-z0-9-]+:[0-9]{12}:table\/[a-zA-Z0-9_.-]+$';
 export const SCHEDULE_EXPRESSION_PATTERN =
   '^(rate\\(\\s*\\d+\\s+(hour|minute|day)s?\\s*\\))|(cron\\(.*\\))$';
 

--- a/src/data-analytics-redshift-stack.ts
+++ b/src/data-analytics-redshift-stack.ts
@@ -97,6 +97,11 @@ export function createRedshiftAnalyticsStack(
     upsertUsersWorkflowData: {
       scheduleExpression: props.upsertUsersConfiguration.scheduleExpression,
     },
+    scanMetadataWorkflowData: {
+      scheduleExpression: props.scanMetadataConfiguration.scheduleExpression,
+      clickstreamAnalyticsMetadataDdbArn: props.scanMetadataConfiguration.clickstreamAnalyticsMetadataDdbArn,
+      topFrequentPropertiesLimit: props.scanMetadataConfiguration.topFrequentPropertiesLimit,
+    },
     clearExpiredEventsWorkflowData: {
       scheduleExpression: props.clearExpiredEventsConfiguration.scheduleExpression,
       retentionRangeDays: props.clearExpiredEventsConfiguration.retentionRangeDays,

--- a/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
@@ -181,6 +181,10 @@ describe('Custom resource - Create schemas for applications in Redshift database
     },
     {
       updatable: 'true',
+      sqlFile: 'sp-scan-metadata.sql',
+    },
+    {
+      updatable: 'true',
       sqlFile: 'sp-clear-expired-events.sql',
     },
 
@@ -255,6 +259,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
       '/opt/sp-clear-expired-events.sql': testSqlContent(rootPath + 'sp-clear-expired-events.sql'),
       '/opt/sp-clickstream-log.sql': testSqlContent(rootPath + 'sp-clickstream-log.sql'),
       '/opt/sp-upsert-users.sql': testSqlContent(rootPath + 'sp-upsert-users.sql'),
+      '/opt/sp-scan-metadata.sql': testSqlContent(rootPath + 'sp-scan-metadata.sql'),
     });
   });
 
@@ -603,7 +608,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
         if (input as BatchExecuteStatementCommandInput) {
           if (input.Sqls.length >= 9 && input.Sqls[0].includes('CREATE SCHEMA IF NOT EXISTS app2')
           && input.Sqls[1].includes(`CREATE TABLE IF NOT EXISTS app2.${TABLE_NAME_ODS_EVENT}(`)
-          && input.Sqls[9].includes(`CREATE TABLE IF NOT EXISTS app1.${TABLE_NAME_ODS_EVENT}`)) {
+          && input.Sqls[10].includes(`CREATE TABLE IF NOT EXISTS app1.${TABLE_NAME_ODS_EVENT}`)) {
             return { Id: 'Id-1' };
           }
         }
@@ -630,8 +635,8 @@ describe('Custom resource - Create schemas for applications in Redshift database
         if (input as BatchExecuteStatementCommandInput) {
           if (input.Sqls.length >= 10 && input.Sqls[0].includes('CREATE SCHEMA IF NOT EXISTS app2')
             && input.Sqls[1].includes(`CREATE TABLE IF NOT EXISTS app2.${TABLE_NAME_ODS_EVENT}(`)
-            && !input.Sqls[9].includes(`CREATE TABLE IF NOT EXISTS app1.${TABLE_NAME_ODS_EVENT}`)
-            && input.Sqls[9].includes('CREATE OR REPLACE PROCEDURE app1.sp_clickstream_log')
+            && !input.Sqls[10].includes(`CREATE TABLE IF NOT EXISTS app1.${TABLE_NAME_ODS_EVENT}`)
+            && input.Sqls[10].includes('CREATE OR REPLACE PROCEDURE app1.sp_clickstream_log')
           ) {
             return { Id: 'Id-1' };
           }

--- a/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/check-scan-metadata-status.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/check-scan-metadata-status.test.ts
@@ -1,0 +1,248 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { DescribeStatementCommand, ExecuteStatementCommand, GetStatementResultCommand, RedshiftDataClient, StatusString } from '@aws-sdk/client-redshift-data';
+import { mockClient } from 'aws-sdk-client-mock';
+import { handler, CheckScanMetadataStatusEvent } from '../../../../../src/analytics/lambdas/scan-metadata-workflow/check-scan-metadata-status';
+import { CheckScanMetadataStatusEventDetail } from '../../../../../src/analytics/private/model';
+import { REDSHIFT_MODE } from '../../../../../src/common/model';
+import 'aws-sdk-client-mock-jest';
+
+const checkScanMetadataStatusEventDetail: CheckScanMetadataStatusEventDetail = {
+  id: 'id-1',
+  appId: 'app1',
+  status: '',
+};
+
+const checkScanMetadataStatusEvent: CheckScanMetadataStatusEvent = {
+  detail: checkScanMetadataStatusEventDetail,
+};
+
+describe('Lambda - check the scan metadata status in Redshift Serverless', () => {
+
+  const redshiftDataMock = mockClient(RedshiftDataClient);
+
+  const workGroupName = 'demo';
+
+  beforeEach(() => {
+    redshiftDataMock.reset();
+
+    // set the env before loading the source
+    process.env.REDSHIFT_MODE = REDSHIFT_MODE.SERVERLESS;
+    process.env.REDSHIFT_SERVERLESS_WORKGROUP_NAME = workGroupName;
+  });
+
+  test('Check scan metadata status with response FINISHED', async () => {
+    const exeuteId = 'Id-1';
+    redshiftDataMock.on(DescribeStatementCommand).resolves({
+      Status: StatusString.FINISHED,
+    });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: exeuteId });
+    redshiftDataMock.on(GetStatementResultCommand).resolvesOnce({ Records: [] });
+    const resp = await handler(checkScanMetadataStatusEvent);
+    expect(resp).toEqual({
+      detail: {
+        appId: 'app1',
+        status: StatusString.FINISHED,
+        message: [],
+      },
+    });
+    expect(redshiftDataMock).toHaveReceivedCommandWith(DescribeStatementCommand, {
+      Id: checkScanMetadataStatusEvent.detail.id,
+    });
+  });
+
+  test('Check scan metadata status with response STARTED', async () => {
+    redshiftDataMock.on(DescribeStatementCommand).resolvesOnce({
+      Status: StatusString.STARTED,
+    });
+    const resp = await handler(checkScanMetadataStatusEvent);
+    expect(resp).toEqual({
+      detail: expect.objectContaining({
+        status: StatusString.STARTED,
+      }),
+    });
+    expect(redshiftDataMock).toHaveReceivedCommandWith(DescribeStatementCommand, {
+      Id: checkScanMetadataStatusEvent.detail.id,
+    });
+  });
+
+  test('Check scan metadata with response FAILED', async () => {
+    const exeuteId = 'Id-1';
+    redshiftDataMock.on(DescribeStatementCommand).resolvesOnce({
+      Status: StatusString.FAILED,
+    }).resolvesOnce({
+      Status: StatusString.FINISHED,
+    }).resolvesOnce({
+      Status: StatusString.FINISHED,
+    });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: exeuteId });
+    redshiftDataMock.on(GetStatementResultCommand).resolvesOnce({ Records: [] });
+    const resp = await handler(checkScanMetadataStatusEvent);
+    expect(resp).toEqual(expect.objectContaining({
+      detail: expect.objectContaining({
+        status: StatusString.FAILED,
+      }),
+    }));
+    expect(redshiftDataMock).toHaveReceivedCommandWith(DescribeStatementCommand, {
+      Id: checkScanMetadataStatusEvent.detail.id,
+    });
+  });
+
+  test('Check scan metadata status with response ABORTED', async () => {
+    const exeuteId = 'Id-1';
+    redshiftDataMock.on(DescribeStatementCommand).resolvesOnce({
+      Status: StatusString.ABORTED,
+    }).resolvesOnce({
+      Status: StatusString.FINISHED,
+    }).resolvesOnce({
+      Status: StatusString.FINISHED,
+    });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: exeuteId });
+    redshiftDataMock.on(GetStatementResultCommand).resolvesOnce({ Records: [] });
+    const resp = await handler(checkScanMetadataStatusEvent);
+    expect(resp).toEqual(expect.objectContaining({
+      detail: expect.objectContaining({
+        status: StatusString.ABORTED,
+      }),
+    }));
+    expect(redshiftDataMock).toHaveReceivedCommandWith(DescribeStatementCommand, {
+      Id: checkScanMetadataStatusEvent.detail.id,
+    });
+  });
+
+  test('Execute command error in Redshift when checking scan metadata status', async () => {
+    redshiftDataMock.on(DescribeStatementCommand).rejectsOnce();
+    try {
+      await handler(checkScanMetadataStatusEvent);
+      fail('The error in executing statement of Redshift data was caught');
+    } catch (error) {
+      expect(redshiftDataMock).toHaveReceivedCommandWith(DescribeStatementCommand, {
+        Id: 'id-1',
+      });
+    }
+  });
+
+  test('Execute command error in Redshift when query scan metadata log', async () => {
+    const exeuteId = 'Id-1';
+    redshiftDataMock.on(DescribeStatementCommand).resolves({
+      Status: StatusString.FINISHED,
+    });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: exeuteId });
+    redshiftDataMock.on(GetStatementResultCommand).rejectsOnce();
+    try {
+      await handler(checkScanMetadataStatusEvent);
+      fail('The error in executing statement of Redshift data was caught');
+    } catch (error) {
+      expect(redshiftDataMock).toHaveReceivedCommandWith(DescribeStatementCommand, {
+        Id: 'id-1',
+      });
+    }
+  });
+});
+
+describe('Lambda - check the scan metadata status in Redshift Provisioned', () => {
+
+  const redshiftDataMock = mockClient(RedshiftDataClient);
+
+  const clusterIdentifier = 'cluster-1';
+  const dbUser = 'aUser';
+
+  beforeEach(() => {
+    redshiftDataMock.reset();
+
+    // set the env before loading the source
+    process.env.REDSHIFT_MODE = REDSHIFT_MODE.PROVISIONED;
+    process.env.REDSHIFT_CLUSTER_IDENTIFIER = clusterIdentifier;
+    process.env.REDSHIFT_DB_USER = dbUser;
+  });
+
+  test('Check scan metadata status with response FINISHED', async () => {
+    const exeuteId = 'Id-1';
+    redshiftDataMock.on(DescribeStatementCommand).resolves({
+      Status: StatusString.FINISHED,
+    });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: exeuteId });
+    redshiftDataMock.on(GetStatementResultCommand).resolvesOnce({ Records: [] });
+    const resp = await handler(checkScanMetadataStatusEvent);
+    expect(resp).toEqual({
+      detail: {
+        appId: 'app1',
+        status: StatusString.FINISHED,
+        message: [],
+      },
+    });
+    expect(redshiftDataMock).toHaveReceivedCommandWith(DescribeStatementCommand, {
+      Id: checkScanMetadataStatusEvent.detail.id,
+    });
+  });
+
+  test('Check scan metadata status with response STARTED', async () => {
+    redshiftDataMock.on(DescribeStatementCommand).resolvesOnce({
+      Status: StatusString.STARTED,
+    });
+    const resp = await handler(checkScanMetadataStatusEvent);
+    expect(resp).toEqual({
+      detail: expect.objectContaining({
+        status: StatusString.STARTED,
+      }),
+    });
+    expect(redshiftDataMock).toHaveReceivedCommandWith(DescribeStatementCommand, {
+      Id: checkScanMetadataStatusEvent.detail.id,
+    });
+  });
+
+  test('Check scan metadata status with response FAILED', async () => {
+    const exeuteId = 'Id-1';
+    redshiftDataMock.on(DescribeStatementCommand).resolvesOnce({
+      Status: StatusString.FAILED,
+    }).resolvesOnce({
+      Status: StatusString.FINISHED,
+    }).resolvesOnce({
+      Status: StatusString.FINISHED,
+    });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: exeuteId });
+    redshiftDataMock.on(GetStatementResultCommand).resolvesOnce({ Records: [] });
+    const resp = await handler(checkScanMetadataStatusEvent);
+    expect(resp).toEqual(expect.objectContaining({
+      detail: expect.objectContaining({
+        status: StatusString.FAILED,
+      }),
+    }));
+    expect(redshiftDataMock).toHaveReceivedCommandWith(DescribeStatementCommand, {
+      Id: checkScanMetadataStatusEvent.detail.id,
+    });
+  });
+
+  test('Check scan metadata status with response ABORTED', async () => {
+    const exeuteId = 'Id-1';
+    redshiftDataMock.on(DescribeStatementCommand).resolvesOnce({
+      Status: StatusString.ABORTED,
+    }).resolvesOnce({
+      Status: StatusString.FINISHED,
+    }).resolvesOnce({
+      Status: StatusString.FINISHED,
+    });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: exeuteId });
+    redshiftDataMock.on(GetStatementResultCommand).resolvesOnce({ Records: [] });
+    const resp = await handler(checkScanMetadataStatusEvent);
+    expect(resp).toEqual(expect.objectContaining({
+      detail: expect.objectContaining({
+        status: StatusString.ABORTED,
+      }),
+    }));
+    expect(redshiftDataMock).toHaveReceivedCommandWith(DescribeStatementCommand, {
+      Id: checkScanMetadataStatusEvent.detail.id,
+    });
+  });
+});

--- a/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/scan-metadata.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/scan-metadata.test.ts
@@ -1,0 +1,100 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { ExecuteStatementCommand, RedshiftDataClient } from '@aws-sdk/client-redshift-data';
+import { mockClient } from 'aws-sdk-client-mock';
+import { handler, ScanMetadataEvent } from '../../../../../src/analytics/lambdas/scan-metadata-workflow/scan-metadata';
+import { ScanMetadataBody } from '../../../../../src/analytics/private/model';
+import { REDSHIFT_MODE } from '../../../../../src/common/model';
+import 'aws-sdk-client-mock-jest';
+
+const scanMetadataBody: ScanMetadataBody = {
+  appId: 'app1',
+};
+
+const scanMetadataEvent: ScanMetadataEvent = {
+  detail: scanMetadataBody,
+};
+
+describe('Lambda - do scan metadata in Redshift Serverless', () => {
+
+  const redshiftDataMock = mockClient(RedshiftDataClient);
+
+  const workGroupName = 'demo';
+
+  beforeEach(() => {
+    redshiftDataMock.reset();
+
+    // set the env before loading the source
+    process.env.REDSHIFT_MODE = REDSHIFT_MODE.SERVERLESS;
+    process.env.REDSHIFT_SERVERLESS_WORKGROUP_NAME = workGroupName;
+  });
+
+  test('Executed Redshift scan metadata command', async () => {
+    const exeuteId = 'Id-1';
+    redshiftDataMock.on(ExecuteStatementCommand).resolvesOnce({ Id: exeuteId });
+    const resp = await handler(scanMetadataEvent);
+    expect(resp).toEqual({
+      detail: expect.objectContaining({
+        id: exeuteId,
+      }),
+    });
+    expect(redshiftDataMock).toHaveReceivedCommandWith(ExecuteStatementCommand, {
+      WorkgroupName: workGroupName,
+    });
+  });
+
+  test('Execute command error in Redshift when doing scan metadata', async () => {
+    redshiftDataMock.on(ExecuteStatementCommand).rejectsOnce();
+    try {
+      await handler(scanMetadataEvent);
+      fail('The error in executing statement of Redshift data was caught');
+    } catch (error) {
+      expect(redshiftDataMock).toHaveReceivedCommandWith(ExecuteStatementCommand, {
+        WorkgroupName: workGroupName,
+      });
+    }
+  });
+});
+
+describe('Lambda - scan metadata in Redshift Provisioned', () => {
+
+  const redshiftDataMock = mockClient(RedshiftDataClient);
+
+  const clusterIdentifier = 'cluster-1';
+  const dbUser = 'aUser';
+
+  beforeEach(() => {
+    redshiftDataMock.reset();
+
+    // set the env before loading the source
+    process.env.REDSHIFT_MODE = REDSHIFT_MODE.PROVISIONED;
+    process.env.REDSHIFT_CLUSTER_IDENTIFIER = clusterIdentifier;
+    process.env.REDSHIFT_DB_USER = dbUser;
+  });
+
+  test('Executed Redshift scan metadata command', async () => {
+    const exeuteId = 'Id-1';
+    redshiftDataMock.on(ExecuteStatementCommand).resolvesOnce({ Id: exeuteId });
+    const resp = await handler(scanMetadataEvent);
+    expect(resp).toEqual({
+      detail: expect.objectContaining({
+        id: exeuteId,
+      }),
+    });
+    expect(redshiftDataMock).toHaveReceivedCommandWith(ExecuteStatementCommand, {
+      ClusterIdentifier: clusterIdentifier,
+      DbUser: dbUser,
+    });
+  });
+});

--- a/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/store-metadata-into-ddb.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/store-metadata-into-ddb.test.ts
@@ -1,0 +1,338 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { DynamoDBClient, BatchWriteItemCommand } from '@aws-sdk/client-dynamodb';
+import { GetStatementResultCommand, DescribeStatementCommand, ExecuteStatementCommand, RedshiftDataClient, StatusString } from '@aws-sdk/client-redshift-data';
+import { mockClient } from 'aws-sdk-client-mock';
+import { handler, StoreMetadataEvent } from '../../../../../src/analytics/lambdas/scan-metadata-workflow/store-metadata-into-ddb';
+import { StoreMetadataBody } from '../../../../../src/analytics/private/model';
+import { REDSHIFT_MODE } from '../../../../../src/common/model';
+
+import 'aws-sdk-client-mock-jest';
+
+const storeMetadataBody: StoreMetadataBody = {
+  appId: 'app1',
+};
+
+const checkScanMetadataStatusEvent: StoreMetadataEvent = {
+  detail: storeMetadataBody,
+};
+
+describe('Lambda - store the metadata into DDB from Redshift', () => {
+
+  const redshiftDataMock = mockClient(RedshiftDataClient);
+
+  const dynamoDBMock = mockClient(DynamoDBClient);
+
+  const workGroupName = 'demo';
+
+  beforeEach(() => {
+    redshiftDataMock.reset();
+
+    // set the env before loading the source
+    process.env.REDSHIFT_MODE = REDSHIFT_MODE.SERVERLESS;
+    process.env.REDSHIFT_SERVERLESS_WORKGROUP_NAME = workGroupName;
+  });
+
+  test('Store metadata with response FINISHED', async () => {
+    const exeuteId = 'Id-1';
+    redshiftDataMock.on(DescribeStatementCommand).resolves({
+      Status: StatusString.FINISHED,
+    });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: exeuteId });
+    dynamoDBMock.on(BatchWriteItemCommand).resolves({});
+    redshiftDataMock.on(GetStatementResultCommand)
+      .resolvesOnce({
+        Records: [
+          [
+            { stringValue: 'projectId#appId#eventName' },
+            { stringValue: 'EVENT#sprojectId#appId#eventName' },
+            { stringValue: 'EVENT#projectId#appId' },
+            { stringValue: 'projectId' },
+            { stringValue: 'appId' },
+            { stringValue: 'eventName' },
+            { stringValue: 'custom' },
+            { stringValue: '2000' },
+            { stringValue: '[ANDROID,IOS]' },
+          ],
+        ],
+      })
+      .resolvesOnce({
+        Records: [
+          [
+            { stringValue: 'projectId#appId#eventName#propertyName' },
+            { stringValue: 'EVENT#sprojectId#appId#eventName' },
+            { stringValue: 'EVENT_PARAMETER#projectId#appId' },
+            { stringValue: 'eventName' },
+            { stringValue: 'projectId' },
+            { stringValue: 'appId' },
+            { stringValue: 'category' },
+            { stringValue: 'custom' },
+            { stringValue: 'Private' },
+            { stringValue: 'propertyName' },
+            { stringValue: 'propertyId' },
+            { stringValue: 'String' },
+            { stringValue: '[value1, value2, value3]' },
+            { stringValue: '[ANDROID,IOS]' },
+          ],
+        ],
+      });
+    const dateNowSpy = jest.spyOn(Date, 'now');
+    const timestamp = 1695120657125;
+    dateNowSpy.mockReturnValue(timestamp);
+    const resp = await handler(checkScanMetadataStatusEvent);
+
+    expect(dynamoDBMock).toHaveReceivedCommandWith(BatchWriteItemCommand, {
+      RequestItems: {
+        ClickstreamAnalyticsMetadata: [
+          {
+            PutRequest: {
+              Item: {
+                appId: {
+                  S: 'appId',
+                },
+                createAt: {
+                  N: '1695120657125',
+                },
+                dataVolumeLastDay: {
+                  N: '2000',
+                },
+                deleted: {
+                  BOOL: false,
+                },
+                description: {
+                  S: '',
+                },
+                displayName: {
+                  S: '',
+                },
+                hasData: {
+                  BOOL: true,
+                },
+                id: {
+                  S: 'projectId#appId#eventName',
+                },
+                metadataSource: {
+                  S: 'custom',
+                },
+                name: {
+                  S: 'eventName',
+                },
+                operator: {
+                  S: '',
+                },
+                platform: {
+                  L: [
+                    {
+                      S: 'ANDROID',
+                    },
+                    {
+                      S: 'IOS',
+                    },
+                  ],
+                },
+                prefix: {
+                  S: 'EVENT#projectId#appId',
+                },
+                projectId: {
+                  S: 'projectId',
+                },
+                ttl: {
+                  N: '1695725457',
+                },
+                type: {
+                  S: 'EVENT#sprojectId#appId#eventName',
+                },
+                updateAt: {
+                  N: '1695120657125',
+                },
+              },
+            },
+          },
+          {
+            PutRequest: {
+              Item: {
+                appId: {
+                  S: 'appId',
+                },
+                category: {
+                  S: 'category',
+                },
+                createAt: {
+                  N: '1695120657125',
+                },
+                deleted: {
+                  BOOL: false,
+                },
+                description: {
+                  S: '',
+                },
+                displayName: {
+                  S: '',
+                },
+                eventDescription: {
+                  S: '',
+                },
+                eventDisplayName: {
+                  S: '',
+                },
+                eventName: {
+                  S: 'eventName',
+                },
+                hasData: {
+                  BOOL: true,
+                },
+                id: {
+                  S: 'projectId#appId#eventName#propertyName',
+                },
+                metadataSource: {
+                  S: 'custom',
+                },
+                name: {
+                  S: 'propertyName',
+                },
+                operator: {
+                  S: '',
+                },
+                parameterId: {
+                  S: 'propertyId',
+                },
+                parameterType: {
+                  S: 'Private',
+                },
+                platform: {
+                  L: [
+                    {
+                      S: 'ANDROID',
+                    },
+                    {
+                      S: 'IOS',
+                    },
+                  ],
+                },
+                prefix: {
+                  S: 'EVENT_PARAMETER#projectId#appId',
+                },
+                projectId: {
+                  S: 'projectId',
+                },
+                ttl: {
+                  N: '1695725457',
+                },
+                type: {
+                  S: 'EVENT#sprojectId#appId#eventName',
+                },
+                updateAt: {
+                  N: '1695120657125',
+                },
+                valueEnum: {
+                  L: [
+                    {
+                      S: 'value1',
+                    },
+                    {
+                      S: ' value2',
+                    },
+                    {
+                      S: ' value3',
+                    },
+                  ],
+                },
+                valueType: {
+                  S: 'String',
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+    expect(resp).toEqual({
+      detail: {
+        appId: 'app1',
+        status: 'SUCCEED',
+        message: 'store metadata into ddb successfully',
+      },
+    });
+    expect(redshiftDataMock).toHaveReceivedNthCommandWith(1, ExecuteStatementCommand, {
+      ClusterIdentifier: undefined,
+      Database: 'project1',
+      DbUser: undefined,
+      Sql: 'SELECT id, type, prefix, project_id, app_id, event_name, metadata_source, data_volumel_last_day, platform FROM app1.event_metadata;',
+      WithEvent: true,
+      WorkgroupName: 'demo',
+    });
+    expect(redshiftDataMock).toHaveReceivedNthCommandWith(2, DescribeStatementCommand, {
+      Id: 'Id-1',
+    });
+    expect(redshiftDataMock).toHaveReceivedNthCommandWith(3, GetStatementResultCommand, {
+      Id: 'Id-1',
+    });
+    expect(redshiftDataMock).toHaveReceivedNthCommandWith(4, ExecuteStatementCommand, {
+      ClusterIdentifier: undefined,
+      Database: 'project1',
+      DbUser: undefined,
+      Sql: 'SELECT id, type, prefix, event_name, project_id, app_id, category, metadata_source, property_type, property_name, property_id, value_type, value_enum, platform FROM app1.event_properties_metadata;',
+      WithEvent: true,
+      WorkgroupName: 'demo',
+    });
+    expect(redshiftDataMock).toHaveReceivedNthCommandWith(5, DescribeStatementCommand, {
+      Id: 'Id-1',
+    });
+    expect(redshiftDataMock).toHaveReceivedNthCommandWith(6, GetStatementResultCommand, {
+      Id: 'Id-1',
+    });
+  });
+
+  test('Store metadata for query id is undefined', async () => {
+    redshiftDataMock.on(DescribeStatementCommand).resolvesOnce({
+      Status: StatusString.FAILED,
+    });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: undefined });
+    dynamoDBMock.on(BatchWriteItemCommand).resolves({});
+    redshiftDataMock.on(GetStatementResultCommand).resolves({
+      Records: [],
+    });
+    const resp = await handler(checkScanMetadataStatusEvent);
+    expect(resp).toEqual({
+      detail: {
+        appId: 'app1',
+        status: 'FAILED',
+        message: 'store metadata into ddb failed',
+      },
+    });
+  });
+
+  test('Store metadata with redshift FAILED', async () => {
+    const exeuteId = 'Id-1';
+    redshiftDataMock.on(DescribeStatementCommand).resolvesOnce({
+      Status: StatusString.STARTED,
+    })
+      .resolvesOnce({
+        Status: StatusString.FAILED,
+      });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: exeuteId });
+    dynamoDBMock.on(BatchWriteItemCommand).resolves({});
+    redshiftDataMock.on(GetStatementResultCommand).resolves({
+      Records: [],
+    });
+    const resp = await handler(checkScanMetadataStatusEvent);
+    expect(resp).toEqual({
+      detail: {
+        appId: 'app1',
+        status: 'FAILED',
+        message: 'store metadata into ddb failed',
+      },
+    });
+  });
+});

--- a/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/store-metadata-into-ddb.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/store-metadata-into-ddb.test.ts
@@ -195,170 +195,6 @@ describe('Lambda - store the metadata into DDB from Redshift', () => {
         ],
       },
     });
-    //   RequestItems: {
-    //     ClickstreamAnalyticsMetadata: [
-    //       {
-    //         PutRequest: {
-    //           Item: {
-    //             appId: {
-    //               S: 'appId',
-    //             },
-    //             createAt: {
-    //               N: '1695120657125',
-    //             },
-    //             dataVolumeLastDay: {
-    //               N: '2000',
-    //             },
-    //             deleted: {
-    //               BOOL: false,
-    //             },
-    //             description: {
-    //               S: '',
-    //             },
-    //             displayName: {
-    //               S: '',
-    //             },
-    //             hasData: {
-    //               BOOL: true,
-    //             },
-    //             id: {
-    //               S: 'projectId#appId#eventName',
-    //             },
-    //             metadataSource: {
-    //               S: 'custom',
-    //             },
-    //             name: {
-    //               S: 'eventName',
-    //             },
-    //             operator: {
-    //               S: '',
-    //             },
-    //             platform: {
-    //               L: [
-    //                 {
-    //                   S: 'ANDROID',
-    //                 },
-    //                 {
-    //                   S: 'IOS',
-    //                 },
-    //               ],
-    //             },
-    //             prefix: {
-    //               S: 'EVENT#projectId#appId',
-    //             },
-    //             projectId: {
-    //               S: 'projectId',
-    //             },
-    //             ttl: {
-    //               N: '1695725457',
-    //             },
-    //             type: {
-    //               S: 'EVENT#sprojectId#appId#eventName',
-    //             },
-    //             updateAt: {
-    //               N: '1695120657125',
-    //             },
-    //           },
-    //         },
-    //       },
-    //       {
-    //         PutRequest: {
-    //           Item: {
-    //             appId: {
-    //               S: 'appId',
-    //             },
-    //             category: {
-    //               S: 'category',
-    //             },
-    //             createAt: {
-    //               N: '1695120657125',
-    //             },
-    //             deleted: {
-    //               BOOL: false,
-    //             },
-    //             description: {
-    //               S: '',
-    //             },
-    //             displayName: {
-    //               S: '',
-    //             },
-    //             eventDescription: {
-    //               S: '',
-    //             },
-    //             eventDisplayName: {
-    //               S: '',
-    //             },
-    //             eventName: {
-    //               S: 'eventName',
-    //             },
-    //             hasData: {
-    //               BOOL: true,
-    //             },
-    //             id: {
-    //               S: 'projectId#appId#eventName#propertyName',
-    //             },
-    //             metadataSource: {
-    //               S: 'custom',
-    //             },
-    //             name: {
-    //               S: 'propertyName',
-    //             },
-    //             operator: {
-    //               S: '',
-    //             },
-    //             parameterId: {
-    //               S: 'propertyId',
-    //             },
-    //             parameterType: {
-    //               S: 'Private',
-    //             },
-    //             platform: {
-    //               L: [
-    //                 {
-    //                   S: 'ANDROID',
-    //                 },
-    //                 {
-    //                   S: 'IOS',
-    //                 },
-    //               ],
-    //             },
-    //             prefix: {
-    //               S: 'EVENT_PARAMETER#projectId#appId',
-    //             },
-    //             projectId: {
-    //               S: 'projectId',
-    //             },
-    //             ttl: {
-    //               N: '1695725457',
-    //             },
-    //             type: {
-    //               S: 'EVENT#sprojectId#appId#eventName',
-    //             },
-    //             updateAt: {
-    //               N: '1695120657125',
-    //             },
-    //             valueEnum: {
-    //               L: [
-    //                 {
-    //                   S: 'value1',
-    //                 },
-    //                 {
-    //                   S: ' value2',
-    //                 },
-    //                 {
-    //                   S: ' value3',
-    //                 },
-    //               ],
-    //             },
-    //             valueType: {
-    //               S: 'String',
-    //             },
-    //           },
-    //         },
-    //       },
-    //     ],
-    //   },
-    // });
     expect(resp).toEqual({
       detail: {
         appId: 'app1',
@@ -396,45 +232,45 @@ describe('Lambda - store the metadata into DDB from Redshift', () => {
     });
   });
 
-  // test('Store metadata for query id is undefined', async () => {
-  //   redshiftDataMock.on(DescribeStatementCommand).resolvesOnce({
-  //     Status: StatusString.FAILED,
-  //   });
-  //   redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: undefined });
-  //   dynamoDBMock.on(BatchWriteCommand).resolves({});
-  //   redshiftDataMock.on(GetStatementResultCommand).resolves({
-  //     Records: [],
-  //   });
-  //   const resp = await handler(checkScanMetadataStatusEvent);
-  //   expect(resp).toEqual({
-  //     detail: {
-  //       appId: 'app1',
-  //       status: 'FAILED',
-  //       message: 'store metadata into ddb failed',
-  //     },
-  //   });
-  // });
+  test('Store metadata for query id is undefined', async () => {
+    redshiftDataMock.on(DescribeStatementCommand).resolvesOnce({
+      Status: StatusString.FAILED,
+    });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: undefined });
+    dynamoDBMock.on(BatchWriteCommand).resolves({});
+    redshiftDataMock.on(GetStatementResultCommand).resolves({
+      Records: [],
+    });
+    const resp = await handler(checkScanMetadataStatusEvent);
+    expect(resp).toEqual({
+      detail: {
+        appId: 'app1',
+        status: 'FAILED',
+        message: 'store metadata into ddb failed',
+      },
+    });
+  });
 
-  // test('Store metadata with redshift FAILED', async () => {
-  //   const exeuteId = 'Id-1';
-  //   redshiftDataMock.on(DescribeStatementCommand).resolvesOnce({
-  //     Status: StatusString.STARTED,
-  //   })
-  //     .resolvesOnce({
-  //       Status: StatusString.FAILED,
-  //     });
-  //   redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: exeuteId });
-  //   dynamoDBMock.on(BatchWriteCommand).resolves({});
-  //   redshiftDataMock.on(GetStatementResultCommand).resolves({
-  //     Records: [],
-  //   });
-  //   const resp = await handler(checkScanMetadataStatusEvent);
-  //   expect(resp).toEqual({
-  //     detail: {
-  //       appId: 'app1',
-  //       status: 'FAILED',
-  //       message: 'store metadata into ddb failed',
-  //     },
-  //   });
-  // });
+  test('Store metadata with redshift FAILED', async () => {
+    const exeuteId = 'Id-1';
+    redshiftDataMock.on(DescribeStatementCommand).resolvesOnce({
+      Status: StatusString.STARTED,
+    })
+      .resolvesOnce({
+        Status: StatusString.FAILED,
+      });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: exeuteId });
+    dynamoDBMock.on(BatchWriteCommand).resolves({});
+    redshiftDataMock.on(GetStatementResultCommand).resolves({
+      Records: [],
+    });
+    const resp = await handler(checkScanMetadataStatusEvent);
+    expect(resp).toEqual({
+      detail: {
+        appId: 'app1',
+        status: 'FAILED',
+        message: 'store metadata into ddb failed',
+      },
+    });
+  });
 });

--- a/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/store-metadata-into-ddb.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/store-metadata-into-ddb.test.ts
@@ -63,7 +63,7 @@ describe('Lambda - store the metadata into DDB from Redshift', () => {
             { stringValue: 'eventName' },
             { stringValue: 'custom' },
             { longValue: 2000 },
-            { stringValue: '[ANDROID,IOS]' },
+            { stringValue: 'ANDROID#IOS' },
           ],
         ],
       })
@@ -82,8 +82,8 @@ describe('Lambda - store the metadata into DDB from Redshift', () => {
             { stringValue: 'propertyName' },
             { stringValue: 'propertyId' },
             { stringValue: 'String' },
-            { stringValue: '[value1,value2,value3]' },
-            { stringValue: '[ANDROID,IOS]' },
+            { stringValue: 'value1#value2#value3' },
+            { stringValue: 'ANDROID#IOS' },
           ],
         ],
       })
@@ -100,8 +100,8 @@ describe('Lambda - store the metadata into DDB from Redshift', () => {
             { stringValue: 'Private' },
             { stringValue: 'userattributename' },
             { stringValue: 'String' },
-            { stringValue: '[value1,value2,value3]' },
-            { stringValue: '[ANDROID,IOS]' },
+            { stringValue: 'value1#value2#value3' },
+            { stringValue: 'ANDROID#IOS' },
           ],
         ],
       });

--- a/test/jestEnv.js
+++ b/test/jestEnv.js
@@ -42,4 +42,5 @@ process.env.ODS_EVENT_BUCKET='EXAMPLE-BUCKET-2'
 process.env.ODS_EVENT_BUCKET_PREFIX='project1/raw/'
 process.env.REDSHIFT_ODS_TABLE_NAME='ods_external_events'
 process.env.REDSHIFT_ROLE = 'arn:aws:iam::xxxxxxxxxxxx:role/redshift-serverless-s3-copyrole'
+process.env.METADATA_DDB_TABLE_ARN = 'arn:aws:dynamodb:us-east-1:111122223333:table/ClickstreamAnalyticsMetadata';
 process.env.REDSHIFT_DATABASE = 'project1'


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Scan metadata feature

## Implementation highlights
Including below implementation:
1. Create scan metadata step function workflow to orchestrate the entire process
2. Stored procedure to aggregate data and store into a temp table.
3. Check stored procedure status
4. Store data into DynamoDB
5. Create Event Bridge Rule to trigger step function workflow daily.


## Test checklist

- [x] add new test cases
- [x] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [x] add parameters without default value in stack
ClickstreamAnalyticsMetadataDdbArn
- [] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend