### PR TITLE
fix: hide value type as parameter suffix

### DIFF
--- a/frontend/src/apis/analytics.ts
+++ b/frontend/src/apis/analytics.ts
@@ -121,10 +121,11 @@ export const getMetadataParametersDetails = async (params: {
   projectId: string;
   appId: string;
   parameterName: string;
+  parameterValueType: string;
 }) => {
   const result: any = await apiRequest(
     'get',
-    `/metadata/event_parameter/${params.parameterName}?projectId=${params.projectId}&appId=${params.appId}`
+    `/metadata/event_parameter/${params.parameterName}_${params.parameterValueType}?projectId=${params.projectId}&appId=${params.appId}`
   );
   return result;
 };

--- a/frontend/src/pages/analytics/metadata/event-parameters/MetadataParameterSplitPanel.tsx
+++ b/frontend/src/pages/analytics/metadata/event-parameters/MetadataParameterSplitPanel.tsx
@@ -150,6 +150,7 @@ const MetadataParameterSplitPanel: React.FC<
           projectId: projectId ?? '',
           appId: appId ?? '',
           parameterName: parameter.name,
+          parameterValueType: parameter.valueType,
         });
       if (success) {
         setParameterDetails(data);
@@ -352,12 +353,8 @@ const MetadataParameterSplitPanel: React.FC<
                     data={parameterDetails.associatedEvents ?? []}
                     tableColumnDefinitions={COLUMN_DEFINITIONS}
                     tableI18nStrings={{
-                      loadingText: t(
-                        'analytics:labels.tableLoading'
-                      ),
-                      emptyText: t(
-                        'analytics:labels.tableEmpty'
-                      ),
+                      loadingText: t('analytics:labels.tableLoading'),
+                      emptyText: t('analytics:labels.tableEmpty'),
                     }}
                   />
                 ),

--- a/src/control-plane/backend/lambda/api/model/metadata.ts
+++ b/src/control-plane/backend/lambda/api/model/metadata.ts
@@ -52,7 +52,7 @@ export interface IMetadataEventParameter {
   readonly eventName: string;
 
   readonly parameterId: string;
-  readonly name: string;
+  name: string;
   displayName: string;
   description: string;
   readonly metadataSource: MetadataSource;
@@ -82,7 +82,7 @@ export interface IMetadataUserAttribute {
   readonly eventName: string;
 
   readonly attributeId: string;
-  readonly name: string;
+  name: string;
   displayName: string;
   description: string;
   readonly metadataSource: MetadataSource;

--- a/src/control-plane/backend/lambda/api/service/display.ts
+++ b/src/control-plane/backend/lambda/api/service/display.ts
@@ -11,6 +11,7 @@
  *  and limitations under the License.
  */
 
+import { MetadataValueType } from '../common/explore-types';
 import { logger } from '../common/powertools';
 import { IMetadataAttributeValue, IMetadataDisplay, IMetadataEvent, IMetadataEventParameter, IMetadataUserAttribute } from '../model/metadata';
 import { DynamoDbMetadataStore } from '../store/dynamodb/dynamodb-metadata-store';
@@ -44,6 +45,14 @@ export class CMetadataDisplay {
     }
   }
 
+  private _getOriginalName(name: string, valueType: MetadataValueType) {
+    const typeSuffix = `_${valueType}`;
+    if (name.endsWith(typeSuffix)) {
+      return name.substring(0, name.length - typeSuffix.length);
+    }
+    return name;
+  }
+
   public async patch(projectId: string, appId: string,
     metadataArray: IMetadataEvent[] | IMetadataEventParameter[] | IMetadataUserAttribute[]) {
     try {
@@ -52,20 +61,24 @@ export class CMetadataDisplay {
         const prefix = metadata.prefix.split('#')[0];
         const key = `${prefix}#${metadata.projectId}#${metadata.appId}#${metadata.name}`;
         const metadataDisplay = displays.find((d: IMetadataDisplay) => d.id === key);
-        metadata.displayName = metadataDisplay?.displayName ?? metadata.name;
         metadata.description = metadataDisplay?.description ?? '';
         if (metadata.prefix.startsWith('EVENT#')) {
           const event = metadata as IMetadataEvent;
+          event.displayName = metadataDisplay?.displayName ?? event.name;
           event.associatedParameters = this.patchAssociatedWithData(event.associatedParameters) as IMetadataEventParameter[];
           event.associatedParameters = this.patchValueEnumWithData(event.associatedParameters) as IMetadataEventParameter[];
         }
         if (metadata.prefix.startsWith('EVENT_PARAMETER#')) {
           let parameter = metadata as IMetadataEventParameter;
+          parameter.name = this._getOriginalName(parameter.name, parameter.valueType);
+          parameter.displayName = metadataDisplay?.displayName ?? this._getOriginalName(parameter.name, parameter.valueType);
           parameter.associatedEvents = this.patchAssociatedWithData(parameter.associatedEvents) as IMetadataEvent[];
           parameter = (this.patchValueEnumWithData([parameter]) as IMetadataEventParameter[])[0];
         }
         if (metadata.prefix.startsWith('USER_ATTRIBUTE#')) {
           let userAttribute = metadata as IMetadataUserAttribute;
+          userAttribute.name = this._getOriginalName(userAttribute.name, userAttribute.valueType);
+          userAttribute.displayName = metadataDisplay?.displayName ?? this._getOriginalName(userAttribute.name, userAttribute.valueType);
           userAttribute = (this.patchValueEnumWithData([userAttribute]) as IMetadataUserAttribute[])[0];
         }
       }
@@ -84,8 +97,15 @@ export class CMetadataDisplay {
       const prefix = metadata.prefix.split('#')[0];
       const key = `${prefix}#${metadata.projectId}#${metadata.appId}#${metadata.name}`;
       const metadataDisplay = displays.find((d: IMetadataDisplay) => d.id === key);
-      metadata.displayName = metadataDisplay?.displayName ?? metadata.name;
-      metadata.description = metadataDisplay?.description ?? '';
+      if (metadata.prefix.startsWith('EVENT_PARAMETER#')) {
+        let parameter = metadata as IMetadataEventParameter;
+        parameter.name = this._getOriginalName(parameter.name, parameter.valueType);
+        parameter.displayName = metadataDisplay?.displayName ?? this._getOriginalName(parameter.name, parameter.valueType);
+        parameter.description = metadataDisplay?.description ?? '';
+      } else if (metadata.prefix.startsWith('EVENT#')) {
+        metadata.displayName = metadataDisplay?.displayName ?? metadata.name;
+        metadata.description = metadataDisplay?.description ?? '';
+      }
     }
     return associated;
   }

--- a/src/control-plane/backend/lambda/api/service/display.ts
+++ b/src/control-plane/backend/lambda/api/service/display.ts
@@ -59,26 +59,34 @@ export class CMetadataDisplay {
       const displays = await this.getDisplay(projectId, appId);
       for (let metadata of metadataArray) {
         const prefix = metadata.prefix.split('#')[0];
-        const key = `${prefix}#${metadata.projectId}#${metadata.appId}#${metadata.name}`;
-        const metadataDisplay = displays.find((d: IMetadataDisplay) => d.id === key);
-        metadata.description = metadataDisplay?.description ?? '';
         if (metadata.prefix.startsWith('EVENT#')) {
           const event = metadata as IMetadataEvent;
+          const key = `${prefix}#${metadata.projectId}#${metadata.appId}#${event.name}`;
+          const metadataDisplay = displays.find((d: IMetadataDisplay) => d.id === key);
           event.displayName = metadataDisplay?.displayName ?? event.name;
+          event.description = metadataDisplay?.description ?? '';
           event.associatedParameters = this.patchAssociatedWithData(event.associatedParameters) as IMetadataEventParameter[];
           event.associatedParameters = this.patchValueEnumWithData(event.associatedParameters) as IMetadataEventParameter[];
         }
         if (metadata.prefix.startsWith('EVENT_PARAMETER#')) {
           let parameter = metadata as IMetadataEventParameter;
-          parameter.name = this._getOriginalName(parameter.name, parameter.valueType);
-          parameter.displayName = metadataDisplay?.displayName ?? this._getOriginalName(parameter.name, parameter.valueType);
+          const originalName = this._getOriginalName(parameter.name, parameter.valueType);
+          const key = `${prefix}#${metadata.projectId}#${metadata.appId}#${originalName}`;
+          const metadataDisplay = displays.find((d: IMetadataDisplay) => d.id === key);
+          parameter.name = originalName;
+          parameter.displayName = metadataDisplay?.displayName ?? originalName;
+          parameter.description = metadataDisplay?.description ?? '';
           parameter.associatedEvents = this.patchAssociatedWithData(parameter.associatedEvents) as IMetadataEvent[];
           parameter = (this.patchValueEnumWithData([parameter]) as IMetadataEventParameter[])[0];
         }
         if (metadata.prefix.startsWith('USER_ATTRIBUTE#')) {
           let userAttribute = metadata as IMetadataUserAttribute;
-          userAttribute.name = this._getOriginalName(userAttribute.name, userAttribute.valueType);
-          userAttribute.displayName = metadataDisplay?.displayName ?? this._getOriginalName(userAttribute.name, userAttribute.valueType);
+          const originalName = this._getOriginalName(userAttribute.name, userAttribute.valueType);
+          const key = `${prefix}#${metadata.projectId}#${metadata.appId}#${originalName}`;
+          const metadataDisplay = displays.find((d: IMetadataDisplay) => d.id === key);
+          userAttribute.name = originalName;
+          userAttribute.displayName = metadataDisplay?.displayName ?? originalName;
+          userAttribute.description = metadataDisplay?.description ?? '';
           userAttribute = (this.patchValueEnumWithData([userAttribute]) as IMetadataUserAttribute[])[0];
         }
       }

--- a/src/control-plane/backend/lambda/api/service/metadata.ts
+++ b/src/control-plane/backend/lambda/api/service/metadata.ts
@@ -13,7 +13,7 @@
 
 import { CMetadataDisplay } from './display';
 import { ApiFail, ApiSuccess } from '../common/types';
-import { groupAssociatedEventParametersByName, groupAssociatedEventsByName, groupEventByName, groupEventParameterByName, isEmpty } from '../common/utils';
+import { groupAssociatedEventParametersByName, groupAssociatedEventsByName, groupEventByName, groupEventParameterByName, groupUserAttributeByName, isEmpty } from '../common/utils';
 import { IMetadataDisplay, IMetadataEvent, IMetadataEventParameter, IMetadataUserAttribute } from '../model/metadata';
 import { DynamoDbMetadataStore } from '../store/dynamodb/dynamodb-metadata-store';
 import { MetadataStore } from '../store/metadata-store';
@@ -161,7 +161,8 @@ export class MetadataUserAttributeServ {
     try {
       const { projectId, appId, order } = req.query;
       const results = await metadataStore.listUserAttributes(projectId, appId, order);
-      const attributes = await metadataDisplay.patch(projectId, appId, results) as IMetadataUserAttribute[];
+      let attributes = groupUserAttributeByName(results);
+      attributes = await metadataDisplay.patch(projectId, appId, attributes) as IMetadataUserAttribute[];
       return res.json(new ApiSuccess({
         totalCount: attributes.length,
         items: attributes,
@@ -190,7 +191,8 @@ export class MetadataUserAttributeServ {
       if (isEmpty(results)) {
         return res.status(404).json(new ApiFail('User attribute not found'));
       }
-      const attribute = (await metadataDisplay.patch(projectId, appId, [results[0]]) as IMetadataUserAttribute[])[0];
+      let attribute = groupUserAttributeByName(results)[0];
+      attribute = (await metadataDisplay.patch(projectId, appId, [attribute]) as IMetadataUserAttribute[])[0];
       return res.json(new ApiSuccess(attribute));
     } catch (error) {
       next(error);

--- a/src/control-plane/backend/lambda/api/test/api/metadata.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/metadata.test.ts
@@ -22,7 +22,7 @@ import { mockClient } from 'aws-sdk-client-mock';
 import request from 'supertest';
 import { metadataEventExistedMock, MOCK_APP_ID, MOCK_EVENT_PARAMETER_NAME, MOCK_EVENT_NAME, MOCK_PROJECT_ID, MOCK_TOKEN, MOCK_USER_ATTRIBUTE_NAME, tokenMock } from './ddb-mock';
 import { analyticsMetadataTable, invertedGSIName, prefixTimeGSIName } from '../../common/constants';
-import { MetadataPlatform } from '../../common/explore-types';
+import { MetadataPlatform, MetadataValueType } from '../../common/explore-types';
 import { app, server } from '../../index';
 import 'aws-sdk-client-mock-jest';
 
@@ -896,7 +896,7 @@ describe('Metadata Event Attribute test', () => {
           description: `Description of event parameter ${MOCK_EVENT_PARAMETER_NAME}12`,
         },
         {
-          id: `DICTIONARY#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_PARAMETER_NAME}#value-02`,
+          id: `DICTIONARY#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#event-attribute-mock#value-02`,
           projectId: MOCK_PROJECT_ID,
           appId: MOCK_APP_ID,
           displayName: `display name of dictionary ${MOCK_EVENT_PARAMETER_NAME} value-02`,
@@ -1071,12 +1071,12 @@ describe('Metadata Event Attribute test', () => {
       ExpressionAttributeValues: {
         ':d': false,
         ':prefix': `EVENT_PARAMETER#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
-        ':name': MOCK_EVENT_PARAMETER_NAME,
+        ':name': `${MOCK_EVENT_PARAMETER_NAME}_String`,
       },
     }).resolves({
       Items: [
         {
-          id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}`,
+          id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}_String`,
           type: `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}`,
           prefix: `EVENT_PARAMETER#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
           projectId: MOCK_PROJECT_ID,
@@ -1085,14 +1085,15 @@ describe('Metadata Event Attribute test', () => {
           updateAt: 1690788840458,
           createAt: 1690788840458,
           operator: '',
-          name: MOCK_EVENT_PARAMETER_NAME,
+          name: `${MOCK_EVENT_PARAMETER_NAME}_String`,
           eventName: MOCK_EVENT_NAME,
           hasData: false,
           platform: [MetadataPlatform.ANDROID],
+          valueType: MetadataValueType.STRING,
           valueEnum: [],
         },
         {
-          id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}`,
+          id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}_String`,
           type: `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}`,
           prefix: `EVENT_PARAMETER#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
           projectId: MOCK_PROJECT_ID,
@@ -1101,16 +1102,17 @@ describe('Metadata Event Attribute test', () => {
           updateAt: 1690788840451,
           createAt: 1690788840451,
           operator: '',
-          name: MOCK_EVENT_PARAMETER_NAME,
+          name: `${MOCK_EVENT_PARAMETER_NAME}_String`,
           eventName: MOCK_EVENT_NAME,
           hasData: false,
           platform: [MetadataPlatform.WEB],
+          valueType: MetadataValueType.STRING,
           valueEnum: ['value-01', 'value-02'],
         },
       ],
     });
     let res = await request(app)
-      .get(`/api/metadata/event_parameter/${MOCK_EVENT_PARAMETER_NAME}?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+      .get(`/api/metadata/event_parameter/${MOCK_EVENT_PARAMETER_NAME}_String?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual({
@@ -1128,7 +1130,7 @@ describe('Metadata Event Attribute test', () => {
             description: `Description of event ${MOCK_EVENT_NAME}`,
           },
         ],
-        id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}`,
+        id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}_String`,
         type: `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}`,
         prefix: `EVENT_PARAMETER#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
         projectId: MOCK_PROJECT_ID,
@@ -1143,6 +1145,7 @@ describe('Metadata Event Attribute test', () => {
         description: `Description of event parameter ${MOCK_EVENT_PARAMETER_NAME}`,
         hasData: false,
         platform: [MetadataPlatform.ANDROID, MetadataPlatform.WEB],
+        valueType: MetadataValueType.STRING,
         values: [
           { value: 'value-01', displayValue: 'value-01' },
           { value: 'value-02', displayValue: `display name of dictionary ${MOCK_EVENT_PARAMETER_NAME} value-02` },
@@ -1178,7 +1181,7 @@ describe('Metadata Event Attribute test', () => {
     }).resolves({
       Items: [
         {
-          id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}`,
+          id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}_String`,
           type: `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}`,
           prefix: `EVENT_PARAMETER#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
           projectId: MOCK_PROJECT_ID,
@@ -1187,14 +1190,15 @@ describe('Metadata Event Attribute test', () => {
           updateAt: 1690788840458,
           createAt: 1690788840458,
           operator: '',
-          name: MOCK_EVENT_PARAMETER_NAME,
+          name: `${MOCK_EVENT_PARAMETER_NAME}_String`,
           eventName: MOCK_EVENT_NAME,
           hasData: false,
           platform: [MetadataPlatform.ANDROID],
+          valueType: MetadataValueType.STRING,
           valueEnum: [],
         },
         {
-          id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}`,
+          id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}_String`,
           type: `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}`,
           prefix: `EVENT_PARAMETER#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
           projectId: MOCK_PROJECT_ID,
@@ -1203,14 +1207,15 @@ describe('Metadata Event Attribute test', () => {
           updateAt: 1690788840451,
           createAt: 1690788840451,
           operator: '',
-          name: MOCK_EVENT_PARAMETER_NAME,
+          name: `${MOCK_EVENT_PARAMETER_NAME}_String`,
           eventName: MOCK_EVENT_NAME,
           hasData: false,
           platform: [MetadataPlatform.WEB],
+          valueType: MetadataValueType.STRING,
           valueEnum: ['value-01', 'value-02'],
         },
         {
-          id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}1`,
+          id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}1_String`,
           type: `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}`,
           prefix: `EVENT_PARAMETER#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
           projectId: MOCK_PROJECT_ID,
@@ -1219,14 +1224,15 @@ describe('Metadata Event Attribute test', () => {
           updateAt: 1690788840458,
           createAt: 1690788840458,
           operator: '',
-          name: `${MOCK_EVENT_PARAMETER_NAME}1`,
+          name: `${MOCK_EVENT_PARAMETER_NAME}1_String`,
           eventName: `${MOCK_EVENT_NAME}1`,
           hasData: false,
           platform: [MetadataPlatform.ANDROID],
+          valueType: MetadataValueType.STRING,
           valueEnum: [],
         },
         {
-          id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}1#${MOCK_EVENT_PARAMETER_NAME}1`,
+          id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}1#${MOCK_EVENT_PARAMETER_NAME}1_String`,
           type: `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}1`,
           prefix: `EVENT_PARAMETER#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
           projectId: MOCK_PROJECT_ID,
@@ -1235,10 +1241,11 @@ describe('Metadata Event Attribute test', () => {
           updateAt: 1690788840451,
           createAt: 1690788840451,
           operator: '',
-          name: `${MOCK_EVENT_PARAMETER_NAME}1`,
+          name: `${MOCK_EVENT_PARAMETER_NAME}1_String`,
           eventName: `${MOCK_EVENT_NAME}1`,
           hasData: false,
           platform: [MetadataPlatform.WEB],
+          valueType: MetadataValueType.STRING,
           valueEnum: ['value-01', 'value-02', 'value-03', 'value-04'],
         },
       ],
@@ -1254,7 +1261,7 @@ describe('Metadata Event Attribute test', () => {
         items: [
           {
             associatedEvents: [],
-            id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}`,
+            id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}_String`,
             type: `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}`,
             prefix: `EVENT_PARAMETER#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
             projectId: MOCK_PROJECT_ID,
@@ -1269,6 +1276,7 @@ describe('Metadata Event Attribute test', () => {
             description: `Description of event parameter ${MOCK_EVENT_PARAMETER_NAME}`,
             hasData: false,
             platform: [MetadataPlatform.ANDROID, MetadataPlatform.WEB],
+            valueType: MetadataValueType.STRING,
             values: [
               { value: 'value-01', displayValue: 'value-01' },
               { value: 'value-02', displayValue: `display name of dictionary ${MOCK_EVENT_PARAMETER_NAME} value-02` },
@@ -1276,7 +1284,7 @@ describe('Metadata Event Attribute test', () => {
           },
           {
             associatedEvents: [],
-            id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}1`,
+            id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}1_String`,
             type: `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}`,
             prefix: `EVENT_PARAMETER#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
             projectId: MOCK_PROJECT_ID,
@@ -1291,6 +1299,7 @@ describe('Metadata Event Attribute test', () => {
             description: '',
             hasData: false,
             platform: [MetadataPlatform.ANDROID, MetadataPlatform.WEB],
+            valueType: MetadataValueType.STRING,
             values: [
               { value: 'value-01', displayValue: 'value-01' },
               { value: 'value-02', displayValue: 'value-02' },
@@ -1560,12 +1569,12 @@ describe('Metadata User Attribute test', () => {
       ExpressionAttributeValues: {
         ':d': false,
         ':prefix': `USER_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
-        ':name': MOCK_USER_ATTRIBUTE_NAME,
+        ':name': `${MOCK_USER_ATTRIBUTE_NAME}_Integer`,
       },
     }).resolves({
       Items: [
         {
-          id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}`,
+          id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}_Integer`,
           type: `USER_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}`,
           prefix: `USER_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
           projectId: MOCK_PROJECT_ID,
@@ -1574,21 +1583,22 @@ describe('Metadata User Attribute test', () => {
           updateAt: 1690788840458,
           createAt: 1690788840458,
           operator: '',
-          name: MOCK_USER_ATTRIBUTE_NAME,
+          name: `${MOCK_USER_ATTRIBUTE_NAME}_Integer`,
           hasData: false,
+          valueType: MetadataValueType.INTEGER,
           valueEnum: ['value-01', 'value-02'],
         },
       ],
     });
     let res = await request(app)
-      .get(`/api/metadata/user_attribute/${MOCK_USER_ATTRIBUTE_NAME}?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+      .get(`/api/metadata/user_attribute/${MOCK_USER_ATTRIBUTE_NAME}_Integer?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual({
       success: true,
       message: '',
       data: {
-        id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}`,
+        id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}_Integer`,
         type: `USER_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}`,
         prefix: `USER_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
         projectId: MOCK_PROJECT_ID,
@@ -1601,6 +1611,7 @@ describe('Metadata User Attribute test', () => {
         displayName: `display name of user parameter ${MOCK_USER_ATTRIBUTE_NAME}`,
         description: `Description of user parameter ${MOCK_USER_ATTRIBUTE_NAME}`,
         hasData: false,
+        valueType: MetadataValueType.INTEGER,
         values: [
           { value: 'value-01', displayValue: 'value-01' },
           { value: 'value-02', displayValue: `display name of dictionary ${MOCK_USER_ATTRIBUTE_NAME} value-02` },
@@ -1638,7 +1649,7 @@ describe('Metadata User Attribute test', () => {
     }).resolves({
       Items: [
         {
-          id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}`,
+          id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}_Integer`,
           type: `USER_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}`,
           prefix: `USER_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
           projectId: MOCK_PROJECT_ID,
@@ -1647,13 +1658,14 @@ describe('Metadata User Attribute test', () => {
           updateAt: 1690788840451,
           createAt: 1690788840451,
           operator: '',
-          name: MOCK_USER_ATTRIBUTE_NAME,
+          name: `${MOCK_USER_ATTRIBUTE_NAME}_Integer`,
           eventName: MOCK_EVENT_NAME,
           hasData: false,
+          valueType: MetadataValueType.INTEGER,
           valueEnum: ['value-01', 'value-02'],
         },
         {
-          id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}1`,
+          id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}1_Integer`,
           type: `USER_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}1`,
           prefix: `USER_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
           projectId: MOCK_PROJECT_ID,
@@ -1662,9 +1674,10 @@ describe('Metadata User Attribute test', () => {
           updateAt: 1690788840451,
           createAt: 1690788840451,
           operator: '',
-          name: `${MOCK_USER_ATTRIBUTE_NAME}1`,
+          name: `${MOCK_USER_ATTRIBUTE_NAME}1_Integer`,
           eventName: `${MOCK_EVENT_NAME}1`,
           hasData: false,
+          valueType: MetadataValueType.INTEGER,
           valueEnum: ['value-01', 'value-02', 'value-03', 'value-04'],
         },
       ],
@@ -1679,7 +1692,7 @@ describe('Metadata User Attribute test', () => {
       data: {
         items: [
           {
-            id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}`,
+            id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}_Integer`,
             type: `USER_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}`,
             prefix: `USER_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
             projectId: MOCK_PROJECT_ID,
@@ -1693,13 +1706,14 @@ describe('Metadata User Attribute test', () => {
             displayName: `display name of user parameter ${MOCK_USER_ATTRIBUTE_NAME}`,
             description: `Description of user parameter ${MOCK_USER_ATTRIBUTE_NAME}`,
             hasData: false,
+            valueType: MetadataValueType.INTEGER,
             values: [
               { value: 'value-01', displayValue: 'value-01' },
               { value: 'value-02', displayValue: `display name of dictionary ${MOCK_USER_ATTRIBUTE_NAME} value-02` },
             ],
           },
           {
-            id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}1`,
+            id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}1_Integer`,
             type: `USER_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}1`,
             prefix: `USER_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
             projectId: MOCK_PROJECT_ID,
@@ -1713,6 +1727,7 @@ describe('Metadata User Attribute test', () => {
             displayName: `${MOCK_USER_ATTRIBUTE_NAME}1`,
             description: '',
             hasData: false,
+            valueType: MetadataValueType.INTEGER,
             values: [
               { value: 'value-01', displayValue: 'value-01' },
               { value: 'value-02', displayValue: 'value-02' },


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend