### PR TITLE
fix: execute bash sqls validation error in redshift when having several applications

### DIFF
--- a/src/analytics/lambdas/custom-resource/create-schemas.ts
+++ b/src/analytics/lambdas/custom-resource/create-schemas.ts
@@ -224,8 +224,10 @@ async function createSchemas(props: ResourcePropertiesType, biUsername: string) 
   const odsTableNames = props.odsTableNames;
 
   const appIds = splitString(props.appIds);
-  const sqlStatements : string[] = [];
+  const sqlStatementsByApp = new Map<string, string[]>();
+
   for (const app of appIds) {
+    const sqlStatements: string[] = [];
     const mustacheParam: MustacheParamType = {
       schema: app,
       table_ods_events: odsTableNames.odsEvents,
@@ -239,20 +241,21 @@ async function createSchemas(props: ResourcePropertiesType, biUsername: string) 
 
     sqlStatements.push(`CREATE SCHEMA IF NOT EXISTS ${app}`);
     for (const sqlDef of props.schemaDefs) {
-      if (sqlDef.multipleLine !== undefined && sqlDef.multipleLine === 'true' ) {
+      if (sqlDef.multipleLine !== undefined && sqlDef.multipleLine === 'true') {
         logger.info('multipleLine SQL: ', sqlDef.sqlFile);
         sqlStatements.push(...getSqlContents(sqlDef.sqlFile, mustacheParam));
       } else {
         sqlStatements.push(getSqlContent(sqlDef.sqlFile, mustacheParam));
       }
     }
+    sqlStatementsByApp.set(app, sqlStatements);
   };
 
-  if (sqlStatements.length == 0) {
+  if (sqlStatementsByApp.size == 0) {
     logger.info('Ignore creating schema in Redshift due to there is no application.');
   } else {
     const redShiftClient = getRedshiftClient(props.dataAPIRole);
-    await createSchemasInRedshift(redShiftClient, sqlStatements, props);
+    await createSchemasInRedshift(redShiftClient, sqlStatementsByApp, props);
   }
 }
 
@@ -260,8 +263,9 @@ async function updateSchemas(props: ResourcePropertiesType, biUsername: string, 
   const odsTableNames = props.odsTableNames;
   const appUpdateProps = getAppUpdateProps(props, oldProps);
 
-  const sqlStatements : string[] = [];
+  const sqlStatementsByApp = new Map<string, string[]>();
   for (const app of appUpdateProps.createAppIds) {
+    const sqlStatements: string[] = [];
     const mustacheParam: MustacheParamType = {
       schema: app,
       table_ods_events: odsTableNames.odsEvents,
@@ -274,16 +278,18 @@ async function updateSchemas(props: ResourcePropertiesType, biUsername: string, 
     };
     sqlStatements.push(`CREATE SCHEMA IF NOT EXISTS ${app}`);
     for (const sqlDef of props.schemaDefs) {
-      if (sqlDef.multipleLine !== undefined && sqlDef.multipleLine === 'true' ) {
+      if (sqlDef.multipleLine !== undefined && sqlDef.multipleLine === 'true') {
         logger.info('multipleLine SQL: ', sqlDef.sqlFile);
         sqlStatements.push(...getSqlContents(sqlDef.sqlFile, mustacheParam));
         continue;
       }
       sqlStatements.push(getSqlContent(sqlDef.sqlFile, mustacheParam));
     }
+    sqlStatementsByApp.set(app, sqlStatements);
   };
 
   for (const app of appUpdateProps.updateAppIds) {
+    const sqlStatements: string[] = [];
     const mustacheParam: MustacheParamType = {
       schema: app,
       table_ods_events: odsTableNames.odsEvents,
@@ -308,24 +314,33 @@ async function updateSchemas(props: ResourcePropertiesType, biUsername: string, 
         logger.info(`skip update ${schemaDef.sqlFile} due to it is not updatable.`);
       }
     }
+
+    if (sqlStatementsByApp.has(app)) {
+      sqlStatementsByApp.get(app)?.push(...sqlStatements);
+    } else {
+      sqlStatementsByApp.set(app, sqlStatements);
+    }
+
   };
-  await doUpdate(sqlStatements, props);
+  await doUpdate(sqlStatementsByApp, props);
 }
 
-async function doUpdate(sqlStatements: string[], props: ResourcePropertiesType) {
-  if (sqlStatements.length == 0) {
+async function doUpdate(sqlStatementsByApp: Map<string, string[]>, props: ResourcePropertiesType) {
+  if (sqlStatementsByApp.size == 0) {
     logger.info('Ignore creating schema in Redshift due to there is no application.');
   } else {
     const redShiftClient = getRedshiftClient(props.dataAPIRole);
-    await createSchemasInRedshift(redShiftClient, sqlStatements, props);
+    await createSchemasInRedshift(redShiftClient, sqlStatementsByApp, props);
   }
 }
 
 async function createViewForReporting(props: ResourcePropertiesType) {
   const odsTableNames = props.odsTableNames;
   const appIds = splitString(props.appIds);
-  const sqlStatements : string[] = [];
+
+  const sqlStatementsByApp = new Map<string, string[]>();
   for (const app of appIds) {
+    const sqlStatements: string[] = [];
     const mustacheParam: MustacheParamType = {
       schema: app,
       table_ods_events: odsTableNames.odsEvents,
@@ -339,13 +354,14 @@ async function createViewForReporting(props: ResourcePropertiesType) {
     for (const viewDef of props.reportingViewsDef) {
       sqlStatements.push(getSqlContent(viewDef.sqlFile, mustacheParam));
     }
+    sqlStatementsByApp.set(app, sqlStatements);
   };
 
-  if (sqlStatements.length == 0) {
+  if (sqlStatementsByApp.size == 0) {
     logger.info('Ignore creating reporting views in Redshift due to there is no application.');
   } else {
     const redShiftClient = getRedshiftClient(props.dataAPIRole);
-    await createSchemasInRedshift(redShiftClient, sqlStatements, props);
+    await createSchemasInRedshift(redShiftClient, sqlStatementsByApp, props);
   }
 }
 
@@ -353,9 +369,10 @@ async function updateViewForReporting(props: ResourcePropertiesType, oldProps: R
   const odsTableNames = props.odsTableNames;
 
   const appUpdateProps = getAppUpdateProps(props, oldProps);
-  const sqlStatements : string[] = [];
 
+  const sqlStatementsByApp = new Map<string, string[]>();
   for (const app of appUpdateProps.createAppIds) {
+    const sqlStatements: string[] = [];
     const mustacheParam: MustacheParamType = {
       schema: app,
       table_ods_events: odsTableNames.odsEvents,
@@ -368,9 +385,11 @@ async function updateViewForReporting(props: ResourcePropertiesType, oldProps: R
     for (const viewDef of props.reportingViewsDef) {
       sqlStatements.push(getSqlContent(viewDef.sqlFile, mustacheParam));
     }
+    sqlStatementsByApp.set(app, sqlStatements);
   };
 
   for (const app of appUpdateProps.updateAppIds) {
+    const sqlStatements: string[] = [];
     const mustacheParam: MustacheParamType = {
       schema: app,
       table_ods_events: odsTableNames.odsEvents,
@@ -394,13 +413,18 @@ async function updateViewForReporting(props: ResourcePropertiesType, oldProps: R
         logger.info(`skip update ${viewDef.sqlFile} due to it is not updatable.`);
       }
     }
+    if (sqlStatementsByApp.has(app)) {
+      sqlStatementsByApp.get(app)?.push(...sqlStatements);
+    } else {
+      sqlStatementsByApp.set(app, sqlStatements);
+    }
   };
 
-  if (sqlStatements.length == 0) {
+  if (sqlStatementsByApp.size == 0) {
     logger.info('Ignore creating reporting views in Redshift due to there is no application.');
   } else {
     const redShiftClient = getRedshiftClient(props.dataAPIRole);
-    await createSchemasInRedshift(redShiftClient, sqlStatements, props);
+    await createSchemasInRedshift(redShiftClient, sqlStatementsByApp, props);
   }
 
 }
@@ -434,15 +458,20 @@ const createDatabaseBIUser = async (redshiftClient: RedshiftDataClient, credenti
   }
 };
 
-const createSchemasInRedshift = async (redshiftClient: RedshiftDataClient, sqlStatements: string[], props: CreateDatabaseAndSchemas) => {
-  try {
-    await executeStatementsWithWait(redshiftClient, sqlStatements,
-      props.serverlessRedshiftProps, props.provisionedRedshiftProps, props.databaseName);
-  } catch (err) {
-    if (err instanceof Error) {
-      logger.error('Error when creating schema in serverless Redshift.', err);
+const createSchemasInRedshift = async (redshiftClient: RedshiftDataClient,
+  sqlStatementsByApp: Map<string, string[]>, props: CreateDatabaseAndSchemas) => {
+
+  for (const [appId, sqlStatements] of sqlStatementsByApp) {
+    logger.info(`creating schema in serverless Redshift for ${appId}`);
+    try {
+      await executeStatementsWithWait(redshiftClient, sqlStatements,
+        props.serverlessRedshiftProps, props.provisionedRedshiftProps, props.databaseName);
+    } catch (err) {
+      if (err instanceof Error) {
+        logger.error('Error when creating schema in serverless Redshift, appId=' + appId, err);
+      }
+      throw err;
     }
-    throw err;
   }
 };
 
@@ -463,7 +492,7 @@ function getAppUpdateProps(props: ResourcePropertiesType, oldProps: ResourceProp
   const oldAppIdArray: string[] = [];
   const oldViewSqlArray: string[] = [];
   const oldSchemaSqlArray: string[] = [];
-  if ( oldProps.appIds.trim().length > 0 ) {
+  if (oldProps.appIds.trim().length > 0) {
     oldAppIdArray.push(...oldProps.appIds.trim().split(','));
   };
   for (const view of oldProps.reportingViewsDef) {
@@ -477,7 +506,7 @@ function getAppUpdateProps(props: ResourcePropertiesType, oldProps: ResourceProp
   logger.info(`old schema sql array: ${oldSchemaSqlArray}`);
 
   const appIdArray: string[] = [];
-  if ( props.appIds.trim().length > 0 ) {
+  if (props.appIds.trim().length > 0) {
     appIdArray.push(...props.appIds.trim().split(','));
   };
 

--- a/src/analytics/private/constant.ts
+++ b/src/analytics/private/constant.ts
@@ -37,5 +37,6 @@ export const SQL_TEMPLATE_PARAMETER = {
   table_ods_users: 'ods_users',
   table_dim_users: 'dim_users',
   sp_clickstream_log: 'sp_clickstream_log',
+  sp_clickstream_log_non_atomic: 'sp_clickstream_log_non_atomic',
   table_clickstream_log: 'clickstream_log',
 };

--- a/src/analytics/private/model.ts
+++ b/src/analytics/private/model.ts
@@ -216,6 +216,7 @@ export type MustacheParamType = {
   table_ods_users: string;
   table_dim_users: string;
   sp_clickstream_log: string;
+  sp_clickstream_log_non_atomic: string;
   table_clickstream_log: string;
   user_bi?: string;
 }

--- a/src/analytics/private/sql-def.ts
+++ b/src/analytics/private/sql-def.ts
@@ -107,6 +107,10 @@ export const schemaDefs: SQLDef[] = [
   },
   {
     updatable: 'true',
+    sqlFile: 'sp-clickstream-log-non-atomic.sql',
+  },
+  {
+    updatable: 'true',
     sqlFile: 'grant-permissions-to-bi-user.sql',
     multipleLine: 'true',
   },

--- a/src/analytics/private/sqls/redshift/sp-clear-expired-events.sql
+++ b/src/analytics/private/sqls/redshift/sp-clear-expired-events.sql
@@ -11,38 +11,38 @@ BEGIN
 
     -- clean table_ods_events
     EXECUTE 'SELECT event_timestamp FROM {{schema}}.{{table_ods_events}} ORDER BY event_timestamp DESC LIMIT 1' INTO latest_timestamp_record1;
-    CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'info', 'get event_timestamp = ' || latest_timestamp_record1.event_timestamp || ' from {{schema}}.{{table_ods_events}}');
+    CALL {{schema}}.{{sp_clickstream_log_non_atomic}}(log_name, 'info', 'get event_timestamp = ' || latest_timestamp_record1.event_timestamp || ' from {{schema}}.{{table_ods_events}}');
     IF latest_timestamp_record1.event_timestamp is null THEN
-        CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'info', 'no event_timestamp found in {{schema}}.{{table_ods_events}}');
+        CALL {{schema}}.{{sp_clickstream_log_non_atomic}}(log_name, 'info', 'no event_timestamp found in {{schema}}.{{table_ods_events}}');
     ELSE
         DELETE FROM {{schema}}.{{table_ods_events}} WHERE event_date < DATEADD(day, -retention_range_days, CAST(TIMESTAMP 'epoch' + (latest_timestamp_record1.event_timestamp / 1000) * INTERVAL '1 second' as date));
         GET DIAGNOSTICS record_number := ROW_COUNT;
-        CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'info', 'delete '||record_number||' expired records from {{schema}}.{{table_event}} for retention_range_days='||retention_range_days);
+        CALL {{schema}}.{{sp_clickstream_log_non_atomic}}(log_name, 'info', 'delete '||record_number||' expired records from {{schema}}.{{table_event}} for retention_range_days='||retention_range_days);
         ANALYZE {{schema}}.{{table_ods_events}};
     END IF;
 
     --  clean table_event and table_event_parameter
     EXECUTE 'SELECT event_timestamp FROM {{schema}}.{{table_event}} ORDER BY event_timestamp DESC LIMIT 1' INTO latest_timestamp_record2;
-    CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'info', 'get event_timestamp = ' || latest_timestamp_record2.event_timestamp || ' from {{schema}}.{{table_ods_events}}');
+    CALL {{schema}}.{{sp_clickstream_log_non_atomic}}(log_name, 'info', 'get event_timestamp = ' || latest_timestamp_record2.event_timestamp || ' from {{schema}}.{{table_ods_events}}');
     IF latest_timestamp_record2.event_timestamp is null THEN
-        CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'info', 'no event_timestamp found in {{schema}}.{{table_event}}');
+        CALL {{schema}}.{{sp_clickstream_log_non_atomic}}(log_name, 'info', 'no event_timestamp found in {{schema}}.{{table_event}}');
     ELSE
         DELETE FROM {{schema}}.{{table_event}} WHERE event_timestamp < (latest_timestamp_record2.event_timestamp - retention_range_days * 24 * 3600 * 1000);
         GET DIAGNOSTICS record_number := ROW_COUNT;
-        CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'info', 'delete '||record_number||' expired records from {{schema}}.{{table_event}} for retention_range_days='||retention_range_days);
+        CALL {{schema}}.{{sp_clickstream_log_non_atomic}}(log_name, 'info', 'delete '||record_number||' expired records from {{schema}}.{{table_event}} for retention_range_days='||retention_range_days);
         ANALYZE {{schema}}.{{table_event}};
 
         delete {{schema}}.{{table_event_parameter}} from {{schema}}.{{table_event_parameter}} e WHERE not exists (
             SELECT 1 from  {{schema}}.{{table_event}} p where e.event_id = p.event_id and e.event_timestamp = p.event_timestamp
         );
         GET DIAGNOSTICS record_number := ROW_COUNT;
-        CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'info', 'delete '||record_number||' expired records from {{schema}}.{{table_event_parameter}} for retention_range_days='||retention_range_days);
+        CALL {{schema}}.{{sp_clickstream_log_non_atomic}}(log_name, 'info', 'delete '||record_number||' expired records from {{schema}}.{{table_event_parameter}} for retention_range_days='||retention_range_days);
         ANALYZE {{schema}}.{{table_event_parameter}};
     END IF;
 
     CALL {{schema}}.sp_clear_item_and_user();
 
 EXCEPTION WHEN OTHERS THEN
-    CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'error', 'error message:' || SQLERRM);    
+    CALL {{schema}}.{{sp_clickstream_log_non_atomic}}(log_name, 'error', 'error message:' || SQLERRM);    
 END;
 $$ LANGUAGE plpgsql;

--- a/src/analytics/private/sqls/redshift/sp-clear-item-and-user.sql
+++ b/src/analytics/private/sqls/redshift/sp-clear-item-and-user.sql
@@ -14,7 +14,7 @@ BEGIN
     where {{schema}}.{{table_item}}.id = item_id_rank.id and item_id_rank.et_rank != 1;
 
     GET DIAGNOSTICS record_number := ROW_COUNT;
-    CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'info', 'delete '||record_number||' from {{schema}}.{{table_item}}');
+    CALL {{schema}}.{{sp_clickstream_log_non_atomic}}(log_name, 'info', 'delete '||record_number||' from {{schema}}.{{table_item}}');
     ANALYZE {{schema}}.{{table_item}};
 
     
@@ -27,11 +27,11 @@ BEGIN
     where {{schema}}.{{table_user}}.user_id = user_id_rank.user_id and user_id_rank.et_rank != 1;
 
     GET DIAGNOSTICS record_number := ROW_COUNT;
-    CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'info', 'delete '||record_number||' from {{schema}}.{{table_user}}');
+    CALL {{schema}}.{{sp_clickstream_log_non_atomic}}(log_name, 'info', 'delete '||record_number||' from {{schema}}.{{table_user}}');
     ANALYZE {{schema}}.{{table_user}};
 
 
 EXCEPTION WHEN OTHERS THEN
-    CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'error', 'error message:' || SQLERRM);    
+    CALL {{schema}}.{{sp_clickstream_log_non_atomic}}(log_name, 'error', 'error message:' || SQLERRM);    
 END;
 $$ LANGUAGE plpgsql;

--- a/src/analytics/private/sqls/redshift/sp-clickstream-log-non-atomic.sql
+++ b/src/analytics/private/sqls/redshift/sp-clickstream-log-non-atomic.sql
@@ -1,5 +1,5 @@
-CREATE OR REPLACE PROCEDURE {{schema}}.{{sp_clickstream_log}}(name in varchar(50), level in varchar(10), msg in varchar(256))
-AS 
+CREATE OR REPLACE PROCEDURE {{schema}}.{{sp_clickstream_log_non_atomic}}(name in varchar(50), level in varchar(10), msg in varchar(256))
+NONATOMIC AS 
 $$ 
 DECLARE 
     log_id INT;

--- a/src/analytics/private/sqls/redshift/sp-scan-metadata.sql
+++ b/src/analytics/private/sqls/redshift/sp-scan-metadata.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE PROCEDURE {{schema}}.sp_scan_metadata(top_frequent_properties_limit NUMERIC, day_range NUMERIC) 
-NONATOMIC AS 
+AS 
 $$ 
 DECLARE
   rec RECORD;

--- a/src/analytics/private/sqls/redshift/sp-upsert-users.sql
+++ b/src/analytics/private/sqls/redshift/sp-upsert-users.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE PROCEDURE {{schema}}.{{sp_upsert_users}}() 
-NONATOMIC AS 
+ AS 
 $$ 
 DECLARE 
   record_number INT; 

--- a/src/analytics/private/sqls/redshift/user-m-view.sql
+++ b/src/analytics/private/sqls/redshift/user-m-view.sql
@@ -1,16 +1,16 @@
 CREATE MATERIALIZED VIEW {{schema}}.user_m_view 
-BACKUP NO SORTKEY(user_id) 
+BACKUP NO SORTKEY(user_pseudo_id) 
 AUTO REFRESH YES 
 AS
-WITH user_id_rank AS
+WITH user_pseudo_id_rank AS
 (
 	SELECT  *
-	       ,ROW_NUMBER() over (partition by user_id ORDER BY event_timestamp desc) AS et_rank
+	       ,ROW_NUMBER() over (partition by user_pseudo_id ORDER BY event_timestamp desc) AS et_rank
 	FROM {{schema}}.{{table_user}}
 ), user_new AS
 (
 	SELECT  *
-	FROM user_id_rank
+	FROM user_pseudo_id_rank
 	WHERE et_rank = 1
 )
 SELECT  user_id

--- a/src/analytics/private/sqls/redshift/user.sql
+++ b/src/analytics/private/sqls/redshift/user.sql
@@ -13,4 +13,4 @@ CREATE TABLE IF NOT EXISTS {{schema}}.{{table_user}}(
     device_id_list SUPER,
     _channel VARCHAR(255)
 ) DISTSTYLE EVEN 
-SORTKEY(user_id, event_timestamp)
+SORTKEY(user_pseudo_id, event_timestamp)

--- a/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
@@ -206,6 +206,10 @@ describe('Custom resource - Create schemas for applications in Redshift database
     },
     {
       updatable: 'true',
+      sqlFile: 'sp-clickstream-log-non-atomic.sql',
+    },
+    {
+      updatable: 'true',
       sqlFile: 'grant-permissions-to-bi-user.sql',
       multipleLine: 'true',
     },
@@ -281,7 +285,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
   beforeEach(async () => {
     redshiftDataMock.reset();
     smMock.reset();
-    const rootPath = __dirname+'/../../../../../src/analytics/private/sqls/redshift/';
+    const rootPath = __dirname + '/../../../../../src/analytics/private/sqls/redshift/';
     mockfs({
       '/opt/clickstream-device-view.sql': testSqlContent(rootPath + 'clickstream-device-view.sql'),
       '/opt/clickstream-path-view.sql': testSqlContent(rootPath + 'clickstream-path-view.sql'),
@@ -302,6 +306,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
       '/opt/sp-clear-expired-events.sql': testSqlContent(rootPath + 'sp-clear-expired-events.sql'),
       '/opt/sp-upsert-users.sql': testSqlContent(rootPath + 'sp-upsert-users.sql'),
       '/opt/sp-clickstream-log.sql': testSqlContent(rootPath + 'sp-clickstream-log.sql'),
+      '/opt/sp-clickstream-log-non-atomic.sql': testSqlContent(rootPath + 'sp-clickstream-log-non-atomic.sql'),
       '/opt/sp-scan-metadata.sql': testSqlContent(rootPath + 'sp-scan-metadata.sql'),
       '/opt/event.sql': testSqlContent(rootPath + 'event.sql'),
       '/opt/event-parameter.sql': testSqlContent(rootPath + 'event-parameter.sql'),
@@ -441,7 +446,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
       const sqlStr = input.Sqls.join(';\n');
       if (input as BatchExecuteStatementCommandInput) {
         if (sqlStr.includes('CREATE SCHEMA IF NOT EXISTS app1')
-        && sqlStr.includes(`CREATE TABLE IF NOT EXISTS app1.${TABLE_NAME_ODS_EVENT}(`)) {
+          && sqlStr.includes(`CREATE TABLE IF NOT EXISTS app1.${TABLE_NAME_ODS_EVENT}(`)) {
           return { Id: 'Id-1' };
         }
       }
@@ -535,7 +540,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
       const sqlStr = input.Sqls.join(';\n');
       if (input as BatchExecuteStatementCommandInput) {
         if (sqlStr.includes('CREATE SCHEMA IF NOT EXISTS app2')
-        && sqlStr.includes(`CREATE TABLE IF NOT EXISTS app2.${TABLE_NAME_ODS_EVENT}(`)) {
+          && sqlStr.includes(`CREATE TABLE IF NOT EXISTS app2.${TABLE_NAME_ODS_EVENT}(`)) {
           return { Id: 'Id-1' };
         }
       }
@@ -572,7 +577,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
       const sqlStr = input.Sqls.join(';\n');
       if (input as BatchExecuteStatementCommandInput) {
         if (sqlStr.includes('CREATE SCHEMA IF NOT EXISTS app2')
-        && sqlStr.includes(`CREATE TABLE IF NOT EXISTS app2.${TABLE_NAME_ODS_EVENT}(`)) {
+          && sqlStr.includes(`CREATE TABLE IF NOT EXISTS app2.${TABLE_NAME_ODS_EVENT}(`)) {
           return { Id: 'Id-1' };
         }
       }
@@ -663,32 +668,51 @@ describe('Custom resource - Create schemas for applications in Redshift database
   test('Updated schemas and views in Redshift provisioned cluster', async () => {
     redshiftDataMock
       .callsFakeOnce(input => {
-        console.log(`Sql-5 is ${JSON.stringify(input.Sqls)}`);
+        console.log(`Sql-5-1 is ${JSON.stringify(input.Sqls)}`);
         const sqlStr = input.Sqls.join(';\n');
 
         if (input as BatchExecuteStatementCommandInput) {
-          if (sqlStr.includes('CREATE SCHEMA IF NOT EXISTS app2')
-          && sqlStr.includes(`CREATE TABLE IF NOT EXISTS app2.${TABLE_NAME_EVENT_PARAMETER}(`)
-          && sqlStr.includes(`CREATE TABLE IF NOT EXISTS app1.${TABLE_NAME_EVENT_PARAMETER}`)) {
-            return { Id: 'Id-1' };
+          if (!sqlStr.includes('app1.')
+            && sqlStr.includes('CREATE SCHEMA IF NOT EXISTS app2')
+            && sqlStr.includes(`CREATE TABLE IF NOT EXISTS app2.${TABLE_NAME_EVENT_PARAMETER}(`)
+            && sqlStr.includes('CREATE OR REPLACE PROCEDURE app2.sp_clickstream_log_non_atomic')
+
+          ) {
+            return { Id: 'Id-1-1' };
           }
         }
-        throw new Error('Sql-5 are not expected');
+        throw new Error('Sql-5-1 are not expected');
+      }).callsFakeOnce(input => {
+        console.log(`Sql-5-2 is ${JSON.stringify(input.Sqls)}`);
+        const sqlStr = input.Sqls.join(';\n');
+
+        if (input as BatchExecuteStatementCommandInput) {
+          if (!sqlStr.includes('app2.')
+            && sqlStr.includes('CREATE SCHEMA IF NOT EXISTS app1')
+            && sqlStr.includes(`CREATE TABLE IF NOT EXISTS app1.${TABLE_NAME_EVENT_PARAMETER}`)
+            && sqlStr.includes('CREATE OR REPLACE PROCEDURE app1.sp_clickstream_log_non_atomic')
+          ) {
+            return { Id: 'Id-1-2' };
+          }
+        }
+        throw new Error('Sql-5-2 are not expected');
       }).resolves({ Id: 'Id-2' });
     redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
+
     const resp = await handler(updateAdditionalProvisionedEvent, context, callback) as CdkCustomResourceResponse;
+
     expect(resp.Status).toEqual('SUCCESS');
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 2);
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 4);
     expect(redshiftDataMock).toHaveReceivedNthSpecificCommandWith(1, BatchExecuteStatementCommand, {
       WorkgroupName: undefined,
       Database: projectDBName,
       ClusterIdentifier: clusterId,
       DbUser: dbUser,
     });
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 2);
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 4);
   });
 
-  console.log(updateServerlessEvent +''+ updateServerlessEvent2 + updateAdditionalProvisionedEvent);
+  console.log(updateServerlessEvent + '' + updateServerlessEvent2 + updateAdditionalProvisionedEvent);
   test('Updated schemas and views in Redshift provisioned cluster with updatable/new added view/schema table', async () => {
     redshiftDataMock
       .callsFakeOnce(input => {
@@ -698,39 +722,55 @@ describe('Custom resource - Create schemas for applications in Redshift database
           if (sqlStr.includes('CREATE SCHEMA IF NOT EXISTS app2')
             && sqlStr.includes('CREATE TABLE IF NOT EXISTS app2.clickstream_log')
             && sqlStr.includes(`CREATE TABLE IF NOT EXISTS app2.${TABLE_NAME_EVENT_PARAMETER}`)
-            && sqlStr.includes('CREATE OR REPLACE PROCEDURE app1.sp_clickstream_log')
-            && sqlStr.includes('CREATE TABLE IF NOT EXISTS app1.clickstream_log')
-            && !sqlStr.includes(`CREATE TABLE IF NOT EXISTS app1.${TABLE_NAME_EVENT_PARAMETER}`)
+            && sqlStr.includes('CREATE OR REPLACE PROCEDURE app2.sp_clickstream_log_non_atomic')
+            && !sqlStr.includes('app1.')
+
           ) {
-            return { Id: 'Id-1' };
+            return { Id: 'Id-1-1' };
           }
         }
         throw new Error('Sql-7 are not expected');
       })
-      .callsFake(input => {
+      .callsFakeOnce(input => {
         console.log(`Sql-8 is ${JSON.stringify(input.Sqls)}`);
         const sqlStr = input.Sqls.join(';\n');
 
         if (input as BatchExecuteStatementCommandInput) {
-          if ( sqlStr.includes('CREATE MATERIALIZED VIEW app2.user_m_view')
+          if (sqlStr.includes('CREATE MATERIALIZED VIEW app2.user_m_view')
             && sqlStr.includes('CREATE MATERIALIZED VIEW app2.item_m_view')
+            && !sqlStr.includes('app1.')
           ) {
-            return { Id: 'Id-2' };
+            return { Id: 'Id-2-2' };
           }
         }
         throw new Error('Sql-8 are not expected');
+      })
+      .callsFakeOnce(input => {
+        console.log(`Sql-9 is ${JSON.stringify(input.Sqls)}`);
+        const sqlStr = input.Sqls.join(';\n');
+
+        if (input as BatchExecuteStatementCommandInput) {
+          if ( !sqlStr.includes('app2.')) {
+            return { Id: 'Id-2-3' };
+          }
+        }
+        throw new Error('Sql-9 are not expected');
+      })
+      .resolves({
+        Id: 'Id-2-4',
       });
+
     redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
     const resp = await handler(updateAdditionalProvisionedEvent2, context, callback) as CdkCustomResourceResponse;
     expect(resp.Status).toEqual('SUCCESS');
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 2);
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 4);
     expect(redshiftDataMock).toHaveReceivedNthSpecificCommandWith(1, BatchExecuteStatementCommand, {
       WorkgroupName: undefined,
       Database: projectDBName,
       ClusterIdentifier: clusterId,
       DbUser: dbUser,
     });
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 2);
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 4);
   });
 
   test('Data api exception in Redshift provisioned cluster', async () => {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights
1. change to exec bash sqls by appId
2. remove non-atomic from sp_scan_metadata
3. add a new sp_clickstream_log_non_atomic

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend