### PR TITLE
fix: change the default of TransformerAndEnrichClassNames in control plane

### DIFF
--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -323,3 +323,5 @@ export const ALARM_NAME_PREFIX = 'Clickstream';
 
 export const DEFAULT_SOLUTION_OPERATOR = 'Clickstream';
 export const DEFAULT_DASHBOARD_NAME = 'User lifecycle';
+
+export const TRANSFORMER_AND_ENRICH_CLASS_NAMES = 'software.aws.solution.clickstream.TransformerV2,software.aws.solution.clickstream.UAEnrichment,software.aws.solution.clickstream.IPEnrichment';

--- a/src/control-plane/backend/config/dictionary.json
+++ b/src/control-plane/backend/config/dictionary.json
@@ -33,7 +33,7 @@
         "name": "Transformer",
         "description": "Convert the data format reported by SDK into the data format in the data warehouse",
         "builtIn": true,
-        "mainFunction": "software.aws.solution.clickstream.Transformer",
+        "mainFunction": "software.aws.solution.clickstream.TransformerV2",
         "jarFile": "",
         "bindCount": 0,
         "pluginType": "Transform",

--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -37,6 +37,7 @@ import {
   S3_PREFIX_PATTERN,
   REDSHIFT_CLUSTER_IDENTIFIER_PATTERN,
   REDSHIFT_DB_USER_NAME_PATTERN,
+  TRANSFORMER_AND_ENRICH_CLASS_NAMES,
 } from '../common/constants-ln';
 import { REDSHIFT_MODE } from '../common/model-ln';
 import { validateDataProcessingInterval, validatePattern, validateServerlessRedshiftRPU, validateSinkBatch } from '../common/stack-params-valid';
@@ -670,7 +671,7 @@ export class CDataProcessingStack extends JSONObject {
   })
     ScheduleExpression?: string;
 
-  @JSONObject.optional('')
+  @JSONObject.optional(TRANSFORMER_AND_ENRICH_CLASS_NAMES)
     TransformerAndEnrichClassNames?: string;
 
   @JSONObject.optional('')

--- a/src/data-pipeline/parameter.ts
+++ b/src/data-pipeline/parameter.ts
@@ -13,7 +13,7 @@
 
 import { CfnParameter } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { EMR_VERSION_PATTERN, PARAMETER_GROUP_LABEL_VPC, PARAMETER_LABEL_PRIVATE_SUBNETS, PARAMETER_LABEL_VPCID, S3_BUCKET_NAME_PATTERN, S3_PATH_PLUGIN_FILES_PATTERN, S3_PATH_PLUGIN_JARS_PATTERN, SCHEDULE_EXPRESSION_PATTERN } from '../common/constant';
+import { EMR_VERSION_PATTERN, PARAMETER_GROUP_LABEL_VPC, PARAMETER_LABEL_PRIVATE_SUBNETS, PARAMETER_LABEL_VPCID, S3_BUCKET_NAME_PATTERN, S3_PATH_PLUGIN_FILES_PATTERN, S3_PATH_PLUGIN_JARS_PATTERN, SCHEDULE_EXPRESSION_PATTERN, TRANSFORMER_AND_ENRICH_CLASS_NAMES } from '../common/constant';
 import { Parameters, SubnetParameterType } from '../common/parameters';
 
 export function createStackParameters(scope: Construct) {
@@ -92,7 +92,7 @@ export function createStackParameters(scope: Construct) {
 
   const transformerAndEnrichClassNamesParam = new CfnParameter(scope, 'TransformerAndEnrichClassNames', {
     description: 'The class name list of custom plugins to transform or enrich data',
-    default: 'software.aws.solution.clickstream.TransformerV2,software.aws.solution.clickstream.UAEnrichment,software.aws.solution.clickstream.IPEnrichment',
+    default: TRANSFORMER_AND_ENRICH_CLASS_NAMES,
     type: 'String',
   });
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary
- set default value TransformerAndEnrichClassNames from empty to `software.aws.solution.clickstream.TransformerV2,software.aws.solution.clickstream.UAEnrichment,software.aws.solution.clickstream.IPEnrichment`

- As PR: https://github.com/awslabs/clickstream-analytics-on-aws/pull/295, only change the default value of TransformerAndEnrichClassNames in `data processing` will not work if upgrading from old version. We also need to change the default value in control plane


(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend