### PR TITLE
fix: add app failure when update session view

### DIFF
--- a/src/analytics/lambdas/custom-resource/create-schemas.ts
+++ b/src/analytics/lambdas/custom-resource/create-schemas.ts
@@ -316,7 +316,7 @@ async function updateSchemas(props: ResourcePropertiesType, biUsername: string, 
 }
 
 
-function getUpdatableSql(sqlOrViewDefs: SQLDef[], oldSqlArray: string[], mustacheParam: MustacheParamType) {
+function getUpdatableSql(sqlOrViewDefs: SQLDef[], oldSqlArray: string[], mustacheParam: MustacheParamType, path: string = '/opt') {
 
   const sqlStatements: string[] = [];
   for (const schemaOrViewDef of sqlOrViewDefs) {
@@ -324,10 +324,10 @@ function getUpdatableSql(sqlOrViewDefs: SQLDef[], oldSqlArray: string[], mustach
 
     if (!oldSqlArray.includes(schemaOrViewDef.sqlFile)) {
       logger.info(`new sql: ${schemaOrViewDef.sqlFile}`);
-      sqlStatements.push(getSqlContent(schemaOrViewDef.sqlFile, mustacheParam));
+      sqlStatements.push(getSqlContent(schemaOrViewDef.sqlFile, mustacheParam, path));
     } else if (schemaOrViewDef.updatable === 'true') {
       logger.info(`update sql: ${schemaOrViewDef.sqlFile}`);
-      sqlStatements.push(getSqlContent(schemaOrViewDef.sqlFile, mustacheParam));
+      sqlStatements.push(getSqlContent(schemaOrViewDef.sqlFile, mustacheParam, path));
     } else {
       logger.info(`skip update ${schemaOrViewDef.sqlFile} due to it is not updatable.`);
     }
@@ -430,7 +430,7 @@ async function updateViewForReporting(props: ResourcePropertiesType, oldProps: R
       ...SQL_TEMPLATE_PARAMETER,
     };
 
-    const sqlStatements2 = getUpdatableSql(props.reportingViewsDef, appUpdateProps.oldViewSqls, mustacheParam);
+    const sqlStatements2 = getUpdatableSql(props.reportingViewsDef, appUpdateProps.oldViewSqls, mustacheParam, '/opt/dashboard');
 
     //grant select on views to bi user.
     const views: string[] = [];

--- a/src/analytics/private/sql-def.ts
+++ b/src/analytics/private/sql-def.ts
@@ -43,7 +43,7 @@ export const reportingViewsDef: SQLDef[] = [
     sqlFile: 'clickstream_user_dim_view.sql',
   },
   {
-    updatable: 'true',
+    updatable: 'false',
     sqlFile: 'clickstream_session_view.sql',
   },
   {

--- a/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
@@ -294,9 +294,6 @@ describe('Custom resource - Create schemas for applications in Redshift database
       '/opt/dashboard/clickstream_user_attr_view.sql': testSqlContent(rootPath + 'dashboard/clickstream_user_attr_view.sql'),
       '/opt/dashboard/clickstream_user_dim_mv_1.sql': testSqlContent(rootPath + 'dashboard/clickstream_user_dim_mv_1.sql'),
       '/opt/dashboard/clickstream_user_dim_mv_2.sql': testSqlContent(rootPath + 'dashboard/clickstream_user_dim_mv_2.sql'),
-      '/opt/clickstream_user_dim_view.sql': testSqlContent(rootPath + 'dashboard/clickstream_user_dim_view.sql'),
-      '/opt/clickstream_session_view.sql': testSqlContent(rootPath + 'dashboard/clickstream_session_view.sql'),
-      '/opt/clickstream_event_view.sql': testSqlContent(rootPath + 'dashboard/clickstream_event_view.sql'),
       '/opt/clickstream_event_parameter_test_view.sql': testSqlContent(rootPath + 'dashboard/clickstream_event_parameter_view.sql'),
       '/opt/dashboard/clickstream_event_parameter_test_view.sql': testSqlContent(rootPath + 'dashboard/clickstream_event_parameter_view.sql'),
       '/opt/grant-permissions-to-bi-user.sql': testSqlContent(rootPath + 'grant-permissions-to-bi-user.sql'),
@@ -573,14 +570,12 @@ describe('Custom resource - Create schemas for applications in Redshift database
     });
     redshiftDataMock.on(BatchExecuteStatementCommand).callsFakeOnce(input => {
       const expectedSql = 'CREATE SCHEMA IF NOT EXISTS app2';
-      console.log(input.Sqls.length);
       if (input.Sqls.length !== 17 || input.Sqls[0] !== expectedSql) {
         throw new Error('create schema sqls are not expected');
       }
       return { Id: 'Id-1' };
     }).callsFakeOnce(input => {
       const expectedSql = 'CREATE TABLE IF NOT EXISTS app1.clickstream_log';
-      console.log(input.Sqls.length);
       if (input.Sqls.length !== 13 || !(input.Sqls[0] as string).startsWith(expectedSql)) {
         throw new Error('update schema sqls are not expected');
       }
@@ -599,15 +594,14 @@ describe('Custom resource - Create schemas for applications in Redshift database
     }).callsFakeOnce(input => {
       const expectedSql = 'CREATE OR REPLACE VIEW app1.clickstream_user_dim_view';
       const expectedSql2 = 'GRANT SELECT ON app1.clickstream_user_attr_view TO clickstream_report_user_abcde;';
-      if (input.Sqls.length !== 13
+      if (input.Sqls.length !== 12
         || !(input.Sqls[0] as string).startsWith(expectedSql)
-        || !(input.Sqls[12] as string).startsWith(expectedSql2)
+        || !(input.Sqls[11] as string).startsWith(expectedSql2)
       ) {
         throw new Error('update report view sqls are not expected');
       }
       return { Id: 'Id-1' };
-    })
-      .resolves({ Id: 'Id-2' });
+    }).resolves({ Id: 'Id-2' });
     redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
     const resp = await handler(updateServerlessEvent3, context, callback) as CdkCustomResourceResponse;
     expect(resp.Status).toEqual('SUCCESS');


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

fix fail when update clickstream_session_view
verify the fix for #172 in #332

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend