### PR TITLE
fix: missing partition by key user_pseudo_id

### DIFF
--- a/src/control-plane/backend/lambda/api/service/quicksight/sql-builder.ts
+++ b/src/control-plane/backend/lambda/api/service/quicksight/sql-builder.ts
@@ -366,8 +366,8 @@ export function buildEventPathAnalysisView(sqlParameters: SQLParameters) : strin
     dataTableSql = `data as (
       select 
         *,
-        ROW_NUMBER() OVER (PARTITION BY _session_id ORDER BY event_timestamp asc) as step_1,
-        ROW_NUMBER() OVER (PARTITION BY _session_id ORDER BY event_timestamp asc) + 1 as step_2
+        ROW_NUMBER() OVER (PARTITION BY user_pseudo_id, _session_id ORDER BY event_timestamp asc) as step_1,
+        ROW_NUMBER() OVER (PARTITION BY user_pseudo_id, _session_id ORDER BY event_timestamp asc) + 1 as step_2
       from mid_table 
     ),
     step_table_1 as (
@@ -393,12 +393,14 @@ export function buildEventPathAnalysisView(sqlParameters: SQLParameters) : strin
         _session_id,
         ROW_NUMBER() OVER (
           PARTITION BY
+            user_pseudo_id,
             _session_id
           ORDER BY
             step_1 asc, step_2
         ) as step_1,
         ROW_NUMBER() OVER (
           PARTITION BY
+            user_pseudo_id,
             _session_id
           ORDER BY
             step_1 asc, step_2

--- a/src/control-plane/backend/lambda/api/service/quicksight/sql-builder.ts
+++ b/src/control-plane/backend/lambda/api/service/quicksight/sql-builder.ts
@@ -376,7 +376,7 @@ export function buildEventPathAnalysisView(sqlParameters: SQLParameters) : strin
       data._session_id _session_id,
       min(step_1) min_step
       from data
-      where event_name in ('${eventNames.join('\',\'')}')
+      where event_name = '${eventNames[0]}'
       group by user_pseudo_id, _session_id
     ),
     step_table_2 as (
@@ -479,7 +479,7 @@ export function buildEventPathAnalysisView(sqlParameters: SQLParameters) : strin
       from
         data
       where
-        event_name in ('${eventNames.join('\',\'')}')
+        event_name = '${eventNames[0]}'
       group by
         user_pseudo_id,
         group_id
@@ -606,7 +606,7 @@ export function buildNodePathAnalysisView(sqlParameters: SQLParameters) : string
       from
         data
       where
-        node in ('${sqlParameters.pathAnalysis?.nodes?.join('\',\'')}')
+        node = '${sqlParameters.pathAnalysis!.nodes![0]}'
       group by
         user_pseudo_id,
         _session_id
@@ -744,7 +744,7 @@ export function buildNodePathAnalysisView(sqlParameters: SQLParameters) : string
       from
         data
       where
-        node in ('${sqlParameters.pathAnalysis?.nodes?.join('\',\'')}')
+        node = '${sqlParameters.pathAnalysis!.nodes![0]}'
       group by
         user_pseudo_id,
         group_id

--- a/src/control-plane/backend/lambda/api/test/api/sql-builder.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/sql-builder.test.ts
@@ -1908,7 +1908,7 @@ describe('SQL Builder test', () => {
         from
           data
         where
-          event_name in ('add_button_click', 'note_share', 'note_export')
+          event_name = 'add_button_click'
         group by
           user_pseudo_id,
           _session_id
@@ -2253,7 +2253,7 @@ describe('SQL Builder test', () => {
         from
           data
         where
-          event_name in ('add_button_click', 'note_share', 'note_export')
+          event_name = 'add_button_click'
         group by
           user_pseudo_id,
           group_id
@@ -2517,12 +2517,7 @@ describe('SQL Builder test', () => {
         from
           data
         where
-          node in (
-            'NotepadActivity',
-            'NotepadExportActivity',
-            'NotepadShareActivity',
-            'NotepadPrintActivity'
-          )
+          node = 'NotepadActivity'
         group by
           user_pseudo_id,
           _session_id
@@ -2815,12 +2810,7 @@ describe('SQL Builder test', () => {
         from
           data
         where
-          node in (
-            'NotepadActivity',
-            'NotepadExportActivity',
-            'NotepadShareActivity',
-            'NotepadPrintActivity'
-          )
+          node = 'NotepadActivity'
         group by
           user_pseudo_id,
           group_id
@@ -6185,7 +6175,7 @@ describe('SQL Builder test', () => {
         from
           data
         where
-          event_name in ('add_button_click', 'note_share', 'note_export')
+          event_name = 'add_button_click'
         group by
           user_pseudo_id,
           _session_id
@@ -6660,7 +6650,7 @@ describe('SQL Builder test', () => {
         from
           data
         where
-          event_name in ('add_button_click', 'note_share', 'note_export')
+          event_name = 'add_button_click'
         group by
           user_pseudo_id,
           group_id
@@ -7127,12 +7117,7 @@ describe('SQL Builder test', () => {
         from
           data
         where
-          node in (
-            'NotepadActivity',
-            'NotepadExportActivity',
-            'NotepadShareActivity',
-            'NotepadPrintActivity'
-          )
+          node = 'NotepadActivity'
         group by
           user_pseudo_id,
           group_id
@@ -12188,7 +12173,7 @@ describe('SQL Builder test', () => {
         from
           data
         where
-          event_name in ('add_button_click', 'note_share', 'note_export')
+          event_name = 'add_button_click'
         group by
           user_pseudo_id,
           _session_id
@@ -12453,7 +12438,7 @@ describe('SQL Builder test', () => {
         from
           data
         where
-          event_name in ('add_button_click', 'note_share', 'note_export')
+          event_name = 'add_button_click'
         group by
           user_pseudo_id,
           _session_id
@@ -12876,12 +12861,7 @@ describe('SQL Builder test', () => {
         from
           data
         where
-          node in (
-            'NotepadActivity',
-            'NotepadExportActivity',
-            'NotepadShareActivity',
-            'NotepadPrintActivity'
-          )
+        node = 'NotepadActivity'
         group by
           user_pseudo_id,
           _session_id
@@ -13350,12 +13330,7 @@ describe('SQL Builder test', () => {
         from
           data
         where
-          node in (
-            'NotepadActivity',
-            'NotepadExportActivity',
-            'NotepadShareActivity',
-            'NotepadPrintActivity'
-          )
+        node = 'NotepadActivity'
         group by
           user_pseudo_id,
           group_id

--- a/src/control-plane/backend/lambda/api/test/api/sql-builder.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/sql-builder.test.ts
@@ -1887,12 +1887,14 @@ describe('SQL Builder test', () => {
           *,
           ROW_NUMBER() OVER (
             PARTITION BY
+              user_pseudo_id,
               _session_id
             ORDER BY
               event_timestamp asc
           ) as step_1,
           ROW_NUMBER() OVER (
             PARTITION BY
+              user_pseudo_id,
               _session_id
             ORDER BY
               event_timestamp asc
@@ -1931,6 +1933,7 @@ describe('SQL Builder test', () => {
           _session_id,
           ROW_NUMBER() OVER (
             PARTITION BY
+              user_pseudo_id,
               _session_id
             ORDER BY
               step_1 asc,
@@ -1938,6 +1941,7 @@ describe('SQL Builder test', () => {
           ) as step_1,
           ROW_NUMBER() OVER (
             PARTITION BY
+              user_pseudo_id,
               _session_id
             ORDER BY
               step_1 asc,
@@ -6154,12 +6158,14 @@ describe('SQL Builder test', () => {
           *,
           ROW_NUMBER() OVER (
             PARTITION BY
+              user_pseudo_id,
               _session_id
             ORDER BY
               event_timestamp asc
           ) as step_1,
           ROW_NUMBER() OVER (
             PARTITION BY
+              user_pseudo_id,
               _session_id
             ORDER BY
               event_timestamp asc
@@ -6198,6 +6204,7 @@ describe('SQL Builder test', () => {
           _session_id,
           ROW_NUMBER() OVER (
             PARTITION BY
+              user_pseudo_id,
               _session_id
             ORDER BY
               step_1 asc,
@@ -6205,6 +6212,7 @@ describe('SQL Builder test', () => {
           ) as step_1,
           ROW_NUMBER() OVER (
             PARTITION BY
+              user_pseudo_id,
               _session_id
             ORDER BY
               step_1 asc,
@@ -12152,12 +12160,14 @@ describe('SQL Builder test', () => {
           *,
           ROW_NUMBER() OVER (
             PARTITION BY
+              user_pseudo_id,
               _session_id
             ORDER BY
               event_timestamp asc
           ) as step_1,
           ROW_NUMBER() OVER (
             PARTITION BY
+              user_pseudo_id,
               _session_id
             ORDER BY
               event_timestamp asc
@@ -12196,6 +12206,7 @@ describe('SQL Builder test', () => {
           _session_id,
           ROW_NUMBER() OVER (
             PARTITION BY
+              user_pseudo_id,
               _session_id
             ORDER BY
               step_1 asc,
@@ -12203,6 +12214,7 @@ describe('SQL Builder test', () => {
           ) as step_1,
           ROW_NUMBER() OVER (
             PARTITION BY
+              user_pseudo_id,
               _session_id
             ORDER BY
               step_1 asc,
@@ -12417,12 +12429,14 @@ describe('SQL Builder test', () => {
           *,
           ROW_NUMBER() OVER (
             PARTITION BY
+              user_pseudo_id,
               _session_id
             ORDER BY
               event_timestamp asc
           ) as step_1,
           ROW_NUMBER() OVER (
             PARTITION BY
+              user_pseudo_id,
               _session_id
             ORDER BY
               event_timestamp asc
@@ -12461,6 +12475,7 @@ describe('SQL Builder test', () => {
           _session_id,
           ROW_NUMBER() OVER (
             PARTITION BY
+              user_pseudo_id,
               _session_id
             ORDER BY
               step_1 asc,
@@ -12468,6 +12483,7 @@ describe('SQL Builder test', () => {
           ) as step_1,
           ROW_NUMBER() OVER (
             PARTITION BY
+              user_pseudo_id,
               _session_id
             ORDER BY
               step_1 asc,
@@ -12918,473 +12934,6 @@ describe('SQL Builder test', () => {
       a.step_2 <= 10
   `.trim().replace(/ /g, ''),
     );
-
-  });
-
-  test('buildNodePathAnalysisView - custom join', () => {
-
-    const sql = buildNodePathAnalysisView({
-      schemaName: 'app1',
-      computeMethod: ExploreComputeMethod.USER_CNT,
-      specifyJoinColumn: true,
-      joinColumn: 'user_pseudo_id',
-      conversionIntervalType: ExploreConversionIntervalType.CUSTOMIZE,
-      conversionIntervalInSeconds: 10*60,
-      globalEventCondition: {
-        conditions: [
-          {
-            category: ConditionCategory.OTHER,
-            property: 'platform',
-            operator: '=',
-            value: ['Android'],
-            dataType: MetadataValueType.STRING,
-          },
-          {
-            category: ConditionCategory.GEO,
-            property: 'country',
-            operator: '=',
-            value: ['China'],
-            dataType: MetadataValueType.STRING,
-          },
-          {
-            category: ConditionCategory.USER,
-            property: '_user_first_touch_timestamp',
-            operator: '>',
-            value: [1686532526770],
-            dataType: MetadataValueType.INTEGER,
-          },
-          {
-            category: ConditionCategory.USER,
-            property: '_user_first_touch_timestamp',
-            operator: '>',
-            value: [1686532526780],
-            dataType: MetadataValueType.INTEGER,
-          },
-        ],
-      },
-      eventAndConditions: [
-        {
-          eventName: 'add_button_click',
-          computeMethod: ExploreComputeMethod.EVENT_CNT,
-          sqlCondition: {
-            conditionOperator: 'and',
-            conditions: [
-              {
-                category: ConditionCategory.OTHER,
-                property: 'platform',
-                operator: '=',
-                value: ['Android'],
-                dataType: MetadataValueType.STRING,
-              },
-              {
-                category: ConditionCategory.GEO,
-                property: 'country',
-                operator: '=',
-                value: ['China'],
-                dataType: MetadataValueType.STRING,
-              },
-              {
-                category: ConditionCategory.USER,
-                property: '_user_first_touch_timestamp',
-                operator: '>',
-                value: [1686532526770],
-                dataType: MetadataValueType.INTEGER,
-              },
-              {
-                category: ConditionCategory.USER,
-                property: '_user_first_touch_timestamp',
-                operator: '>',
-                value: [1686532526780],
-                dataType: MetadataValueType.INTEGER,
-              },
-            ],
-          },
-        },
-        {
-          eventName: 'note_share',
-          computeMethod: ExploreComputeMethod.EVENT_CNT,
-        },
-        {
-          eventName: 'note_export',
-          computeMethod: ExploreComputeMethod.USER_CNT,
-          sqlCondition: {
-            conditionOperator: 'and',
-            conditions: [
-              {
-                category: ConditionCategory.OTHER,
-                property: 'platform',
-                operator: '=',
-                value: ['Android'],
-                dataType: MetadataValueType.STRING,
-              },
-              {
-                category: ConditionCategory.GEO,
-                property: 'country',
-                operator: '=',
-                value: ['China'],
-                dataType: MetadataValueType.STRING,
-              },
-              {
-                category: ConditionCategory.USER,
-                property: '_user_first_touch_timestamp',
-                operator: '>',
-                value: [1686532526770],
-                dataType: MetadataValueType.INTEGER,
-              },
-              {
-                category: ConditionCategory.EVENT,
-                property: '_session_duration',
-                operator: '>',
-                value: [200],
-                dataType: MetadataValueType.INTEGER,
-              },
-            ],
-          },
-        },
-      ],
-      pathAnalysis: {
-        platform: MetadataPlatform.ANDROID,
-        sessionType: ExplorePathSessionDef.CUSTOMIZE,
-        lagSeconds: 3600,
-        nodeType: ExplorePathNodeType.SCREEN_NAME,
-        nodes: ['NotepadActivity', 'NotepadExportActivity', 'NotepadShareActivity', 'NotepadPrintActivity'],
-      },
-      timeScopeType: ExploreTimeScopeType.FIXED,
-      timeStart: new Date('2023-10-01'),
-      timeEnd: new Date('2023-10-10'),
-      groupColumn: ExploreGroupColumn.DAY,
-    });
-
-    const expectResult = `
-    with
-      user_base as (
-        select
-          COALESCE(user_id, user_pseudo_id) as user_pseudo_id,
-          user_id,
-          user_first_touch_timestamp,
-          _first_visit_date,
-          _first_referer,
-          _first_traffic_source_type,
-          _first_traffic_medium,
-          _first_traffic_source,
-          _channel,
-          user_properties.key::varchar as user_param_key,
-          user_properties.value.string_value::varchar as user_param_string_value,
-          user_properties.value.int_value::bigint as user_param_int_value,
-          user_properties.value.float_value::double precision as user_param_float_value,
-          user_properties.value.double_value::double precision as user_param_double_value
-        from
-          app1.user_m_view u,
-          u.user_properties as user_properties
-      ),
-      event_base as (
-        select
-          event.event_date,
-          event.event_name,
-          event.event_id,
-          event_bundle_sequence_id::bigint as event_bundle_sequence_id,
-          event_previous_timestamp::bigint as event_previous_timestamp,
-          event_timestamp::bigint as event_timestamp,
-          ingest_timestamp,
-          event_value_in_usd,
-          app_info.app_id::varchar as app_info_app_id,
-          app_info.id::varchar as app_info_package_id,
-          app_info.install_source::varchar as app_info_install_source,
-          app_info.version::varchar as app_info_version,
-          device.vendor_id::varchar as device_id,
-          device.mobile_brand_name::varchar as device_mobile_brand_name,
-          device.mobile_model_name::varchar as device_mobile_model_name,
-          device.manufacturer::varchar as device_manufacturer,
-          device.screen_width::bigint as device_screen_width,
-          device.screen_height::bigint as device_screen_height,
-          device.viewport_height::bigint as device_viewport_height,
-          device.carrier::varchar as device_carrier,
-          device.network_type::varchar as device_network_type,
-          device.operating_system::varchar as device_operating_system,
-          device.operating_system_version::varchar as device_operating_system_version,
-          device.ua_browser::varchar as device_ua_browser,
-          device.ua_browser_version::varchar as device_ua_browser_version,
-          device.ua_os::varchar as device_ua_os,
-          device.ua_os_version::varchar as device_ua_os_version,
-          device.ua_device::varchar as device_ua_device,
-          device.ua_device_category::varchar as device_ua_device_category,
-          device.system_language::varchar as device_system_language,
-          device.time_zone_offset_seconds::bigint as device_time_zone_offset_seconds,
-          device.advertising_id::varchar as device_advertising_id,
-          geo.continent::varchar as geo_continent,
-          geo.country::varchar as geo_country,
-          geo.city::varchar as geo_city,
-          geo.metro::varchar as geo_metro,
-          geo.region::varchar as geo_region,
-          geo.sub_continent::varchar as geo_sub_continent,
-          geo.locale::varchar as geo_locale,
-          platform,
-          project_id,
-          traffic_source.name::varchar as traffic_source_name,
-          traffic_source.medium::varchar as traffic_source_medium,
-          traffic_source.source::varchar as traffic_source_source,
-          COALESCE(event.user_id, event.user_pseudo_id) as user_pseudo_id,
-          event.user_id,
-          TO_CHAR(
-            TIMESTAMP 'epoch' + cast(event_timestamp / 1000 as bigint) * INTERVAL '1 second',
-            'YYYY-MM'
-          ) as month,
-          TO_CHAR(
-            date_trunc(
-              'week',
-              TIMESTAMP 'epoch' + cast(event_timestamp / 1000 as bigint) * INTERVAL '1 second'
-            ),
-            'YYYY-MM-DD'
-          ) || ' - ' || TO_CHAR(
-            date_trunc(
-              'week',
-              (
-                TIMESTAMP 'epoch' + cast(event_timestamp / 1000 as bigint) * INTERVAL '1 second'
-              ) + INTERVAL '6 days'
-            ),
-            'YYYY-MM-DD'
-          ) as week,
-          TO_CHAR(
-            TIMESTAMP 'epoch' + cast(event_timestamp / 1000 as bigint) * INTERVAL '1 second',
-            'YYYY-MM-DD'
-          ) as day,
-          TO_CHAR(
-            TIMESTAMP 'epoch' + cast(event_timestamp / 1000 as bigint) * INTERVAL '1 second',
-            'YYYY-MM-DD HH24'
-          ) || '00:00' as hour
-        from
-          app1.event as event
-        where
-          event.event_date >= date '2023-10-01'
-          and event.event_date <= date '2023-10-10'
-          and event.event_name = '_screen_view'
-          and platform = 'Android'
-      ),
-      base_data as (
-        select
-          _user_first_touch_timestamp,
-          _session_duration,
-          event_base.*
-        from
-          event_base
-          join (
-            select
-              event_base.event_id,
-              max(
-                case
-                  when event_param_key = '_session_duration' then event_param_int_value
-                  else null
-                end
-              ) as _session_duration
-            from
-              event_base
-              join app1.event_parameter as event_param on event_base.event_timestamp = event_param.event_timestamp
-              and event_base.event_id = event_param.event_id
-            group by
-              event_base.event_id
-          ) as event_join_table on event_base.event_id = event_join_table.event_id
-          join (
-            select
-              event_base.user_pseudo_id,
-              max(
-                case
-                  when user_param_key = '_user_first_touch_timestamp' then user_param_int_value
-                  else null
-                end
-              ) as _user_first_touch_timestamp
-            from
-              event_base
-              join user_base on event_base.user_pseudo_id = user_base.user_pseudo_id
-            group by
-              event_base.user_pseudo_id
-          ) user_join_table on event_base.user_pseudo_id = user_join_table.user_pseudo_id
-        where
-          1 = 1
-          and (
-            platform = 'Android'
-            and geo_country = 'China'
-            and _user_first_touch_timestamp > 1686532526770
-            and _user_first_touch_timestamp > 1686532526780
-          )
-      ),
-      mid_table_1 as (
-        select
-          event_name,
-          user_pseudo_id,
-          event_id,
-          event_timestamp
-        from
-          base_data
-      ),
-      mid_table_2 as (
-        select
-          base_data.event_timestamp,
-          base_data.event_id,
-          max(event_param.event_param_string_value) as node
-        from
-          base_data
-          join app1.event_parameter as event_param on base_data.event_timestamp = event_param.event_timestamp
-          and base_data.event_id = event_param.event_id
-        where
-          event_param.event_param_key = '_screen_name'
-        group by
-          1,
-          2
-      ),
-      mid_table as (
-        select
-          mid_table_1.*,
-          mid_table_2.node
-        from
-          mid_table_1
-          join mid_table_2 on mid_table_1.event_id = mid_table_2.event_id
-      ),
-      data_1 as (
-        select
-          user_pseudo_id,
-          event_id,
-          event_timestamp,
-          case
-            when node in (
-              'NotepadActivity',
-              'NotepadExportActivity',
-              'NotepadShareActivity',
-              'NotepadPrintActivity'
-            ) then node
-            else 'other'
-          end as node,
-          ROW_NUMBER() OVER (
-            PARTITION BY
-              user_pseudo_id
-            ORDER BY
-              event_timestamp asc
-          ) as step_1,
-          ROW_NUMBER() OVER (
-            PARTITION BY
-              user_pseudo_id
-            ORDER BY
-              event_timestamp asc
-          ) + 1 as step_2
-        from
-          mid_table
-      ),
-      data_2 as (
-        select
-          a.node,
-          a.user_pseudo_id,
-          a.event_id,
-          a.event_timestamp,
-          case
-            when (
-              b.event_timestamp - a.event_timestamp < 3600000
-              and b.event_timestamp - a.event_timestamp >= 0
-            ) then 0
-            else 1
-          end as group_start
-        from
-          data_1 a
-          left join data_1 b on a.user_pseudo_id = b.user_pseudo_id
-          and a.step_2 = b.step_1
-      ),
-      data_3 AS (
-        select
-          *,
-          SUM(group_start) over (
-            order by
-              user_pseudo_id,
-              event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING
-              AND CURRENT ROW
-          ) AS group_id
-        from
-          data_2
-      ),
-      data as (
-        select
-          node,
-          user_pseudo_id,
-          event_id,
-          event_timestamp,
-          group_id,
-          ROW_NUMBER() OVER (
-            PARTITION BY
-              user_pseudo_id,
-              group_id
-            ORDER BY
-              event_timestamp asc
-          ) as step_1,
-          ROW_NUMBER() OVER (
-            PARTITION BY
-              user_pseudo_id,
-              group_id
-            ORDER BY
-              event_timestamp asc
-          ) + 1 as step_2
-        from
-          data_3
-      ),
-      step_table_1 as (
-        select
-          data.user_pseudo_id user_pseudo_id,
-          group_id,
-          min(step_1) min_step
-        from
-          data
-        where
-        node = 'NotepadActivity'
-        group by
-          user_pseudo_id,
-          group_id
-      ),
-      step_table_2 as (
-        select
-          data.*
-        from
-          data
-          join step_table_1 on data.user_pseudo_id = step_table_1.user_pseudo_id
-          and data.group_id = step_table_1.group_id
-          and data.step_1 >= step_table_1.min_step
-      ),
-      data_final as (
-        select
-          node,
-          user_pseudo_id,
-          event_id,
-          group_id,
-          ROW_NUMBER() OVER (
-            PARTITION BY
-              user_pseudo_id,
-              group_id
-            ORDER BY
-              step_1 asc,
-              step_2
-          ) as step_1,
-          ROW_NUMBER() OVER (
-            PARTITION BY
-              user_pseudo_id,
-              group_id
-            ORDER BY
-              step_1 asc,
-              step_2
-          ) + 1 as step_2
-        from
-          step_table_2
-      )
-    select
-      a.node || '_' || a.step_1 as source,
-      CASE
-        WHEN b.node is not null THEN b.node || '_' || a.step_2
-        ELSE 'lost'
-      END as target,
-      a.user_pseudo_id as x_id
-    from
-      data_final a
-      left join data_final b on a.user_pseudo_id = b.user_pseudo_id
-      and a.group_id = b.group_id
-      and a.step_2 = b.step_1
-    where
-      a.step_2 <= 10
-    `;
-    expect(sql.trim().replace(/ /g, '')).toEqual(expectResult.trim().replace(/ /g, ''));
 
   });
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

add user_pseudo_id as PARTITION BY key
filter sequence that not start from first specified event/node


## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend