### PR TITLE
chore: add the value type into property name to cover same parameter and different value type

### DIFF
--- a/src/analytics/private/sqls/redshift/sp-scan-metadata.sql
+++ b/src/analytics/private/sqls/redshift/sp-scan-metadata.sql
@@ -230,7 +230,7 @@ BEGIN
               project_id, 
               app_info_app_id, 
               property_category, 
-              property_name, 
+              property_name || '_' || value_type as property_name,
               property_value, 
               platform, 
               value_type, 
@@ -312,7 +312,7 @@ BEGIN
               SELECT 
                 project_id, 
                 app_info_app_id, 
-                property_name, 
+                property_name || '_' || value_type as property_name,
                 property_value, 
                 platform, 
                 value_type, 


### PR DESCRIPTION

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Add the value type into property name to cover same parameter and different value type.
Otherwise, there will be the same primary key during lambda persist the metadata into ddb.

## Implementation highlights

Add the value type into property name to cover same parameter and different value type

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend