### PR TITLE
chore: force to use IMDSv2 in EC2 managed by ECS for ingestion server

### DIFF
--- a/src/ingestion-server/server/private/ecs-cluster.ts
+++ b/src/ingestion-server/server/private/ecs-cluster.ts
@@ -97,6 +97,7 @@ export function createECSClusterAndService(
         volume: BlockDeviceVolume.ebs(30),
       },
     ],
+    requireImdsv2: true,
   });
 
   if (Token.isUnresolved(ecsAsgSetting.warmPoolSize)) {

--- a/test/ingestion-server/server/ingestion-server.test.ts
+++ b/test/ingestion-server/server/ingestion-server.test.ts
@@ -820,7 +820,7 @@ test('Check EC2 IMDSv2 Enabled', () => {
     template,
     'AWS::AutoScaling::LaunchConfiguration',
   )?.resource;
-  
+
   const properties = launchConfiguration.Properties;
   expect(properties.MetadataOptions.HttpTokens == 'required').toBeTruthy();
 });

--- a/test/ingestion-server/server/ingestion-server.test.ts
+++ b/test/ingestion-server/server/ingestion-server.test.ts
@@ -809,3 +809,19 @@ test('Ingestion server with MskConfig should set metrics widgets for kafkaCluste
   });
 });
 
+test('Check EC2 IMDSv2 Enabled', () => {
+  const app = new App();
+  const stack = new TestStack(app, 'test', {
+    withS3SinkConfig: true,
+  });
+
+  const template = Template.fromStack(stack);
+  const launchConfiguration = findFirstResource(
+    template,
+    'AWS::AutoScaling::LaunchConfiguration',
+  )?.resource;
+  
+  const properties = launchConfiguration.Properties;
+  expect(properties.MetadataOptions.HttpTokens == 'required').toBeTruthy();
+});
+


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Force to use IMDSv2 in EC2 managed by ECS for ingestion server
close #141 

## Implementation highlights

1. Force to use IMDSv2 in EC2 managed by ECS for ingestion server
2. Add unit test

## Test checklist

- [x] add new test cases
- [x] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [x] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [x] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend