### PR TITLE
tests: add case for no data in last day in metadata

### DIFF
--- a/src/control-plane/backend/lambda/api/test/api/metadata.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/metadata.test.ts
@@ -610,19 +610,6 @@ describe('Metadata Event test', () => {
         totalCount: 1,
       },
     });
-
-    // Mock DynamoDB error
-    ddbMock.on(QueryCommand).rejects(new Error('Mock DynamoDB error'));
-    res = await request(app)
-      .get(`/api/metadata/events?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
-    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
-    expect(res.statusCode).toBe(500);
-
-    expect(res.body).toEqual({
-      success: false,
-      message: 'Unexpected error occurred at server.',
-      error: 'Error',
-    });
   });
   it('Get metadata event list with parameters', async () => {
     jest


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Add ut case to cover without data in last day for metadata

## Implementation highlights

Add ut case to cover without data in last day for metadata

## Test checklist

- [x] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend