### PR TITLE
chore: specify the runner of build via variables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: {}
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LARGE_RUNNER_L || 'ubuntu-latest' }}
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/dist-scan.yml
+++ b/.github/workflows/dist-scan.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: {}
 jobs:
   build-dist:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LARGE_RUNNER_S || 'ubuntu-latest' }}
     permissions:
       id-token: write
       contents: read

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-const { awscdk, gitlab, javascript, typescript } = require('projen');
+const { awscdk, gitlab, javascript, typescript, JsonPatch } = require('projen');
 const version = '1.0.0';
 const cdkVersion = '2.81.0';
 const minNodeVersion = '18.17.0';
@@ -290,6 +290,7 @@ apiProject.addFields({ version });
 project.buildWorkflow.buildTask._env = {
   NODE_OPTIONS: '--max_old_space_size=6144',
 };
+
 project.buildWorkflow.workflow.file?.addOverride(
   'jobs.build.permissions.checks',
   'write',
@@ -361,6 +362,11 @@ project.buildWorkflow.addPostBuildSteps({
     path: 'code-coverage-results.md',
   },
 });
+const runner = 'LARGE_RUNNER_L';
+project.buildWorkflow.workflow.file?.patch(
+  JsonPatch.replace('/jobs/build/runs-on', `$\{\{ vars.${runner} || 'ubuntu-latest' }}`),
+);
+
 project.upgradeWorkflow.workflows[0].jobs.upgrade.steps.splice(4, 0, {
   name: 'Upgrade frontend dependencies',
   run: 'yarn upgrade --cwd frontend',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend