### PR TITLE
fix: add analytics metadata DDB table Arn parameter to Redshift stack

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -23,3 +23,4 @@ src/common/constant.ts:80
 src/common/constant.ts:83
 src/common/constant.ts:86
 src/common/constant.ts:89
+test/jestEnv.js:19

--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -14,6 +14,7 @@
 import { Parameter } from '@aws-sdk/client-cloudformation';
 import { JSONObject } from 'ts-json-object';
 import { CPipelineResources, IPipeline } from './pipeline';
+import { analyticsMetadataTable, awsAccountId, awsRegion } from '../common/constants';
 import {
   CORS_PATTERN,
   DOMAIN_NAME_PATTERN, MULTI_EMAIL_PATTERN,
@@ -50,7 +51,6 @@ import {
   ProjectEnvironment,
 } from '../common/types';
 import { getBucketPrefix, getKafkaTopic, getPluginInfo, isEmpty, getValueFromStackOutputSuffix, isEmail, corsStackInput } from '../common/utils';
-import { analyticsMetadataTable, awsAccountId, awsRegion } from '../common/constants';
 
 export function getStackParameters(stack: JSONObject): Parameter[] {
   const parameters: Parameter[] = [];

--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -50,6 +50,7 @@ import {
   ProjectEnvironment,
 } from '../common/types';
 import { getBucketPrefix, getKafkaTopic, getPluginInfo, isEmpty, getValueFromStackOutputSuffix, isEmail, corsStackInput } from '../common/utils';
+import { analyticsMetadataTable, awsAccountId, awsRegion } from '../common/constants';
 
 export function getStackParameters(stack: JSONObject): Parameter[] {
   const parameters: Parameter[] = [];
@@ -953,6 +954,9 @@ export class CDataModelingStack extends JSONObject {
   @JSONObject.optional('')
     EMRServerlessApplicationId?: string;
 
+  @JSONObject.optional('')
+    ClickstreamAnalyticsMetadataDdbArn?: string;
+
   constructor(pipeline: IPipeline, resources: CPipelineResources) {
     if (pipeline.dataModeling?.redshift?.provisioned) {
       if (isEmpty(pipeline.dataModeling?.redshift?.provisioned.clusterIdentifier) ||
@@ -968,6 +972,8 @@ export class CDataModelingStack extends JSONObject {
         throw new ClickStreamBadRequestError('VpcId, SubnetIds, SecurityGroups required for provisioning new Redshift Serverless.');
       }
     }
+
+    const partition = awsRegion?.startsWith('cn') ? 'aws-cn' : 'aws';
 
     super({
       _pipeline: pipeline,
@@ -993,6 +999,7 @@ export class CDataModelingStack extends JSONObject {
         PipelineStackType.DATA_PROCESSING,
         OUTPUT_DATA_PROCESSING_EMR_SERVERLESS_APPLICATION_ID_SUFFIX,
       ),
+      ClickstreamAnalyticsMetadataDdbArn: `arn:${partition}:dynamodb:${awsRegion}:${awsAccountId}:table/${analyticsMetadataTable}`,
 
     });
   }

--- a/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
@@ -687,6 +687,10 @@ const BASE_DATAANALYTICS_PARAMETERS = [
     ParameterKey: 'EMRServerlessApplicationId.#',
     ParameterValue: '#.Clickstream-DataProcessing-6666-6666.EMRServerlessApplicationId',
   },
+  {
+    ParameterKey: 'ClickstreamAnalyticsMetadataDdbArn',
+    ParameterValue: 'arn:aws:dynamodb:us-east-1:555555555555:table/analytics-metadata-table-name',
+  },
 ];
 
 export const MSK_DATA_PROCESSING_EXISTING_SERVERLESS_DATAANALYTICS_PARAMETERS = mergeParameters(

--- a/test/jestEnv.js
+++ b/test/jestEnv.js
@@ -16,6 +16,7 @@ SOLUTION_VERSION='v1.0.0_dev'
 
 // controlpalne backend API
 process.env.AWS_REGION = 'us-east-1'
+process.env.AWS_ACCOUNT_ID = '555555555555'
 process.env.AWS_URL_SUFFIX = 'amazonaws.com'
 process.env.S3_MAIN_REGION = 'us-east-1'
 process.env.STACK_WORKFLOW_S3_BUCKET = 'TEST_EXAMPLE_BUCKET'


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend