### PR TITLE
fix: hardcode database schema name when join event_parameter table

### DIFF
--- a/src/control-plane/backend/lambda/api/service/quicksight/sql-builder.ts
+++ b/src/control-plane/backend/lambda/api/service/quicksight/sql-builder.ts
@@ -991,7 +991,7 @@ export function _buildCommonPartSql(eventNames: string[], sqlParameters: SQLPara
     eventAttributes.push(...eventConditionProps.eventAttributes);
     const eventCommonColumnsSql = _buildCommonColumnsSql(eventAttributes, 'event_param_key', 'event_param_{{}}_value');
     eventColList = eventCommonColumnsSql.columns;
-    eventJoinTable = _buildEventJoinTable(eventCommonColumnsSql.columnsSql);
+    eventJoinTable = _buildEventJoinTable(sqlParameters.schemaName, eventCommonColumnsSql.columnsSql);
   }
 
   const userConditionProps = _getUserConditionProps(sqlParameters);
@@ -1129,7 +1129,7 @@ function _buildUserJoinTable(columnsSql: any) {
   `;
 }
 
-function _buildEventJoinTable(columnsSql: string) {
+function _buildEventJoinTable(schema: string, columnsSql: string) {
   return `
   join
   (
@@ -1137,7 +1137,7 @@ function _buildEventJoinTable(columnsSql: string) {
     event_base.event_id,
     ${columnsSql}
     from event_base
-    join app1.event_parameter as event_param on event_base.event_timestamp = event_param.event_timestamp 
+    join ${schema}.event_parameter as event_param on event_base.event_timestamp = event_param.event_timestamp 
       and event_base.event_id = event_param.event_id
     group by
       event_base.event_id

--- a/src/control-plane/backend/lambda/api/test/api/sql-builder.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/sql-builder.test.ts
@@ -13931,7 +13931,7 @@ describe('SQL Builder test', () => {
 
   });
 
-  test('schema name hard code', () => {
+  test('use specified schema name in generated SQL', () => {
 
     const sql = buildFunnelView({
       schemaName: 'shopping',

--- a/src/control-plane/backend/lambda/api/test/api/sql-builder.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/sql-builder.test.ts
@@ -13996,7 +13996,6 @@ describe('SQL Builder test', () => {
     expect(sql.includes('shopping.event')).toEqual(true);
     expect(sql.includes('app1.')).toEqual(false);
 
-    console.log(sql);
     expect(sql.trim().replace(/ /g, '')).toEqual(`
     with
       event_base as (


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

fix hard code 'app1' as event_parameter table schema.

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend