### PR TITLE
fix: pipeline inconsistent status when rollback complete

### DIFF
--- a/src/control-plane/backend/lambda/api/service/stack.ts
+++ b/src/control-plane/backend/lambda/api/service/stack.ts
@@ -211,7 +211,7 @@ export class StackManager {
     for (let s of stackStatusDetails) {
       if (s.stackStatus === undefined) {
         miss = true;
-      } else if (s.stackStatus.endsWith('_FAILED')) {
+      } else if (s.stackStatus.endsWith('_FAILED') || s.stackStatus.endsWith('_ROLLBACK_COMPLETE')) {
         action = s.stackStatus.split('_')[0];
         status = PipelineStatusType.FAILED;
         break;


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

closes: #238 

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend