### PR TITLE
fix: user setting is overwritten in dictionary table when update control plane

### DIFF
--- a/src/control-plane/backend/lambda/api/router/user.ts
+++ b/src/control-plane/backend/lambda/api/router/user.ts
@@ -68,6 +68,9 @@ router_user.get(
 
 router_user.post(
   '/settings',
+  validate([
+    header('X-Click-Stream-Request-Id').custom(isRequestIdExisted),
+  ]),
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     return userServ.updateSettings(req, res, next);
   });

--- a/src/control-plane/backend/lambda/api/service/user.ts
+++ b/src/control-plane/backend/lambda/api/service/user.ts
@@ -13,8 +13,7 @@
 
 import { DEFAULT_ANALYST_ROLE_NAMES, DEFAULT_OPERATOR_ROLE_NAMES, DEFAULT_ROLE_JSON_PATH } from '../common/constants';
 import { ApiFail, ApiSuccess } from '../common/types';
-import { getRoleFromToken, getTokenFromRequest, tryToJson } from '../common/utils';
-import { IDictionary } from '../model/dictionary';
+import { getRoleFromToken, getTokenFromRequest } from '../common/utils';
 import { IUser, IUserSettings } from '../model/user';
 import { ClickStreamStore } from '../store/click-stream-store';
 import { DynamoDbStore } from '../store/dynamodb/dynamodb-store';
@@ -103,8 +102,8 @@ export class UserServ {
   };
 
   public async getUserSettingsFromDDB() {
-    const userSettingsDic = await store.getDictionary('UserSettings');
-    if (!userSettingsDic) {
+    const userSettings = await store.getUserSettings();
+    if (!userSettings) {
       const defaultSettings = {
         roleJsonPath: DEFAULT_ROLE_JSON_PATH,
         operatorRoleNames: DEFAULT_OPERATOR_ROLE_NAMES,
@@ -112,7 +111,7 @@ export class UserServ {
       } as IUserSettings;
       return defaultSettings;
     }
-    return tryToJson(userSettingsDic?.data) as IUserSettings;
+    return userSettings;
   }
 
   public async getSettings(_req: any, res: any, next: any) {
@@ -127,9 +126,7 @@ export class UserServ {
   public async updateSettings(req: any, res: any, next: any) {
     try {
       const userSettings: IUserSettings = req.body as IUserSettings;
-      await store.updateDictionary(
-        { name: 'UserSettings', data: userSettings } as IDictionary,
-      );
+      await store.updateUserSettings(userSettings);
       return res.status(200).json(new ApiSuccess(null, 'User settings updated.'));
     } catch (error) {
       next(error);

--- a/src/control-plane/backend/lambda/api/store/click-stream-store.ts
+++ b/src/control-plane/backend/lambda/api/store/click-stream-store.ts
@@ -16,7 +16,7 @@ import { IDictionary } from '../model/dictionary';
 import { IPipeline } from '../model/pipeline';
 import { IPlugin } from '../model/plugin';
 import { IDashboard, IProject } from '../model/project';
-import { IUser } from '../model/user';
+import { IUser, IUserSettings } from '../model/user';
 
 export interface ClickStreamStore {
   createProject: (project: IProject) => Promise<string>;
@@ -59,6 +59,8 @@ export interface ClickStreamStore {
   updateUser: (user: IUser) => Promise<void>;
   listUser: () => Promise<IUser[]>;
   deleteUser: (uid: string, operator: string) => Promise<void>;
+  getUserSettings: () => Promise<IUserSettings | undefined>;
+  updateUserSettings: (settings: IUserSettings) => Promise<void>;
 
   getDictionary: (name: string) => Promise<IDictionary | undefined>;
   updateDictionary: (dictionary: IDictionary) => Promise<void>;

--- a/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-store.ts
+++ b/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-store.ts
@@ -30,7 +30,7 @@ import { IDictionary } from '../../model/dictionary';
 import { IPipeline } from '../../model/pipeline';
 import { IPlugin } from '../../model/plugin';
 import { IDashboard, IProject } from '../../model/project';
-import { IUser } from '../../model/user';
+import { IUser, IUserSettings } from '../../model/user';
 import { ClickStreamStore } from '../click-stream-store';
 
 export class DynamoDbStore implements ClickStreamStore {
@@ -1123,6 +1123,37 @@ export class DynamoDbStore implements ClickStreamStore {
       ExpressionAttributeValues: {
         ':d': true,
         ':operator': operator,
+      },
+      ReturnValues: 'ALL_NEW',
+    });
+    await docClient.send(params);
+  };
+
+  public async getUserSettings(): Promise<IUserSettings | undefined> {
+    const params: GetCommand = new GetCommand({
+      TableName: clickStreamTableName,
+      Key: {
+        id: 'USER_SETTINGS',
+        type: 'USER_SETTINGS',
+      },
+    });
+    const result: GetCommandOutput = await docClient.send(params);
+    return result.Item ? result.Item as IUserSettings : undefined;
+  };
+
+  public async updateUserSettings(userSettings: IUserSettings): Promise<void> {
+    const params: UpdateCommand = new UpdateCommand({
+      TableName: clickStreamTableName,
+      Key: {
+        id: 'USER_SETTINGS',
+        type: 'USER_SETTINGS',
+      },
+      // Define expressions for the new or updated attributes
+      UpdateExpression: 'SET roleJsonPath= :roleJsonPath, operatorRoleNames= :operatorRoleNames, analystRoleNames= :analystRoleNames',
+      ExpressionAttributeValues: {
+        ':roleJsonPath': userSettings.roleJsonPath,
+        ':operatorRoleNames': userSettings.operatorRoleNames,
+        ':analystRoleNames': userSettings.analystRoleNames,
       },
       ReturnValues: 'ALL_NEW',
     });

--- a/src/control-plane/backend/lambda/api/test/api/auth.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/auth.test.ts
@@ -23,7 +23,7 @@ import {
 import { mockClient } from 'aws-sdk-client-mock';
 import request from 'supertest';
 import 'aws-sdk-client-mock-jest';
-import { MOCK_USER_ID, dictionaryMock, userMock } from './ddb-mock';
+import { MOCK_USER_ID, userMock } from './ddb-mock';
 import { amznRequestContextHeader } from '../../common/constants';
 import { IUserRole } from '../../common/types';
 import { app, server } from '../../index';
@@ -113,7 +113,7 @@ describe('Validate role middleware test', () => {
   });
 
   it('User not in DDB and no group in token.', async () => {
-    dictionaryMock(ddbMock);
+    ddbMock.on(GetCommand).resolves({});
     userMock(ddbMock, 'fake@example.com', IUserRole.ADMIN, false);
     const res = await request(app)
       .get('/api/user/details?id=fake@example.com')
@@ -126,7 +126,7 @@ describe('Validate role middleware test', () => {
   });
 
   it('User not in DDB but group in token.', async () => {
-    dictionaryMock(ddbMock);
+    ddbMock.on(GetCommand).resolves({});
     userMock(ddbMock, 'fake@example.com', IUserRole.ADMIN, false);
     const res = await request(app)
       .get('/api/user/details?id=fake@example.com')
@@ -139,7 +139,7 @@ describe('Validate role middleware test', () => {
   });
 
   it('User not in DDB and error group in token.', async () => {
-    dictionaryMock(ddbMock);
+    ddbMock.on(GetCommand).resolves({});
     userMock(ddbMock, 'fake@example.com', IUserRole.ADMIN, false);
     const res = await request(app)
       .get('/api/user/details?id=fake@example.com')
@@ -152,7 +152,7 @@ describe('Validate role middleware test', () => {
   });
 
   it('Get User settings with current user not in DDB and error group in token.', async () => {
-    dictionaryMock(ddbMock);
+    ddbMock.on(GetCommand).resolves({});
     userMock(ddbMock, 'fake@example.com', IUserRole.ADMIN, false);
     const res = await request(app)
       .get('/api/user/settings')
@@ -165,7 +165,7 @@ describe('Validate role middleware test', () => {
   });
 
   it('Get User settings with current user in DDB and error group in token.', async () => {
-    dictionaryMock(ddbMock);
+    ddbMock.on(GetCommand).resolves({});
     userMock(ddbMock, 'fake@example.com', IUserRole.ADMIN, true);
     const res = await request(app)
       .get('/api/user/settings')

--- a/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
@@ -28,7 +28,7 @@ import { GetBucketPolicyCommand } from '@aws-sdk/client-s3';
 import { GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
 import { StartExecutionCommand } from '@aws-sdk/client-sfn';
 import { GetCommand, GetCommandInput, QueryCommand, QueryCommandInput } from '@aws-sdk/lib-dynamodb';
-import { DEFAULT_ANALYST_ROLE_NAMES, DEFAULT_OPERATOR_ROLE_NAMES, DEFAULT_ROLE_JSON_PATH, analyticsMetadataTable, clickStreamTableName, dictionaryTableName, prefixTimeGSIName } from '../../common/constants';
+import { analyticsMetadataTable, clickStreamTableName, dictionaryTableName, prefixTimeGSIName } from '../../common/constants';
 import { IUserRole, ProjectEnvironment } from '../../common/types';
 import { IPipeline } from '../../model/pipeline';
 
@@ -342,23 +342,6 @@ function dictionaryMock(ddbMock: any, name?: string): any {
           target: 'feature-rel/main',
           prefix: 'default/',
           version: MOCK_SOLUTION_VERSION,
-        },
-      },
-    });
-  }
-  if (!name || name === 'UserSettings') {
-    ddbMock.on(GetCommand, {
-      TableName: dictionaryTableName,
-      Key: {
-        name: 'UserSettings',
-      },
-    }).resolves({
-      Item: {
-        name: 'UserSettings',
-        data: {
-          roleJsonPath: DEFAULT_ROLE_JSON_PATH,
-          operatorRoleNames: DEFAULT_OPERATOR_ROLE_NAMES,
-          analystRoleNames: DEFAULT_ANALYST_ROLE_NAMES,
         },
       },
     });


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Move user settings from dictionary table to metadata table.

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend