### PR TITLE
fix: ETL spark UT failure

### DIFF
--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/BaseSparkTest.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/BaseSparkTest.java
@@ -79,8 +79,8 @@ public class BaseSparkTest {
         System.setProperty(WAREHOUSE_DIR_PROP, "/tmp/warehouse");
         String dbName = "test_db";
         System.setProperty(DATABASE_PROP, dbName);
-        System.setProperty(USER_KEEP_DAYS_PROP, String.valueOf(180));
-        System.setProperty(ITEM_KEEP_DAYS_PROP, String.valueOf(180));
+        System.setProperty(USER_KEEP_DAYS_PROP, String.valueOf(365 * 100));
+        System.setProperty(ITEM_KEEP_DAYS_PROP, String.valueOf(365 * 100));
 
         spark = SparkSession.builder()
                 .appName("Test Spark App")


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

### Root cause:

the test datasets where filtered by below keep days. 
```
  System.setProperty(USER_KEEP_DAYS_PROP, String.valueOf(180));
  System.setProperty(ITEM_KEEP_DAYS_PROP, String.valueOf(180));
```
### Fix:
change these two values to 356 * 100, 100 years.


(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend