### PR TITLE
fix: change event_param_string_value to VARCHAR(4096)

### DIFF
--- a/src/analytics/private/sqls/redshift/event-parameter.sql
+++ b/src/analytics/private/sqls/redshift/event-parameter.sql
@@ -6,6 +6,6 @@ CREATE TABLE IF NOT EXISTS {{schema}}.{{table_event_parameter}}(
     event_param_double_value DOUBLE PRECISION,
     event_param_float_value DOUBLE PRECISION,
     event_param_int_value BIGINT,
-    event_param_string_value VARCHAR(255)    
+    event_param_string_value VARCHAR(4096)    
 ) DISTSTYLE EVEN 
 SORTKEY(event_timestamp, event_name)


### PR DESCRIPTION
----
close https://github.com/awslabs/clickstream-analytics-on-aws/issues/344

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend