### PR TITLE
fix: log group name already exist error

### DIFF
--- a/src/common/logs.ts
+++ b/src/common/logs.ts
@@ -16,6 +16,7 @@ import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import { addCfnNagSuppressRules } from './cfn-nag';
 import { getShortIdOfStack } from './stack';
+import { generateRandomStr } from './utils';
 
 export function createLogGroup(
   scope: Construct,
@@ -25,7 +26,8 @@ export function createLogGroup(
   },
 ) {
   const shortId = getShortIdOfStack(Stack.of(scope));
-  const logGroupName = `${props.prefix ?? 'clickstream-loggroup'}-${shortId}`;
+  const randStr = generateRandomStr(5, 'abcdefghijklmnopqrstuvwxyz0123456789');
+  const logGroupName = `${props.prefix ?? 'clickstream-loggroup'}-${shortId}${randStr}`;
 
   const logGroup = new LogGroup(scope, 'LogGroup', {
     logGroupName,

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -11,6 +11,7 @@
  *  and limitations under the License.
  */
 
+import { Match } from 'aws-cdk-lib/assertions';
 import { findResourcesName, TestEnv } from './test-utils';
 import { removeFolder } from '../common/jest';
 
@@ -984,6 +985,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
                 },
               ],
             },
+            Match.anyValue(),
           ],
         ],
       },
@@ -1604,6 +1606,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
                 },
               ],
             },
+            Match.anyValue(),
           ],
         ],
       },


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend