### PR TITLE
feat: show built-in metadata when no data in DDB

### DIFF
--- a/src/control-plane/backend/config/dictionary.json
+++ b/src/control-plane/backend/config/dictionary.json
@@ -451,7 +451,7 @@
           "name": "_traffic_source_medium",
           "dataType": "string",
           "description": {
-            "en-US": "",
+            "en-US": "Traffic medium. Use this attribute to store the medium that acquired user when events were logged. Example: Email, Paid search, Search engine",
             "zh-CN": "流量媒介，存储事件记录时获取用户的媒介，例如：电子邮件、付费搜索、搜索引擎"
           }
         },
@@ -459,7 +459,7 @@
           "name": "_traffic_source_name",
           "dataType": "string",
           "description": {
-            "en-US": "",
+            "en-US": "Traffic name. Use this attribute to store the marketing campaign that acquired user when events were logged. Example: Summer promotion",
             "zh-CN": "流量名称，存储事件记录时获取用户的营销活动，例如：夏季促销"
           }
         },
@@ -467,7 +467,7 @@
           "name": "_traffic_source_source",
           "dataType": "string",
           "description": {
-            "en-US": "",
+            "en-US": "Traffic source. Name of the network source that acquired the user when the event were reported. Example: Google, Facebook, Bing, Baidu",
             "zh-CN": "流量来源，事件报告时获取的网络来源的名称，例如：Google, Facebook, Bing, Baidu"
           }
         },
@@ -475,7 +475,7 @@
           "name": "_channel",
           "dataType": "string",
           "description": {
-            "en-US": "",
+            "en-US": "Install source, it is the channel for app was downloaded",
             "zh-CN": "安装源，app下载的渠道"
           }
         },

--- a/src/control-plane/backend/config/dictionary.json
+++ b/src/control-plane/backend/config/dictionary.json
@@ -205,6 +205,281 @@
       ],
       "PresetEventParameters": [
         {
+          "name": "_screen_id",
+          "dataType": "string",
+          "description": {
+            "en-US": "The screen ID",
+            "zh-CN": "屏幕ID"
+          },
+          "eventName": "_screen_view"
+        },
+        {
+          "name": "_previous_screen_name",
+          "dataType": "string",
+          "description": {
+            "en-US": "The previous screen name",
+            "zh-CN": "上一个屏幕名称"
+          },
+          "eventName": "_screen_view"
+        },
+        {
+          "name": "_previous_screen_id",
+          "dataType": "string",
+          "description": {
+            "en-US": "The previous screen ID",
+            "zh-CN": "上一个屏幕ID"
+          },
+          "eventName": "_screen_view"
+        },
+        {
+          "name": "_previous_screen_unique_id",
+          "dataType": "string",
+          "description": {
+            "en-US": "The previous screen unique ID",
+            "zh-CN": "上一个屏幕唯一ID"
+          },
+          "eventName": "_screen_view"
+        },
+        {
+          "name": "_page_referrer",
+          "dataType": "string",
+          "description": {
+            "en-US": "Last page url",
+            "zh-CN": "前一个页面URL"
+          },
+          "eventName": "_page_view"
+        },
+        {
+          "name": "_page_referrer_title",
+          "dataType": "string",
+          "description": {
+            "en-US": "Last page title",
+            "zh-CN": "前一个页面标题"
+          },
+          "eventName": "_page_view"
+        },
+        {
+          "name": "_entrances",
+          "dataType": "string",
+          "description": {
+            "en-US": "The first screen view event in a session is 1, others is 0",
+            "zh-CN": "会话中的第一个屏幕浏览事件该值为 1，其他则为 0"
+          },
+          "eventName": "_page_view"
+        },
+        {
+          "name": "_entrances",
+          "dataType": "string",
+          "description": {
+            "en-US": "The first screen view event in a session is 1, others is 0",
+            "zh-CN": "会话中的第一个屏幕浏览事件该值为 1，其他则为 0"
+          },
+          "eventName": "_screen_view"
+        },
+        {
+          "name": "_previous_timestamp",
+          "dataType": "int",
+          "description": {
+            "en-US": "The timestamp of the previous _screen_view event",
+            "zh-CN": "上一个 screen_view 事件的时间戳"
+          },
+          "eventName": "_screen_view"
+        },
+        {
+          "name": "_previous_timestamp",
+          "dataType": "int",
+          "description": {
+            "en-US": "The timestamp of the previous _screen_view event",
+            "zh-CN": "上一个 screen_view 事件的时间戳"
+          },
+          "eventName": "_page_view"
+        },
+        {
+          "name": "_engagement_time_msec",
+          "dataType": "int",
+          "description": {
+            "en-US": "The previous page last engagement milliseconds",
+            "zh-CN": "上个屏幕最后一次用户参与事件时长的毫秒数"
+          },
+          "eventName": "_screen_view"
+        },
+        {
+          "name": "_engagement_time_msec",
+          "dataType": "int",
+          "description": {
+            "en-US": "The previous page last engagement milliseconds",
+            "zh-CN": "上个屏幕最后一次用户参与事件时长的毫秒数"
+          },
+          "eventName": "_page_view"
+        },
+        {
+          "name": "_engagement_time_msec",
+          "dataType": "int",
+          "description": {
+            "en-US": "The previous page last engagement milliseconds",
+            "zh-CN": "上个屏幕最后一次用户参与事件时长的毫秒数"
+          },
+          "eventName": "_user_engagement"
+        },
+        {
+          "name": "_is_first_time",
+          "dataType": "string",
+          "description": {
+            "en-US": "When it is the first _app_start event after the application starts, the value is true",
+            "zh-CN": "当应用程序启动后第一个 _app_start 事件时，值为 true"
+          },
+          "eventName": "_app_start"
+        },
+        {
+          "name": "_exception_message",
+          "dataType": "string",
+          "description": {
+            "en-US": "The message of exception",
+            "zh-CN": "异常信息"
+          },
+          "eventName": "_app_exception"
+        },
+        {
+          "name": "_exception_stack",
+          "dataType": "string",
+          "description": {
+            "en-US": "The stack details of exception",
+            "zh-CN": "异常堆栈信息"
+          },
+          "eventName": "_app_exception"
+        },
+        {
+          "name": "_previous_app_version",
+          "dataType": "string",
+          "description": {
+            "en-US": "The version of previous app",
+            "zh-CN": "上一个应用版本"
+          },
+          "eventName": "_app_update"
+        },
+        {
+          "name": "_previous_os_version",
+          "dataType": "string",
+          "description": {
+            "en-US": "The version of previous operating system",
+            "zh-CN": "上一个操作系统版本"
+          },
+          "eventName": "_os_update"
+        },
+        {
+          "name": "_error_code",
+          "dataType": "string",
+          "description": {
+            "en-US": "Error code",
+            "zh-CN": "错误代码"
+          },
+          "eventName": "_clickstream_error"
+        },
+        {
+          "name": "_error_message",
+          "dataType": "string",
+          "description": {
+            "en-US": "Error message",
+            "zh-CN": "错误信息"
+          },
+          "eventName": "_clickstream_error"
+        },
+        {
+          "name": "_search_key",
+          "dataType": "string",
+          "description": {
+            "en-US": "The keyword name",
+            "zh-CN": "搜索参数名称"
+          },
+          "eventName": "_search"
+        },
+        {
+          "name": "_search_term",
+          "dataType": "string",
+          "description": {
+            "en-US": "The search content",
+            "zh-CN": "搜索内容"
+          },
+          "eventName": "_search"
+        },
+        {
+          "name": "_link_classes",
+          "dataType": "string",
+          "description": {
+            "en-US": "The content of class in tag <a>",
+            "zh-CN": "标签 <a>中class里的内容"
+          },
+          "eventName": "_click"
+        },
+        {
+          "name": "_link_domain",
+          "dataType": "string",
+          "description": {
+            "en-US": "The domain of href in tag <a>",
+            "zh-CN": "标签 <a>中href里的域名"
+          },
+          "eventName": "_click"
+        },
+        {
+          "name": "_link_id",
+          "dataType": "string",
+          "description": {
+            "en-US": "The content of id in tag <a>",
+            "zh-CN": "标签 <a>中id里的内容"
+          },
+          "eventName": "_click"
+        },
+        {
+          "name": "_link_url",
+          "dataType": "string",
+          "description": {
+            "en-US": "The content of href in tag <a>",
+            "zh-CN": "标签 <a>中href里的内容"
+          },
+          "eventName": "_click"
+        },
+        {
+          "name": "_outbound",
+          "dataType": "string",
+          "description": {
+            "en-US": "If the domain is not in configured domain list, the attribute value is true",
+            "zh-CN": "如果该域不在配置的域名列表中，则属性值为true"
+          },
+          "eventName": "_click"
+        },
+        {
+          "name": "_traffic_source_medium",
+          "dataType": "string",
+          "description": {
+            "en-US": "",
+            "zh-CN": "流量媒介，存储事件记录时获取用户的媒介，例如：电子邮件、付费搜索、搜索引擎"
+          }
+        },
+        {
+          "name": "_traffic_source_name",
+          "dataType": "string",
+          "description": {
+            "en-US": "",
+            "zh-CN": "流量名称，存储事件记录时获取用户的营销活动，例如：夏季促销"
+          }
+        },
+        {
+          "name": "_traffic_source_source",
+          "dataType": "string",
+          "description": {
+            "en-US": "",
+            "zh-CN": "流量来源，事件报告时获取的网络来源的名称，例如：Google, Facebook, Bing, Baidu"
+          }
+        },
+        {
+          "name": "_channel",
+          "dataType": "string",
+          "description": {
+            "en-US": "",
+            "zh-CN": "安装源，app下载的渠道"
+          }
+        },
+        {
           "name": "_session_id",
           "dataType": "string",
           "description": {
@@ -237,22 +512,6 @@
           }
         },
         {
-          "name": "_page_title",
-          "dataType": "string",
-          "description": {
-            "en-US": "The page title",
-            "zh-CN": "页面标题"
-          }
-        },
-        {
-          "name": "_page_url",
-          "dataType": "string",
-          "description": {
-            "en-US": "The page url",
-            "zh-CN": "页面URL"
-          }
-        },
-        {
           "name": "_latest_referrer",
           "dataType": "string",
           "description": {
@@ -277,14 +536,6 @@
           }
         },
         {
-          "name": "_screen_id",
-          "dataType": "string",
-          "description": {
-            "en-US": "The screen ID",
-            "zh-CN": "屏幕ID"
-          }
-        },
-        {
           "name": "_screen_unique_id",
           "dataType": "string",
           "description": {
@@ -293,191 +544,23 @@
           }
         },
         {
-          "name": "_previous_screen_name",
+          "name": "_page_title",
           "dataType": "string",
           "description": {
-            "en-US": "The previous screen name",
-            "zh-CN": "上一个屏幕名称"
+            "en-US": "The page title",
+            "zh-CN": "页面标题"
           }
         },
         {
-          "name": "_previous_screen_id",
+          "name": "_page_url",
           "dataType": "string",
           "description": {
-            "en-US": "The previous screen ID",
-            "zh-CN": "上一个屏幕ID"
-          }
-        },
-        {
-          "name": "_previous_screen_unique_id",
-          "dataType": "string",
-          "description": {
-            "en-US": "The previous screen unique ID",
-            "zh-CN": "上一个屏幕唯一ID"
-          }
-        },
-        {
-          "name": "_entrances",
-          "dataType": "string",
-          "description": {
-            "en-US": "The first screen view event in a session is 1, others is 0",
-            "zh-CN": "会话中的第一个屏幕浏览事件该值为 1，其他则为 0"
-          }
-        },
-        {
-          "name": "_previous_timestamp",
-          "dataType": "int",
-          "description": {
-            "en-US": "The timestamp of the previous _screen_view event",
-            "zh-CN": "上一个 screen_view 事件的时间戳"
-          }
-        },
-        {
-          "name": "_engagement_time_msec",
-          "dataType": "string",
-          "description": {
-            "en-US": "The previous page last engagement milliseconds",
-            "zh-CN": "上个屏幕最后一次用户参与事件时长的毫秒数"
-          }
-        },
-        {
-          "name": "_is_first_time",
-          "dataType": "string",
-          "description": {
-            "en-US": "When it is the first _app_start event after the application starts, the value is true",
-            "zh-CN": "当应用程序启动后第一个 _app_start 事件时，值为 true"
-          }
-        },
-        {
-          "name": "_exception_message",
-          "dataType": "string",
-          "description": {
-            "en-US": "The message of exception",
-            "zh-CN": "异常信息"
-          }
-        },
-        {
-          "name": "_exception_stack",
-          "dataType": "string",
-          "description": {
-            "en-US": "The stack details of exception",
-            "zh-CN": "异常堆栈信息"
-          }
-        },
-        {
-          "name": "_previous_app_version",
-          "dataType": "string",
-          "description": {
-            "en-US": "The version of previous app",
-            "zh-CN": "上一个应用版本"
-          }
-        },
-        {
-          "name": "_previous_os_version",
-          "dataType": "string",
-          "description": {
-            "en-US": "The version of previous operating system",
-            "zh-CN": "上一个操作系统版本"
-          }
-        },
-        {
-          "name": "_error_code",
-          "dataType": "string",
-          "description": {
-            "en-US": "Error code",
-            "zh-CN": "错误代码"
-          }
-        },
-        {
-          "name": "_error_message",
-          "dataType": "string",
-          "description": {
-            "en-US": "Error message",
-            "zh-CN": "错误信息"
-          }
-        },
-        {
-          "name": "_page_referrer",
-          "dataType": "string",
-          "description": {
-            "en-US": "Last page url",
-            "zh-CN": "前一个页面URL"
-          }
-        },
-        {
-          "name": "_page_referrer_title",
-          "dataType": "string",
-          "description": {
-            "en-US": "Last page title",
-            "zh-CN": "前一个页面标题"
-          }
-        },
-        {
-          "name": "_search_key",
-          "dataType": "string",
-          "description": {
-            "en-US": "The keyword name",
-            "zh-CN": "搜索参数名称"
-          }
-        },
-        {
-          "name": "_search_term",
-          "dataType": "string",
-          "description": {
-            "en-US": "The search content",
-            "zh-CN": "搜索内容"
-          }
-        },
-        {
-          "name": "_link_classes",
-          "dataType": "string",
-          "description": {
-            "en-US": "The content of class in tag <a>",
-            "zh-CN": "标签 <a>中class里的内容"
-          }
-        },
-        {
-          "name": "_link_domain",
-          "dataType": "string",
-          "description": {
-            "en-US": "The domain of href in tag <a>",
-            "zh-CN": "标签 <a>中href里的域名"
-          }
-        },
-        {
-          "name": "_link_id",
-          "dataType": "string",
-          "description": {
-            "en-US": "The content of id in tag <a>",
-            "zh-CN": "标签 <a>中id里的内容"
-          }
-        },
-        {
-          "name": "_link_url",
-          "dataType": "string",
-          "description": {
-            "en-US": "The content of href in tag <a>",
-            "zh-CN": "标签 <a>中href里的内容"
-          }
-        },
-        {
-          "name": "_outbound",
-          "dataType": "string",
-          "description": {
-            "en-US": "If the domain is not in configured domain list, the attribute value is true",
-            "zh-CN": "如果该域不在配置的域名列表中，则属性值为true"
+            "en-US": "The page url",
+            "zh-CN": "页面URL"
           }
         }
       ],
       "PublicEventParameters": [
-        {
-          "name": "hashCode",
-          "dataType": "string",
-          "description": {
-            "en-US": "The hash code of the event",
-            "zh-CN": "事件哈希码"
-          }
-        },
         {
           "name": "app_id",
           "dataType": "string",
@@ -700,32 +783,40 @@
           "name": "_user_id",
           "dataType": "string",
           "description": {
-            "en-US": "The user ID",
+            "en-US": "Reserved for user id that is assigned by app",
             "zh-CN": "用户ID"
           }
         },
         {
-          "name": "_user_i_user_ltv_revenued",
+          "name": "_user_name",
           "dataType": "string",
           "description": {
-            "en-US": "The user lifetime value",
-            "zh-CN": "用户生命周期价值"
+            "en-US": "User name",
+            "zh-CN": "用户名"
+          }
+        },
+        {
+          "name": "_user_ltv_revenue",
+          "dataType": "string",
+          "description": {
+            "en-US": "Reserved for user lifetime value",
+            "zh-CN": "用户终身价值"
           }
         },
         {
           "name": "_user_ltv_currency",
           "dataType": "string",
           "description": {
-            "en-US": "The currency of the user lifetime value",
-            "zh-CN": "当前用户生命周期价值"
+            "en-US": "Reserved for user lifetime value currency",
+            "zh-CN": "用户终身价值货币"
           }
         },
         {
           "name": "_user_first_touch_timestamp",
-          "dataType": "string",
+          "dataType": "int",
           "description": {
-            "en-US": "The timestamp of the first touch",
-            "zh-CN": "首次触摸时间戳"
+            "en-US": "Added to the user object for all events. The time (in milliseconds) when the user first opened the app",
+            "zh-CN": "用户首次打开应用程序或访问站点的时间（以毫秒为单位），在 user 对象的每个事件中都包含此属性"
           }
         }
       ]

--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -691,7 +691,6 @@ function getParameterByNameAndType(metadata: IMetadataRaw[], parameterName: stri
 IMetadataEventParameter | undefined {
   const filteredMetadata = metadata.filter((r: IMetadataRaw) => r.name === parameterName && r.valueType === valueType);
   if (filteredMetadata.length === 0) {
-    // Add built-in metadata
     return;
   }
   const groupEvents: IMetadataEvent[] = [];

--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -599,7 +599,7 @@ function groupAssociatedEventParametersByName(events: IMetadataEvent[], paramete
 function getCurMonthStr() {
   const year = new Date().getFullYear();
   const month = new Date().getMonth() + 1;
-  return `#${year}${month < 10 ? '0' + month : month}`;
+  return `#${year}${month.toString().padStart(2, '0')}`;
 }
 
 function getDataFromLastDay(metadata: IMetadataRaw) {

--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -596,14 +596,18 @@ function groupAssociatedEventParametersByName(events: IMetadataEvent[], paramete
   return events;
 };
 
-function getDataFromLastDay(metadata: IMetadataRaw) {
+function getCurMonthStr() {
   const year = new Date().getFullYear();
   const month = new Date().getMonth() + 1;
-  const key = `#${year}${month < 10 ? '0' + month : month}`;
+  return `#${year}${month < 10 ? '0' + month : month}`;
+}
+
+function getDataFromLastDay(metadata: IMetadataRaw) {
+  const curMonth = getCurMonthStr();
   const lastDay = `day${new Date().getDate() - 1}`;
   let hasData = false;
   let dataVolumeLastDay = 0;
-  if (metadata.month === key) {
+  if (metadata.month === curMonth) {
     const lastDayData = (metadata as any)[lastDay];
     if (lastDayData) {
       dataVolumeLastDay = lastDayData.count ?? 0;
@@ -687,6 +691,7 @@ function getParameterByNameAndType(metadata: IMetadataRaw[], parameterName: stri
 IMetadataEventParameter | undefined {
   const filteredMetadata = metadata.filter((r: IMetadataRaw) => r.name === parameterName && r.valueType === valueType);
   if (filteredMetadata.length === 0) {
+    // Add built-in metadata
     return;
   }
   const groupEvents: IMetadataEvent[] = [];
@@ -845,4 +850,5 @@ export {
   getAttributeByNameAndType,
   getDataFromLastDay,
   pathNodesToAttribute,
+  getCurMonthStr,
 };

--- a/src/control-plane/backend/lambda/api/model/metadata.ts
+++ b/src/control-plane/backend/lambda/api/model/metadata.ts
@@ -125,17 +125,18 @@ export interface IMetadataBuiltInList {
   }>;
   readonly PresetEventParameters: Array<{
     name: string;
-    dataType: string;
+    eventName?: string;
+    dataType: MetadataValueType;
     description: IMetadataDescription;
   }>;
   readonly PublicEventParameters: Array<{
     name: string;
-    dataType: string;
+    dataType: MetadataValueType;
     description: IMetadataDescription;
   }>;
   readonly PresetUserAttributes: Array<{
     name: string;
-    dataType: string;
+    dataType: MetadataValueType;
     description: IMetadataDescription;
   }>;
 }

--- a/src/control-plane/backend/lambda/api/service/display.ts
+++ b/src/control-plane/backend/lambda/api/service/display.ts
@@ -11,9 +11,8 @@
  *  and limitations under the License.
  */
 
-import { ConditionCategory, MetadataParameterType, MetadataSource, MetadataValueType } from '../common/explore-types';
+import { MetadataParameterType, MetadataSource } from '../common/explore-types';
 import { logger } from '../common/powertools';
-import { getCurMonthStr } from '../common/utils';
 import { IMetadataAttributeValue, IMetadataDisplay, IMetadataEvent, IMetadataEventParameter, IMetadataUserAttribute, IMetadataBuiltInList } from '../model/metadata';
 import { ClickStreamStore } from '../store/click-stream-store';
 import { DynamoDbMetadataStore } from '../store/dynamodb/dynamodb-metadata-store';
@@ -150,110 +149,6 @@ export class CMetadataDisplay {
       logger.error('Patch display error', { error });
     }
     return metadataArray;
-  }
-
-  public async patchPresetEvents(projectId: string, appId: string, eventArray: IMetadataEvent[], associated?: boolean) {
-    try {
-      if (eventArray.length === 0) {
-        return this.getPresetEvents(projectId, appId, associated);
-      }
-    } catch (error) {
-      logger.error('Patch Preset Events error', { error });
-    }
-    return eventArray;
-  }
-
-  private getPresetEvents(projectId: string, appId: string, associated?: boolean) {
-    const presetEvents: IMetadataEvent[] = [];
-    if (this.builtList) {
-      for (let e of this.builtList.PresetEvents) {
-        const presetEvent: IMetadataEvent = {
-          id: `${projectId}#${appId}#${e.name}`,
-          month: getCurMonthStr(),
-          prefix: `EVENT#${projectId}#${appId}`,
-          projectId: projectId,
-          appId: appId,
-          name: e.name,
-          dataVolumeLastDay: 0,
-          hasData: true,
-          platform: [],
-          displayName: e.name,
-          description: e.description,
-          metadataSource: MetadataSource.PRESET,
-          associatedParameters: [],
-        };
-        if (associated) {
-          const associatedParameters = this.getPresetEventParameters(projectId, appId, e.name).concat(
-            this.getPublicEventParameters(projectId, appId, e.name),
-          );
-          presetEvent.associatedParameters = associatedParameters;
-        }
-        presetEvents.push(presetEvent);
-      }
-    }
-    return presetEvents;
-  }
-
-  private getPresetEventParameters(projectId: string, appId: string, eventName: string, associated?: boolean) {
-    const presetEventParameters: IMetadataEventParameter[] = [];
-    if (this.builtList) {
-      for (let p of this.builtList.PresetEventParameters) {
-        const parameter: IMetadataEventParameter = {
-          id: `${projectId}#${appId}#${eventName}#${p.dataType}`,
-          month: getCurMonthStr(),
-          prefix: `EVENT_PARAMETER#${projectId}#${appId}`,
-          projectId: projectId,
-          appId: appId,
-          name: p.name,
-          eventName: eventName,
-          valueType: p.dataType as MetadataValueType,
-          category: ConditionCategory.EVENT,
-          hasData: true,
-          platform: [],
-          displayName: p.name,
-          description: p.description,
-          metadataSource: MetadataSource.PRESET,
-          parameterType: MetadataParameterType.PRIVATE,
-          values: [],
-        };
-        if (associated) {
-          parameter.associatedEvents = this.getPresetEvents(projectId, appId);
-        }
-        presetEventParameters.push(parameter);
-      }
-    }
-    return presetEventParameters;
-  }
-
-  private getPublicEventParameters(projectId: string, appId: string, eventName: string, associated?: boolean) {
-    const publicEventParameters: IMetadataEventParameter[] = [];
-    if (this.builtList) {
-      for (let p of this.builtList.PublicEventParameters) {
-        const parameter: IMetadataEventParameter = {
-          id: `${projectId}#${appId}#${eventName}#${p.dataType}`,
-          month: getCurMonthStr(),
-          prefix: `EVENT_PARAMETER#${projectId}#${appId}`,
-          projectId: projectId,
-          appId: appId,
-          name: p.name,
-          eventName: eventName,
-          valueType: p.dataType as MetadataValueType,
-          category: ConditionCategory.EVENT,
-          hasData: true,
-          platform: [],
-          displayName: p.name,
-          description: p.description,
-          metadataSource: MetadataSource.PRESET,
-          parameterType: MetadataParameterType.PUBLIC,
-          values: [],
-        };
-        if (associated) {
-          parameter.associatedEvents = this.getPresetEvents(projectId, appId);
-        }
-        publicEventParameters.push(parameter);
-      }
-    }
-    return publicEventParameters;
   }
 
   private patchAssociated(associated: IMetadataEvent[] | IMetadataEventParameter[] | undefined) {

--- a/src/control-plane/backend/lambda/api/service/display.ts
+++ b/src/control-plane/backend/lambda/api/service/display.ts
@@ -11,8 +11,9 @@
  *  and limitations under the License.
  */
 
-import { MetadataParameterType, MetadataSource } from '../common/explore-types';
+import { ConditionCategory, MetadataParameterType, MetadataSource, MetadataValueType } from '../common/explore-types';
 import { logger } from '../common/powertools';
+import { getCurMonthStr } from '../common/utils';
 import { IMetadataAttributeValue, IMetadataDisplay, IMetadataEvent, IMetadataEventParameter, IMetadataUserAttribute, IMetadataBuiltInList } from '../model/metadata';
 import { ClickStreamStore } from '../store/click-stream-store';
 import { DynamoDbMetadataStore } from '../store/dynamodb/dynamodb-metadata-store';
@@ -149,6 +150,110 @@ export class CMetadataDisplay {
       logger.error('Patch display error', { error });
     }
     return metadataArray;
+  }
+
+  public async patchPresetEvents(projectId: string, appId: string, eventArray: IMetadataEvent[], associated?: boolean) {
+    try {
+      if (eventArray.length === 0) {
+        return this.getPresetEvents(projectId, appId, associated);
+      }
+    } catch (error) {
+      logger.error('Patch Preset Events error', { error });
+    }
+    return eventArray;
+  }
+
+  private getPresetEvents(projectId: string, appId: string, associated?: boolean) {
+    const presetEvents: IMetadataEvent[] = [];
+    if (this.builtList) {
+      for (let e of this.builtList.PresetEvents) {
+        const presetEvent: IMetadataEvent = {
+          id: `${projectId}#${appId}#${e.name}`,
+          month: getCurMonthStr(),
+          prefix: `EVENT#${projectId}#${appId}`,
+          projectId: projectId,
+          appId: appId,
+          name: e.name,
+          dataVolumeLastDay: 0,
+          hasData: true,
+          platform: [],
+          displayName: e.name,
+          description: e.description,
+          metadataSource: MetadataSource.PRESET,
+          associatedParameters: [],
+        };
+        if (associated) {
+          const associatedParameters = this.getPresetEventParameters(projectId, appId, e.name).concat(
+            this.getPublicEventParameters(projectId, appId, e.name),
+          );
+          presetEvent.associatedParameters = associatedParameters;
+        }
+        presetEvents.push(presetEvent);
+      }
+    }
+    return presetEvents;
+  }
+
+  private getPresetEventParameters(projectId: string, appId: string, eventName: string, associated?: boolean) {
+    const presetEventParameters: IMetadataEventParameter[] = [];
+    if (this.builtList) {
+      for (let p of this.builtList.PresetEventParameters) {
+        const parameter: IMetadataEventParameter = {
+          id: `${projectId}#${appId}#${eventName}#${p.dataType}`,
+          month: getCurMonthStr(),
+          prefix: `EVENT_PARAMETER#${projectId}#${appId}`,
+          projectId: projectId,
+          appId: appId,
+          name: p.name,
+          eventName: eventName,
+          valueType: p.dataType as MetadataValueType,
+          category: ConditionCategory.EVENT,
+          hasData: true,
+          platform: [],
+          displayName: p.name,
+          description: p.description,
+          metadataSource: MetadataSource.PRESET,
+          parameterType: MetadataParameterType.PRIVATE,
+          values: [],
+        };
+        if (associated) {
+          parameter.associatedEvents = this.getPresetEvents(projectId, appId);
+        }
+        presetEventParameters.push(parameter);
+      }
+    }
+    return presetEventParameters;
+  }
+
+  private getPublicEventParameters(projectId: string, appId: string, eventName: string, associated?: boolean) {
+    const publicEventParameters: IMetadataEventParameter[] = [];
+    if (this.builtList) {
+      for (let p of this.builtList.PublicEventParameters) {
+        const parameter: IMetadataEventParameter = {
+          id: `${projectId}#${appId}#${eventName}#${p.dataType}`,
+          month: getCurMonthStr(),
+          prefix: `EVENT_PARAMETER#${projectId}#${appId}`,
+          projectId: projectId,
+          appId: appId,
+          name: p.name,
+          eventName: eventName,
+          valueType: p.dataType as MetadataValueType,
+          category: ConditionCategory.EVENT,
+          hasData: true,
+          platform: [],
+          displayName: p.name,
+          description: p.description,
+          metadataSource: MetadataSource.PRESET,
+          parameterType: MetadataParameterType.PUBLIC,
+          values: [],
+        };
+        if (associated) {
+          parameter.associatedEvents = this.getPresetEvents(projectId, appId);
+        }
+        publicEventParameters.push(parameter);
+      }
+    }
+    return publicEventParameters;
   }
 
   private patchAssociated(associated: IMetadataEvent[] | IMetadataEventParameter[] | undefined) {

--- a/src/control-plane/backend/lambda/api/service/metadata.ts
+++ b/src/control-plane/backend/lambda/api/service/metadata.ts
@@ -70,7 +70,6 @@ export class MetadataEventServ {
         events = groupAssociatedEventParametersByName(events, eventParameters);
       }
       events = await metadataDisplay.patch(projectId, appId, events) as IMetadataEvent[];
-      events = await metadataDisplay.patchPresetEvents(projectId, appId, events, associated);
       return res.json(new ApiSuccess({
         totalCount: events.length,
         items: events,

--- a/src/control-plane/backend/lambda/api/service/metadata.ts
+++ b/src/control-plane/backend/lambda/api/service/metadata.ts
@@ -64,11 +64,13 @@ export class MetadataEventServ {
     try {
       const { projectId, appId, attribute } = req.query;
       let events = await metadataStore.listEvents(projectId, appId);
-      if (attribute && attribute === 'true') {
-        let eventParameters = await metadataStore.listEventParameters(projectId, appId);
+      const associated = attribute && attribute === 'true';
+      if (associated) {
+        const eventParameters = await metadataStore.listEventParameters(projectId, appId);
         events = groupAssociatedEventParametersByName(events, eventParameters);
       }
       events = await metadataDisplay.patch(projectId, appId, events) as IMetadataEvent[];
+      events = await metadataDisplay.patchPresetEvents(projectId, appId, events, associated);
       return res.json(new ApiSuccess({
         totalCount: events.length,
         items: events,

--- a/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-metadata-store.ts
+++ b/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-metadata-store.ts
@@ -44,10 +44,10 @@ export class DynamoDbMetadataStore implements MetadataStore {
       ScanIndexForward: false,
     };
     let records = await query(input) as IMetadataRaw[];
-    if (!records || records.length === 0) {
+    if (records.length === 0) {
       records = await this.queryEventFromBuiltInList(projectId, appId, eventName);
     }
-    if (!records || records.length === 0) {
+    if (records.length === 0) {
       return;
     }
     const lastDayData = getDataFromLastDay(records[0]);
@@ -101,7 +101,7 @@ export class DynamoDbMetadataStore implements MetadataStore {
       ScanIndexForward: false,
     };
     let records = await query(input) as IMetadataRaw[];
-    if (!records || records.length === 0) {
+    if (records.length === 0) {
       records = await this.queryEventParameterFromBuiltInList(projectId, appId, parameterName, valueType);
     }
     return getParameterByNameAndType(records, parameterName, valueType);

--- a/src/control-plane/backend/lambda/api/test/api/metadata.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/metadata.test.ts
@@ -23,7 +23,7 @@ import { mockClient } from 'aws-sdk-client-mock';
 import request from 'supertest';
 import { metadataEventExistedMock, MOCK_APP_ID, MOCK_EVENT_PARAMETER_NAME, MOCK_EVENT_NAME, MOCK_PROJECT_ID, MOCK_TOKEN, MOCK_USER_ATTRIBUTE_NAME, tokenMock } from './ddb-mock';
 import { analyticsMetadataTable, dictionaryTableName, prefixMonthGSIName } from '../../common/constants';
-import { MetadataParameterType, MetadataPlatform, MetadataSource, MetadataValueType } from '../../common/explore-types';
+import { ConditionCategory, MetadataParameterType, MetadataPlatform, MetadataSource, MetadataValueType } from '../../common/explore-types';
 import { app, server } from '../../index';
 import 'aws-sdk-client-mock-jest';
 
@@ -276,6 +276,7 @@ function displayDataMock(m: any) {
         PresetEventParameters: [
           {
             name: MOCK_EVENT_PARAMETER_NAME,
+            eventName: MOCK_EVENT_NAME,
             dataType: MetadataValueType.STRING,
             description: {
               'en-US': 'mock preset event parameter description in built-in',
@@ -432,12 +433,86 @@ describe('Metadata Event test', () => {
       Items: [],
     });
     const res = await request(app)
-      .get(`/api/metadata/event/${MOCK_EVENT_NAME}?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+      .get(`/api/metadata/event/${MOCK_EVENT_NAME}NoExist?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(404);
     expect(res.body).toEqual({
       success: false,
       message: 'Event not found',
+    });
+  });
+  it('Get preset event when no data in DDB', async () => {
+    ddbMock.on(QueryCommand).resolves({
+      Items: [],
+    });
+    const res = await request(app)
+      .get(`/api/metadata/event/${MOCK_EVENT_NAME}?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      message: '',
+      data: {
+        id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}`,
+        prefix: `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+        month: '#202303',
+        associatedParameters: [
+          {
+            id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}#${MetadataValueType.STRING}`,
+            month: '#202303',
+            prefix: `EVENT_PARAMETER#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+            projectId: MOCK_PROJECT_ID,
+            appId: MOCK_APP_ID,
+            category: ConditionCategory.EVENT,
+            metadataSource: MetadataSource.PRESET,
+            name: MOCK_EVENT_PARAMETER_NAME,
+            eventName: MOCK_EVENT_NAME,
+            displayName: MOCK_EVENT_PARAMETER_NAME,
+            description: {
+              'en-US': 'mock preset event parameter description in built-in',
+              'zh-CN': '内置事件参数的描述',
+            },
+            parameterType: 'Public',
+            hasData: false,
+            platform: [],
+            valueType: MetadataValueType.STRING,
+            values: [],
+          },
+          {
+            id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}11#${MetadataValueType.INTEGER}`,
+            month: '#202303',
+            prefix: `EVENT_PARAMETER#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+            projectId: MOCK_PROJECT_ID,
+            appId: MOCK_APP_ID,
+            category: ConditionCategory.EVENT,
+            metadataSource: MetadataSource.CUSTOM,
+            name: `${MOCK_EVENT_PARAMETER_NAME}11`,
+            eventName: MOCK_EVENT_NAME,
+            displayName: `${MOCK_EVENT_PARAMETER_NAME}11`,
+            description: {
+              'en-US': '',
+              'zh-CN': '',
+            },
+            parameterType: 'Public',
+            hasData: false,
+            platform: [],
+            valueType: MetadataValueType.INTEGER,
+            values: [],
+          },
+        ],
+        hasData: false,
+        platform: [],
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        name: MOCK_EVENT_NAME,
+        metadataSource: MetadataSource.PRESET,
+        dataVolumeLastDay: 0,
+        displayName: `display name of event ${MOCK_EVENT_NAME}`,
+        description: {
+          'en-US': 'mock event description in built-in',
+          'zh-CN': '内置事件的描述',
+        },
+      },
     });
   });
   it('Get metadata event list', async () => {
@@ -832,6 +907,56 @@ describe('Metadata Event test', () => {
       },
     });
   });
+  it('Get metadata event list when no data in DDB', async () => {
+    jest
+      .useFakeTimers()
+      .setSystemTime(new Date('2023-02-02'));
+    ddbMock.on(QueryCommand, {
+      TableName: analyticsMetadataTable,
+      IndexName: prefixMonthGSIName,
+      KeyConditionExpression: '#prefix= :prefix',
+      ExpressionAttributeNames: {
+        '#prefix': 'prefix',
+      },
+      ExpressionAttributeValues: {
+        ':prefix': `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+      },
+      ScanIndexForward: false,
+    }).resolves({
+      Items: [],
+    });
+    const res = await request(app)
+      .get(`/api/metadata/events?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      message: '',
+      data: {
+        items: [
+          {
+            id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}`,
+            month: '#202302',
+            prefix: `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+            projectId: MOCK_PROJECT_ID,
+            appId: MOCK_APP_ID,
+            name: `${MOCK_EVENT_NAME}`,
+            displayName: `display name of event ${MOCK_EVENT_NAME}`,
+            description: {
+              'en-US': 'mock event description in built-in',
+              'zh-CN': '内置事件的描述',
+            },
+            metadataSource: MetadataSource.PRESET,
+            hasData: false,
+            dataVolumeLastDay: 0,
+            associatedParameters: [],
+            platform: [],
+          },
+        ],
+        totalCount: 1,
+      },
+    });
+  });
   it('Update metadata display data', async () => {
     tokenMock(ddbMock, false);
     let res = await request(app)
@@ -1031,12 +1156,75 @@ describe('Metadata Event Attribute test', () => {
       Items: [],
     });
     const res = await request(app)
-      .get(`/api/metadata/event_parameter?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}&name=${MOCK_EVENT_PARAMETER_NAME}&type=String`);
+      .get(`/api/metadata/event_parameter?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}&name=${MOCK_EVENT_PARAMETER_NAME}NoExist&type=String`);
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(404);
     expect(res.body).toEqual({
       success: false,
       message: 'Event attribute not found',
+    });
+  });
+  it('Get metadata event attribute by name when no data in DDB', async () => {
+    jest
+      .useFakeTimers()
+      .setSystemTime(new Date('2023-03-02'));
+    ddbMock.on(QueryCommand, {
+      TableName: analyticsMetadataTable,
+      IndexName: prefixMonthGSIName,
+      KeyConditionExpression: '#prefix= :prefix',
+      ExpressionAttributeNames: {
+        '#prefix': 'prefix',
+      },
+      ExpressionAttributeValues: {
+        ':prefix': `EVENT_PARAMETER#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+      },
+      ScanIndexForward: false,
+    }).resolves({
+      Items: [],
+    });
+    const res = await request(app)
+      .get(`/api/metadata/event_parameter?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}&name=${MOCK_EVENT_PARAMETER_NAME}&type=${MetadataValueType.STRING}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      message: '',
+      data: {
+        associatedEvents: [
+          {
+            name: MOCK_EVENT_NAME,
+            prefix: `EVENT#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+            id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}`,
+            projectId: MOCK_PROJECT_ID,
+            appId: MOCK_APP_ID,
+            metadataSource: MetadataSource.PRESET,
+            displayName: `display name of event ${MOCK_EVENT_NAME}`,
+            description: {
+              'en-US': 'mock event description in built-in',
+              'zh-CN': '内置事件的描述',
+            },
+          },
+        ],
+        id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}#${MetadataValueType.STRING}`,
+        month: '#202303',
+        prefix: `EVENT_PARAMETER#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+        projectId: MOCK_PROJECT_ID,
+        appId: MOCK_APP_ID,
+        name: MOCK_EVENT_PARAMETER_NAME,
+        description: {
+          'en-US': 'mock preset event parameter description in built-in',
+          'zh-CN': '内置事件参数的描述',
+        },
+        displayName: MOCK_EVENT_PARAMETER_NAME,
+        eventName: '',
+        category: ConditionCategory.EVENT,
+        metadataSource: MetadataSource.PRESET,
+        parameterType: MetadataParameterType.PUBLIC,
+        hasData: false,
+        platform: [],
+        valueType: MetadataValueType.STRING,
+        values: [],
+      },
     });
   });
   it('Get metadata event attribute list', async () => {
@@ -1201,6 +1389,82 @@ describe('Metadata Event Attribute test', () => {
       error: 'Error',
     });
   });
+  it('Get metadata event attribute list when no data in DDB', async () => {
+    jest
+      .useFakeTimers()
+      .setSystemTime(new Date('2023-02-02'));
+    ddbMock.on(QueryCommand, {
+      TableName: analyticsMetadataTable,
+      IndexName: prefixMonthGSIName,
+      KeyConditionExpression: '#prefix= :prefix',
+      ExpressionAttributeNames: {
+        '#prefix': 'prefix',
+      },
+      ExpressionAttributeValues: {
+        ':prefix': `EVENT_PARAMETER#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+      },
+      ScanIndexForward: false,
+    }).resolves({
+      Items: [],
+    });
+    const res = await request(app)
+      .get(`/api/metadata/event_parameters?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      message: '',
+      data: {
+        items: [
+          {
+            associatedEvents: [],
+            id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}#${MetadataValueType.STRING}`,
+            month: '#202302',
+            prefix: `EVENT_PARAMETER#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+            projectId: MOCK_PROJECT_ID,
+            appId: MOCK_APP_ID,
+            name: MOCK_EVENT_PARAMETER_NAME,
+            description: {
+              'en-US': 'mock preset event parameter description in built-in',
+              'zh-CN': '内置事件参数的描述',
+            },
+            displayName: MOCK_EVENT_PARAMETER_NAME,
+            eventName: MOCK_EVENT_NAME,
+            category: ConditionCategory.EVENT,
+            metadataSource: MetadataSource.PRESET,
+            parameterType: MetadataParameterType.PUBLIC,
+            hasData: false,
+            platform: [],
+            valueType: MetadataValueType.STRING,
+            values: [],
+          },
+          {
+            associatedEvents: [],
+            id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_EVENT_NAME}#${MOCK_EVENT_PARAMETER_NAME}11#${MetadataValueType.INTEGER}`,
+            month: '#202302',
+            prefix: `EVENT_PARAMETER#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+            projectId: MOCK_PROJECT_ID,
+            appId: MOCK_APP_ID,
+            name: `${MOCK_EVENT_PARAMETER_NAME}11`,
+            description: {
+              'en-US': '',
+              'zh-CN': '',
+            },
+            displayName: `${MOCK_EVENT_PARAMETER_NAME}11`,
+            eventName: `${MOCK_EVENT_NAME}`,
+            category: ConditionCategory.EVENT,
+            metadataSource: MetadataSource.CUSTOM,
+            parameterType: MetadataParameterType.PUBLIC,
+            hasData: false,
+            platform: [],
+            valueType: MetadataValueType.INTEGER,
+            values: [],
+          },
+        ],
+        totalCount: 2,
+      },
+    });
+  });
 
   afterAll((done) => {
     server.close();
@@ -1321,7 +1585,7 @@ describe('Metadata User Attribute test', () => {
               'zh-CN': '内置用户属性的描述',
             },
             displayName: 'display name of user parameter user-attribute-mock',
-            category: 'user',
+            category: ConditionCategory.USER,
             hasData: true,
             metadataSource: MetadataSource.PRESET,
             valueType: MetadataValueType.STRING,
@@ -1343,7 +1607,7 @@ describe('Metadata User Attribute test', () => {
               'zh-CN': '',
             },
             displayName: `${MOCK_USER_ATTRIBUTE_NAME}1`,
-            category: 'user',
+            category: ConditionCategory.USER,
             metadataSource: MetadataSource.CUSTOM,
             valueType: MetadataValueType.FLOAT,
             hasData: false,
@@ -1367,6 +1631,56 @@ describe('Metadata User Attribute test', () => {
       success: false,
       message: 'Unexpected error occurred at server.',
       error: 'Error',
+    });
+  });
+  it('Get metadata user attribute list when no data in DDB', async () => {
+    jest
+      .useFakeTimers()
+      .setSystemTime(new Date('2023-02-02'));
+    ddbMock.on(QueryCommand, {
+      TableName: analyticsMetadataTable,
+      IndexName: prefixMonthGSIName,
+      KeyConditionExpression: '#prefix= :prefix',
+      ExpressionAttributeNames: {
+        '#prefix': 'prefix',
+      },
+      ExpressionAttributeValues: {
+        ':prefix': `USER_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+      },
+      ScanIndexForward: false,
+    }).resolves({
+      Items: [],
+    });
+    const res = await request(app)
+      .get(`/api/metadata/user_attributes?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      message: '',
+      data: {
+        items: [
+          {
+            id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${MOCK_USER_ATTRIBUTE_NAME}#${MetadataValueType.STRING}`,
+            month: '#202302',
+            prefix: `USER_ATTRIBUTE#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+            projectId: MOCK_PROJECT_ID,
+            appId: MOCK_APP_ID,
+            name: MOCK_USER_ATTRIBUTE_NAME,
+            description: {
+              'en-US': 'mock preset user attribute description in built-in',
+              'zh-CN': '内置用户属性的描述',
+            },
+            displayName: 'display name of user parameter user-attribute-mock',
+            category: ConditionCategory.USER,
+            hasData: false,
+            metadataSource: MetadataSource.PRESET,
+            valueType: MetadataValueType.STRING,
+            values: [],
+          },
+        ],
+        totalCount: 1,
+      },
     });
   });
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

closes: #339 

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend