### PR TITLE
fix: wrong title of QuickSight visual

### DIFF
--- a/src/analytics/lambdas/custom-resource/create-schemas.ts
+++ b/src/analytics/lambdas/custom-resource/create-schemas.ts
@@ -348,6 +348,11 @@ async function doUpdate(sqlStatementsByApp: Map<string, string[]>, props: Resour
 function _buildGrantSqlStatements(views: string[], schema: string, biUser: string): string[] {
 
   const statements: string[] = [];
+
+  //grant select permission on base base tables to BI user for explore analysis
+  const tables = ['event', 'event_parameter', 'user', 'item', 'user_m_view', 'item_m_view'];
+  views.push(...tables);
+
   for (const view of views) {
     statements.push(`GRANT SELECT ON ${schema}.${view} TO ${biUser};`);
   }

--- a/src/control-plane/backend/Dockerfile
+++ b/src/control-plane/backend/Dockerfile
@@ -7,6 +7,8 @@ RUN cd src/control-plane/backend/lambda/api && rm -rf node_modules && yarn insta
 
 RUN mkdir -p /home/node/app/src/control-plane/backend/lambda/api/dist/service/quicksight/
 RUN cp -r /home/node/app/src/control-plane/backend/lambda/api/service/quicksight/templates /home/node/app/src/control-plane/backend/lambda/api/dist/service/quicksight/
+RUN cp -r /home/node/app/src/control-plane/backend/lambda/api/locales /home/node/app/src/control-plane/backend/lambda/api/dist/locales/
+
 
 RUN mkdir -p /asset
 RUN cp -r /home/node/app/src/control-plane/backend/lambda/api/node_modules /asset/

--- a/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
@@ -584,9 +584,13 @@ describe('Custom resource - Create schemas for applications in Redshift database
     }).callsFakeOnce(input => {
       const expectedSql = 'CREATE MATERIALIZED VIEW app2.clickstream_event_view';
       const expectedSql2 = 'GRANT SELECT ON app2.clickstream_user_attr_view TO clickstream_report_user_abcde;';
-      if (input.Sqls.length !== 22
+      const expectedSql3 = 'GRANT SELECT ON app2.event TO clickstream_report_user_abcde;';
+      const expectedSql4 = 'GRANT SELECT ON app2.item_m_view TO clickstream_report_user_abcde;';
+      if (input.Sqls.length !== 28
         || !(input.Sqls[0] as string).startsWith(expectedSql)
         || !(input.Sqls[21] as string).startsWith(expectedSql2)
+        || !(input.Sqls[22] as string).startsWith(expectedSql3)
+        || !(input.Sqls[27] as string).startsWith(expectedSql4)
       ) {
         throw new Error('create report view sqls are not expected');
       }
@@ -594,9 +598,13 @@ describe('Custom resource - Create schemas for applications in Redshift database
     }).callsFakeOnce(input => {
       const expectedSql = 'CREATE OR REPLACE VIEW app1.clickstream_user_dim_view';
       const expectedSql2 = 'GRANT SELECT ON app1.clickstream_user_attr_view TO clickstream_report_user_abcde;';
-      if (input.Sqls.length !== 12
+      const expectedSql3 = 'GRANT SELECT ON app1.event TO clickstream_report_user_abcde;';
+      const expectedSql4 = 'GRANT SELECT ON app1.item_m_view TO clickstream_report_user_abcde;';
+      if (input.Sqls.length !== 18
         || !(input.Sqls[0] as string).startsWith(expectedSql)
         || !(input.Sqls[11] as string).startsWith(expectedSql2)
+        || !(input.Sqls[12] as string).startsWith(expectedSql3)
+        || !(input.Sqls[17] as string).startsWith(expectedSql4)
       ) {
         throw new Error('update report view sqls are not expected');
       }


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. Wrong title of QuickSight visuals
2. Missing select permission on base tables 

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend