### PR TITLE
fix: remain solution version in basic info and tags after pipeline update

### DIFF
--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -248,6 +248,7 @@ export class CPipeline {
     this.pipeline = pipeline;
     this.stackManager = new StackManager(pipeline);
     this.validateNetworkOnce = false;
+    this.stackTags = this.getStackTags();
   }
 
   public async create(): Promise<void> {
@@ -321,8 +322,8 @@ export class CPipeline {
     this.pipeline.workflow = newWorkflow;
     this.pipeline.executionArn = await this.stackManager.execute(execWorkflow, this.pipeline.executionName);
 
-    const templateInfo = await this.getTemplateInfo();
-    this.pipeline.templateVersion = templateInfo.solutionVersion;
+    this.pipeline.templateVersion = oldPipeline.templateVersion;
+
     await store.updatePipeline(this.pipeline, oldPipeline);
   }
 


### PR DESCRIPTION
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Remain solution version in basic info and tags after pipeline update.

Previously we were using latest solution version that was retrieved from Dictionary ddb table. Now we will use current version. For the tags, we need to initiate `stackTags`, otherwise they will be replaced with default values.

closes #279 

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend