### PR TITLE
fix: clear expired events workflow execution faild

### DIFF
--- a/src/analytics/lambdas/clear-expired-events-workflow/check-clear-status.ts
+++ b/src/analytics/lambdas/clear-expired-events-workflow/check-clear-status.ts
@@ -53,13 +53,12 @@ export const handler = async (event: ClearExpiredEventsEvent) => {
     };
   } else if (response.Status == StatusString.FAILED || response.Status == StatusString.ABORTED) {
     logger.info(`Executing ${queryId} status of statement is ${response.Status}`);
-    const queryResult = await queryClearLog(appId);
     return {
       detail: {
         id: queryId,
         appId: appId,
         status: response.Status,
-        message: 'Error:' + response.Error + '\nLog:' + queryResult.detail.message,
+        message: 'Error:' + response.Error,
       },
     };
   } else {

--- a/src/analytics/lambdas/clear-expired-events-workflow/clear-expired-events.ts
+++ b/src/analytics/lambdas/clear-expired-events-workflow/clear-expired-events.ts
@@ -12,6 +12,7 @@
  */
 
 import { logger } from '../../../common/powertools';
+import { SP_CLEAR_EXPIRED_EVENTS } from '../../private/constant';
 import { ClearExpiredEventsBody } from '../../private/model';
 import { getRedshiftClient, executeStatements, getRedshiftProps } from '../redshift-data';
 
@@ -38,14 +39,13 @@ export const handler = async (event: ClearExpiredEventsEvent) => {
   const schema = event.detail.appId;
   const retentionRangeDays = event.detail.retentionRangeDays;
   const sqlStatements : string[] = [];
-  sqlStatements.push(`CALL ${schema}.sp_clear_expired_events(${retentionRangeDays})`);
-  sqlStatements.push(`CALL ${schema}.sp_clear_item_and_user()`);
+  sqlStatements.push(`CALL ${schema}.${SP_CLEAR_EXPIRED_EVENTS}(${retentionRangeDays})`);
 
   try {
     const queryId = await executeStatements(
       redshiftDataApiClient, sqlStatements, redshiftProps.serverlessRedshiftProps, redshiftProps.provisionedRedshiftProps);
-
     logger.info('Clear expired events response:', { queryId });
+
     return {
       detail: {
         appId: schema,

--- a/src/analytics/lambdas/custom-resource/get-source-prefix.ts
+++ b/src/analytics/lambdas/custom-resource/get-source-prefix.ts
@@ -21,6 +21,7 @@ export interface ServiceTokenType {
 
 export interface GetResourcePrefixPropertiesType {
   readonly odsEventPrefix: string;
+  readonly projectId: string;
 }
 
 type PropertiesType = ServiceTokenType & GetResourcePrefixPropertiesType;
@@ -47,14 +48,18 @@ async function _handler(event: CdkCustomResourceEvent) {
   const odsEventPrefix = (event.ResourceProperties as PropertiesType).odsEventPrefix;
 
   let prefix = odsEventPrefix;
+  const projectId = (event.ResourceProperties as PropertiesType).projectId;
 
   if (odsEventPrefix.endsWith('/ods_events/') || odsEventPrefix.endsWith('/ods_events')) {
-    prefix = odsEventPrefix.replace(new RegExp('/ods_events[/]?'), '');
+    prefix = odsEventPrefix.replace(/ods_events\/?/, '');
+  } else if (odsEventPrefix.endsWith(`clickstream/${projectId}/data/ods/`)) {
+    // control plane set the prefix to clickstream/<projectId>/data/ods/
+    // the actual prefix should be clickstream/<projectId>/data/ods/<projectId>/
+    prefix = odsEventPrefix + projectId;
   }
-
   if (prefix.length > 0 && !prefix.endsWith('/')) {
     prefix += '/';
   }
-
+  logger.info(`prefix: '${prefix}'`);
   return prefix;
 }

--- a/src/analytics/parameter.ts
+++ b/src/analytics/parameter.ts
@@ -742,7 +742,7 @@ export function createStackParameters(scope: Construct): {
           'pipeline-ods-events-bucket',
           odsEventBucketParam.valueAsString,
         ),
-        prefix: getSourcePrefix(scope, odsEventBucketPrefixParam.valueAsString),
+        prefix: getSourcePrefix(scope, odsEventBucketPrefixParam.valueAsString, projectIdParam.valueAsString),
         fileSuffix: odsEventFileSuffixParam.valueAsString,
         emrServerlessApplicationId: emrServerlessApplicationIdParam.valueAsString,
       },
@@ -805,7 +805,7 @@ function createWorkgroupParameter(scope: Construct, id: string): CfnParameter {
   });
 }
 
-function getSourcePrefix(scope: Construct, odsEventPrefix: string): string {
+function getSourcePrefix(scope: Construct, odsEventPrefix: string, projectId: string): string {
 
   const role = createLambdaRole(scope, 'GetSourcePrefixCustomerResourceFnRole', false, []);
 
@@ -839,6 +839,7 @@ function getSourcePrefix(scope: Construct, odsEventPrefix: string): string {
 
   const customProps: GetResourcePrefixPropertiesType = {
     odsEventPrefix,
+    projectId,
   };
 
   const cr = new CustomResource(scope, 'GetSourcePrefixCustomerResource', {

--- a/src/analytics/private/metrics-common-workflow.ts
+++ b/src/analytics/private/metrics-common-workflow.ts
@@ -81,7 +81,7 @@ export function buildMetricsWidgetForWorkflows(scope: Construct, id: string, pro
     treatMissingData: TreatMissingData.NOT_BREACHING,
     metric: props.loadDataWorkflows.event.metricFailed({ period: Duration.hours(1) }), // place-holder value here, Override by addPropertyOverride below
     alarmDescription: `Load event workflow failed, projectId: ${props.projectId}`,
-    alarmName: getAlarmName(scope, props.projectId, 'Load event workflow'),
+    alarmName: getAlarmName(scope, props.projectId, 'Load Event Workflow'),
   });
   (loadEventsWorkflowAlarm.node.defaultChild as CfnResource).addPropertyOverride('Period', processingJobInterval.getIntervalSeconds());
 
@@ -92,7 +92,7 @@ export function buildMetricsWidgetForWorkflows(scope: Construct, id: string, pro
     treatMissingData: TreatMissingData.NOT_BREACHING,
     metric: props.upsertUsersWorkflow.metricFailed({ period: Duration.hours(24) }), // place-holder value here, Override by addPropertyOverride below
     alarmDescription: `Upsert users workflow failed, projectId: ${props.projectId}`,
-    alarmName: getAlarmName(scope, props.projectId, 'Upsert users workflow'),
+    alarmName: getAlarmName(scope, props.projectId, 'Upsert User Workflow'),
   });
   (upsertUsersWorkflowAlarm.node.defaultChild as CfnResource).addPropertyOverride('Period', upsertUsersInterval.getIntervalSeconds());
 

--- a/src/analytics/private/sql-def.ts
+++ b/src/analytics/private/sql-def.ts
@@ -79,6 +79,10 @@ export const reportingViewsDef: SQLDef[] = [
 export const schemaDefs: SQLDef[] = [
   {
     updatable: 'true',
+    sqlFile: 'clickstream-log.sql',
+  },
+  {
+    updatable: 'true',
     sqlFile: 'ods-events.sql',
   },
   {

--- a/src/analytics/private/sqls/redshift/clickstream-log.sql
+++ b/src/analytics/private/sqls/redshift/clickstream-log.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS {{schema}}.{{table_clickstream_log}} (
+    id varchar(256),
+    log_name varchar(50),
+    log_level varchar(10), 
+    log_msg varchar(256),
+    log_date TIMESTAMP default getdate()
+);

--- a/src/analytics/private/sqls/redshift/sp-clear-item-and-user.sql
+++ b/src/analytics/private/sqls/redshift/sp-clear-item-and-user.sql
@@ -1,9 +1,9 @@
 CREATE OR REPLACE PROCEDURE {{schema}}.sp_clear_item_and_user() 
-AS
+NONATOMIC AS
 $$
 DECLARE
     record_number INT; 
-    log_name varchar(50) := 'sp_clear_item_and_user';
+    log_name varchar(50) := 'sp_clear_expired_events';
 BEGIN
     -- clean table_item
     WITH item_id_rank AS(

--- a/src/analytics/private/sqls/redshift/sp-clickstream-log.sql
+++ b/src/analytics/private/sqls/redshift/sp-clickstream-log.sql
@@ -1,10 +1,9 @@
 CREATE OR REPLACE PROCEDURE {{schema}}.{{sp_clickstream_log}}(name in varchar(50), level in varchar(10), msg in varchar(256))
-AS 
+NONATOMIC AS 
 $$ 
 DECLARE 
     log_id INT;
-BEGIN 
-CREATE TABLE IF NOT EXISTS {{schema}}.{{table_clickstream_log}} (id varchar(256), log_name varchar(50), log_level varchar(10), log_msg varchar(256), log_date TIMESTAMP default getdate());
+BEGIN
 EXECUTE 'SELECT COUNT(1) FROM {{schema}}.{{table_clickstream_log}}' INTO log_id;
 INSERT INTO {{schema}}.{{table_clickstream_log}} VALUES(log_id, name, level, msg);
 EXCEPTION WHEN OTHERS THEN

--- a/src/analytics/private/sqls/redshift/sp-scan-metadata.sql
+++ b/src/analytics/private/sqls/redshift/sp-scan-metadata.sql
@@ -1,5 +1,6 @@
-CREATE OR REPLACE PROCEDURE {{schema}}.sp_scan_metadata(top_frequent_properties_limit NUMERIC, day_range NUMERIC)
-AS $$ 
+CREATE OR REPLACE PROCEDURE {{schema}}.sp_scan_metadata(top_frequent_properties_limit NUMERIC, day_range NUMERIC) 
+NONATOMIC AS 
+$$ 
 DECLARE
   rec RECORD;
   query text;

--- a/src/analytics/private/sqls/redshift/sp-upsert-users.sql
+++ b/src/analytics/private/sqls/redshift/sp-upsert-users.sql
@@ -1,5 +1,5 @@
-CREATE OR REPLACE PROCEDURE {{schema}}.{{sp_upsert_users}}()
-AS 
+CREATE OR REPLACE PROCEDURE {{schema}}.{{sp_upsert_users}}() 
+NONATOMIC AS 
 $$ 
 DECLARE 
   record_number INT; 

--- a/src/metrics/util.ts
+++ b/src/metrics/util.ts
@@ -82,5 +82,5 @@ export function setCfnNagForAlarms(alarms: Alarm[]) {
 
 export function getAlarmName(scope: Construct, projectId: string, alarm: string) {
   const stackId = getShortIdOfStack(Stack.of(scope));
-  return `${ALARM_NAME_PREFIX}|${projectId} ${alarm} ${stackId}`;
+  return `${ALARM_NAME_PREFIX}|${projectId} ${alarm}_${stackId}`;
 }

--- a/test/analytics/analytics-on-redshift/lambda/clear-expire-events/clear-expire-events.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/clear-expire-events/clear-expire-events.test.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-import { BatchExecuteStatementCommand, RedshiftDataClient } from '@aws-sdk/client-redshift-data';
+import { ExecuteStatementCommand, RedshiftDataClient } from '@aws-sdk/client-redshift-data';
 import { mockClient } from 'aws-sdk-client-mock';
 import { ClearExpiredEventsEvent, handler } from '../../../../../src/analytics/lambdas/clear-expired-events-workflow/clear-expired-events';
 import { ClearExpiredEventsBody } from '../../../../../src/analytics/private/model';
@@ -43,25 +43,25 @@ describe('Lambda - do clear expired events in Redshift Serverless', () => {
 
   test('Executed Redshift clear expired events command', async () => {
     const executeId = 'Id-1';
-    redshiftDataMock.on(BatchExecuteStatementCommand).resolves({ Id: executeId });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: executeId });
     const resp = await handler(clearExpiredEventsEvent);
     expect(resp).toEqual({
       detail: expect.objectContaining({
         id: executeId,
       }),
     });
-    expect(redshiftDataMock).toHaveReceivedCommandWith(BatchExecuteStatementCommand, {
+    expect(redshiftDataMock).toHaveReceivedCommandWith(ExecuteStatementCommand, {
       WorkgroupName: workGroupName,
     });
   });
 
   test('Execute command error in Redshift when doing clear expired events', async () => {
-    redshiftDataMock.on(BatchExecuteStatementCommand).rejectsOnce();
+    redshiftDataMock.on(ExecuteStatementCommand).rejectsOnce();
     try {
       await handler(clearExpiredEventsEvent);
       fail('The error in executing statement of Redshift data was caught');
     } catch (error) {
-      expect(redshiftDataMock).toHaveReceivedCommandWith(BatchExecuteStatementCommand, {
+      expect(redshiftDataMock).toHaveReceivedCommandWith(ExecuteStatementCommand, {
         WorkgroupName: workGroupName,
       });
     }
@@ -86,14 +86,14 @@ describe('Lambda - do clear expire events in Redshift Provisioned', () => {
 
   test('Executed Redshift clear expired events command', async () => {
     const executeId = 'Id-1';
-    redshiftDataMock.on(BatchExecuteStatementCommand).resolves({ Id: executeId });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: executeId });
     const resp = await handler(clearExpiredEventsEvent);
     expect(resp).toEqual({
       detail: expect.objectContaining({
         id: executeId,
       }),
     });
-    expect(redshiftDataMock).toHaveReceivedCommandWith(BatchExecuteStatementCommand, {
+    expect(redshiftDataMock).toHaveReceivedCommandWith(ExecuteStatementCommand, {
       ClusterIdentifier: clusterIdentifier,
       DbUser: dbUser,
     });

--- a/test/analytics/analytics-on-redshift/lambda/custom-resources/get-source-prefix.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/custom-resources/get-source-prefix.test.ts
@@ -44,6 +44,7 @@ const event: CloudFormationCustomResourceEvent = {
   ResourceProperties: {
     ServiceToken: 'arn:aws:lambda:us-east-1:11111111111:function:testFn',
     odsEventPrefix: 'project0001/test/ods_events/',
+    projectId: 'test_project_id',
   },
 };
 
@@ -77,6 +78,14 @@ test('can get prefix from data prefix4', async () => {
 
   const res = await handler(event, c);
   expect(res).toEqual({ Data: { prefix: 'project0004/data/' }, Status: 'SUCCESS' });
+});
+
+
+test('can get prefix from data prefix endswith /data/ods/', async () => {
+  event.ResourceProperties.odsEventPrefix = 'clickstream/test_project_id/data/ods/';
+
+  const res = await handler(event, c);
+  expect(res).toEqual({ Data: { prefix: 'clickstream/test_project_id/data/ods/test_project_id/' }, Status: 'SUCCESS' });
 });
 
 


### PR DESCRIPTION
close https://github.com/awslabs/clickstream-analytics-on-aws/issues/289

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

- fix https://github.com/awslabs/clickstream-analytics-on-aws/issues/289
- fix upgrade error for alarm 'Clickstream|test_project_007 Max file age d9170ff0 already exists'
- fix upgrade error for s3 prefix of ods events files from control plane

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [x] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend