### PR TITLE
chore: specify cfn-lint version as 0.81.0

### DIFF
--- a/.github/workflows/dist-scan.yml
+++ b/.github/workflows/dist-scan.yml
@@ -48,8 +48,10 @@ jobs:
         with:
           name: templates-${{ github.event.pull_request.number }}
           path: templates
-      - name: Setup Cloud Formation Linter with Latest Version
+      - name: Setup Cloud Formation Linter with 0.81.0
         uses: scottbrenner/cfn-lint-action@v2
+        with: 
+          version: 0.81.0
       - name: Print the Cloud Formation Linter Version & run Linter.
         id: cfn-lint
         run: |


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Specify cfn-lint version as 0.81.0, because 0.82.0 version caused error.
Already cut issue to track this 0.82.0 issue.  [cfn-lint issue](https://github.com/aws-cloudformation/cfn-lint/issues/2914)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend