### PR TITLE
fix: handle the case that user attribute value is empty and read user attribute hasData from summary

### DIFF
--- a/src/analytics/lambdas/scan-metadata-workflow/store-metadata-into-ddb.ts
+++ b/src/analytics/lambdas/scan-metadata-workflow/store-metadata-into-ddb.ts
@@ -216,6 +216,7 @@ async function handleUserAttributeMetadata(appId: string, metadataItems: any[]) 
         valueEnum: convertValueEnumToDDBList(record[9].stringValue),
       };
       item.summary = {
+        hasData: true,
         valueEnum: convertValueEnumToDDBList(record[9].stringValue),
       };
     } else {
@@ -233,6 +234,7 @@ async function handleUserAttributeMetadata(appId: string, metadataItems: any[]) 
           valueEnum: convertValueEnumToDDBList(record[9].stringValue),
         },
         summary: {
+          hasData: true,
           valueEnum: convertValueEnumToDDBList(record[9].stringValue),
         },
       };

--- a/src/analytics/private/sqls/redshift/sp-scan-metadata.sql
+++ b/src/analytics/private/sqls/redshift/sp-scan-metadata.sql
@@ -340,6 +340,7 @@ BEGIN
 				property_name NOT LIKE '%timestamp%'
 				AND rank = 1 
 				AND property_value IS NOT NULL
+				AND property_value != ''
 			GROUP BY property_category, property_name, property_value, value_type
 		)
 		GROUP BY project_id, app_info_app_id, month, day_number, property_category, property_name, value_type

--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -715,7 +715,6 @@ IMetadataEventParameter | undefined {
 function getLatestAttributeByName(metadata: IMetadataRaw[]): IMetadataUserAttribute[] {
   const latestUserAttributes: IMetadataUserAttribute[] = [];
   for (let meta of metadata) {
-    const lastDayData = getDataFromLastDay(meta);
     const attribute: IMetadataUserAttribute = {
       id: meta.id,
       month: meta.month,
@@ -723,7 +722,7 @@ function getLatestAttributeByName(metadata: IMetadataRaw[]): IMetadataUserAttrib
       projectId: meta.projectId,
       appId: meta.appId,
       name: meta.name,
-      hasData: lastDayData.hasData,
+      hasData: meta.summary.hasData ?? false,
       category: meta.category ?? ConditionCategory.OTHER,
       valueType: meta.valueType ?? MetadataValueType.STRING,
       valueEnum: meta.summary.valueEnum ?? [],

--- a/src/control-plane/backend/lambda/api/model/metadata.ts
+++ b/src/control-plane/backend/lambda/api/model/metadata.ts
@@ -34,6 +34,7 @@ export interface IMetadataRaw {
   readonly summary: {
     readonly platform?: MetadataPlatform[];
     readonly valueEnum?: IMetadataRawValue[];
+    readonly hasData?: boolean;
   };
 }
 

--- a/src/control-plane/backend/lambda/api/test/api/metadata.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/metadata.test.ts
@@ -1202,6 +1202,7 @@ describe('Metadata User Attribute test', () => {
                 value: 'value-02',
               },
             ],
+            hasData: true,
           },
         },
         {
@@ -1216,6 +1217,7 @@ describe('Metadata User Attribute test', () => {
                 value: 'value-02',
               },
             ],
+            hasData: true,
           },
         },
         {
@@ -1232,6 +1234,7 @@ describe('Metadata User Attribute test', () => {
                 value: 'value-02',
               },
             ],
+            hasData: false,
           },
         },
       ],

--- a/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/store-metadata-into-ddb.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/store-metadata-into-ddb.test.ts
@@ -461,6 +461,7 @@ describe('Lambda - store the metadata into DDB from Redshift', () => {
                   ],
                 },
                 summary: {
+                  hasData: true,
                   valueEnum: [
                     {
                       count: 10,


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

handle the case that user attribute value is empty and read user attribute hasData from summary

## Implementation highlights

1. Handle the case that user attribute value is empty.
2. Add hasData field into summary for user attribute metadata.
3. Read user attribute hasData from summary.

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend