### PR TITLE
chore: refactor metadata scanning

### DIFF
--- a/src/analytics/analytics-on-redshift.ts
+++ b/src/analytics/analytics-on-redshift.ts
@@ -251,6 +251,7 @@ export class RedshiftAnalyticsStack extends NestedStack {
 
     const scanMetadataWorkflow = new ScanMetadataWorkflow(this, 'ScanMetadataWorkflow', {
       appIds: props.appIds,
+      projectId: props.projectId,
       networkConfig: {
         vpc: props.vpc,
         vpcSubnets: props.subnetSelection,
@@ -313,7 +314,6 @@ export class RedshiftAnalyticsStack extends NestedStack {
         projectId: props.projectId,
         dataProcessingCronOrRateExpression: props.dataProcessingCronOrRateExpression,
         upsertUsersCronOrRateExpression: props.upsertUsersWorkflowData.scheduleExpression,
-        scanMetadataCronOrRateExpression: props.scanMetadataWorkflowData.scheduleExpression,
         redshiftServerlessNamespace: this.redshiftServerlessWorkgroup.workgroup.namespaceName,
         redshiftServerlessWorkgroupName: this.redshiftServerlessWorkgroup.workgroup.workgroupName,
         loadDataWorkflow: loadRedshiftTablesWorkflow.loadDataWorkflow,
@@ -329,7 +329,6 @@ export class RedshiftAnalyticsStack extends NestedStack {
         projectId: props.projectId,
         dataProcessingCronOrRateExpression: props.dataProcessingCronOrRateExpression,
         upsertUsersCronOrRateExpression: props.upsertUsersWorkflowData.scheduleExpression,
-        scanMetadataCronOrRateExpression: props.scanMetadataWorkflowData.scheduleExpression,
         redshiftServerlessNamespace: props.existingRedshiftServerlessProps.namespaceId,
         redshiftServerlessWorkgroupName: props.existingRedshiftServerlessProps.workgroupName,
         loadDataWorkflow: loadRedshiftTablesWorkflow.loadDataWorkflow,
@@ -344,7 +343,6 @@ export class RedshiftAnalyticsStack extends NestedStack {
         projectId: props.projectId,
         dataProcessingCronOrRateExpression: props.dataProcessingCronOrRateExpression,
         upsertUsersCronOrRateExpression: props.upsertUsersWorkflowData.scheduleExpression,
-        scanMetadataCronOrRateExpression: props.scanMetadataWorkflowData.scheduleExpression,
         redshiftClusterIdentifier: props.provisionedRedshiftProps.clusterIdentifier,
         loadDataWorkflow: loadRedshiftTablesWorkflow.loadDataWorkflow,
         upsertUsersWorkflow: upsertUsersWorkflow.upsertUsersWorkflow,
@@ -398,9 +396,6 @@ function addCfnNag(stack: Stack) {
       'UpsertUsersWorkflow/UpsertUsersStateMachine/Role/DefaultPolicy/Resource',
       'UpsertUsersWorkflow', 'logs/xray'),
     ruleRolePolicyWithWildcardResources(
-      'ScanMetadataWorkflow/ScanMetadataStateMachine/Role/DefaultPolicy/Resource',
-      'ScanMetadataWorkflow', 'logs/xray'),
-    ruleRolePolicyWithWildcardResources(
       'ClearExpiredEventsWorkflow/ClearExpiredEventsStateMachine/Role/DefaultPolicy/Resource',
       'ClearExpiredEventsWorkflow', 'logs/xray'),
     ruleRolePolicyWithWildcardResources(
@@ -437,6 +432,20 @@ function addCfnNag(stack: Stack) {
         },
       ],
     },
+
+    {
+      paths_endswith: ['ScanMetadataStateMachine/Role/DefaultPolicy/Resource'],
+      rules_to_suppress: [
+        ...ruleRolePolicyWithWildcardResources(
+          'ScanMetadataStateMachine/Role/DefaultPolicy/Resource',
+          'ScanMetadataWorkflow', 'logs/xray').rules_to_suppress,
+        {
+          id: 'W76',
+          reason: 'ACK: SPCM for IAM policy document is higher than 25',
+        },
+      ],
+    },
+
     {
       paths_endswith: ['CopyDataFromS3Role/DefaultPolicy/Resource'],
       rules_to_suppress: [

--- a/src/analytics/lambdas/scan-metadata-workflow/check-metadata-workflow-start.ts
+++ b/src/analytics/lambdas/scan-metadata-workflow/check-metadata-workflow-start.ts
@@ -1,0 +1,186 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { logger } from '../../../common/powertools';
+import { readS3ObjectAsJson } from '../../../common/s3';
+import { getLatestEmrJobEndTime } from '../../../data-pipeline/utils/utils-common';
+import { WorkflowStatus } from '../../private/constant';
+
+const pipelineS3BucketName = process.env.PIPELINE_S3_BUCKET_NAME!;
+const pipelineS3Prefix = process.env.PIPELINE_S3_PREFIX!;
+const projectId = process.env.PROJECT_ID!;
+
+export interface CheckMetadataWorkflowEvent {
+  eventSource: string;
+  scanStartDate: string;
+  scanEndDate: string;
+}
+
+/**
+ * The lambda function submit a SQL statement to scan metadata.
+ * @param event CheckMetadataWorkflowEvent, the JSON format is as follows:
+ {
+    "eventSource" : "LoadDataFlow",
+    "scanStartDate" : "2023-10-25",
+    "scanEndDate" : "2023-10-30",
+  }
+  @returns as follows:
+  {
+    status: WorkflowStatus,
+    scanEndDate: scanEndDate,
+    jobStartTimestamp: currentTimestamp,
+    scanStartDate: startScanDate,
+  };
+ */
+export const handler = async (event: CheckMetadataWorkflowEvent) => {
+  logger.debug('request event:', JSON.stringify(event));
+  try {
+    const eventSource = event.eventSource;
+    // workflow is triggered from upstream workflow
+    if (eventSource === 'LoadDataFlow') {
+      return await handleEventFromUpstreamWorkflow();
+    } else {
+      const inputScanEndDate = formatScanDate(event.scanEndDate);
+      const inputScanStartDate = formatScanDate(event.scanStartDate);
+      const currentTimestamp = Date.now();
+      const scanEndDate = getScanEndDate(inputScanEndDate, getDateFromTimestamp(currentTimestamp));
+      let scanStartDate = inputScanStartDate;
+      return {
+        status: WorkflowStatus.CONTINUE,
+        scanEndDate: scanEndDate,
+        jobStartTimestamp: currentTimestamp,
+        scanStartDate: scanStartDate,
+      };
+    }
+  } catch (err) {
+    if (err instanceof Error) {
+      logger.error('Error when scan metadata.', err);
+    }
+    throw err;
+  }
+};
+
+async function handleEventFromUpstreamWorkflow() {
+  const currentTimestamp = Date.now();
+  const scanEndDate = await getMaxScanEndDate();
+  const response = await getWorkflowInfoFromS3();
+  let result = {};
+  if (response) {
+    const lastJobStartTimestamp = response.lastJobStartTimestamp;
+    const startScanDate = response.lastScanEndDate;
+
+    // Triggered if more than 24 hours have passed since the last job execution
+    const workflowMinInterval = parseInt(process.env.WORKFLOW_MIN_INTERVAL || '1440');
+    if (!lastJobStartTimestamp || currentTimestamp - lastJobStartTimestamp >= workflowMinInterval * 60 * 1000) {
+      result = {
+        status: WorkflowStatus.CONTINUE,
+        scanEndDate: scanEndDate,
+        jobStartTimestamp: currentTimestamp,
+        scanStartDate: startScanDate,
+      };
+    } else {
+      result = {
+        status: WorkflowStatus.SKIP,
+      };
+    }
+  } else {
+    // first time to execution, no job info in ddb.
+    result = {
+      status: WorkflowStatus.CONTINUE,
+      scanEndDate: scanEndDate,
+      jobStartTimestamp: currentTimestamp,
+      scanStartDate: '',
+    };
+  }
+  return result;
+}
+
+async function getWorkflowInfoFromS3() {
+  try {
+    const s3Key = getWorkflowInfoKey(pipelineS3Prefix, projectId);
+
+    return await readS3ObjectAsJson(
+      pipelineS3BucketName,
+      s3Key,
+    );
+  } catch (error) {
+    if (error instanceof Error) {
+      logger.error('Error get workflow info data from s3:', error);
+    }
+    throw error;
+  }
+}
+
+// get latest date from emr ods job file
+async function getMaxScanEndDate() {
+  try {
+    const latestJobTimestamp = await getLatestEmrJobEndTime(pipelineS3BucketName, pipelineS3Prefix, projectId);
+    let maxScanEndDate = undefined;
+    if (latestJobTimestamp) {
+      logger.info(`found emr latest job timestamp: ${latestJobTimestamp}`);
+      maxScanEndDate = getDateFromTimestamp(latestJobTimestamp);
+    }
+
+    if (!maxScanEndDate) {
+      maxScanEndDate = getDateFromTimestamp(Date.now());
+    }
+    return maxScanEndDate;
+  } catch (error) {
+    if (error instanceof Error) {
+      logger.error('Error determining scan end date:', error);
+    }
+    throw error;
+  }
+}
+
+function getDateFromTimestamp(timestamp: number) {
+  const date = new Date(timestamp);
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  const formattedDate = `${year}-${month}-${day}`;
+  return formattedDate;
+}
+
+function getScanEndDate(inputScanStartDate: string, maxScanStartDate: string) {
+  if (!inputScanStartDate) {
+    return maxScanStartDate;
+  }
+
+  const inputDate = new Date(inputScanStartDate);
+  const maxDate = new Date(maxScanStartDate);
+
+  return inputDate < maxDate ? inputScanStartDate : maxScanStartDate;
+}
+
+function formatScanDate(inputScanDate: string) {
+  if (!inputScanDate) {
+    return '';
+  } else if (!isValidDateFormat(inputScanDate)) {
+    throw new Error('input scan date format is not yyyy-mm-dd');
+  } else {
+    return inputScanDate;
+  }
+}
+
+// check dateString is 'yyyy-mm-dd'
+function isValidDateFormat(dateString: string): boolean {
+  const regex = /^\d{4}-\d{2}-\d{2}$/;
+  return regex.test(dateString);
+}
+
+export function getWorkflowInfoKey(s3Prefix: string, inputProjectId: string) {
+  return `${s3Prefix}scan-metadata-job-info/${inputProjectId}/workflow-job-info.json`;
+}

--- a/src/analytics/lambdas/scan-metadata-workflow/store-metadata-into-ddb.ts
+++ b/src/analytics/lambdas/scan-metadata-workflow/store-metadata-into-ddb.ts
@@ -23,7 +23,7 @@ import { getRedshiftClient, executeStatementsWithWait, getRedshiftProps, getStat
 const REDSHIFT_DATA_API_ROLE_ARN = process.env.REDSHIFT_DATA_API_ROLE!;
 const REDSHIFT_DATABASE = process.env.REDSHIFT_DATABASE!;
 
-const { ddb_region, ddb_table_name } = parseDynamoDBTableARN(process.env.METADATA_DDB_TABLE_ARN!);
+const { ddbRegion, ddbTableName } = parseDynamoDBTableARN(process.env.METADATA_DDB_TABLE_ARN!);
 
 // Create an Amazon service client object.
 const redshiftDataApiClient = getRedshiftClient(REDSHIFT_DATA_API_ROLE_ARN);
@@ -35,7 +35,7 @@ export interface StoreMetadataEvent {
 // Create an Amazon DynamoDB service client object.
 const ddbClient = new DynamoDBClient({
   ...aws_sdk_client_common_config,
-  region: ddb_region,
+  region: ddbRegion,
 });
 
 const ddbDocClient = DynamoDBDocumentClient.from(ddbClient);
@@ -251,7 +251,7 @@ async function batchWriteIntoDDB(metadataItems: any[]) {
   for (const itemsChunk of chunkedMetadataItems) {
     const inputPara: BatchWriteCommandInput = {
       RequestItems: {
-        [ddb_table_name]: itemsChunk,
+        [ddbTableName]: itemsChunk,
       },
     };
     await ddbDocClient.send(new BatchWriteCommand(inputPara));
@@ -303,11 +303,11 @@ async function queryMetadata(inputSql: string) {
 function parseDynamoDBTableARN(ddbArn: string) {
   const arnComponents = ddbArn.split(':');
   const region = arnComponents[3];
-  const table_name = arnComponents[5].split('/')[1];
+  const tableName = arnComponents[5].split('/')[1];
 
   return {
-    ddb_region: region,
-    ddb_table_name: table_name,
+    ddbRegion: region,
+    ddbTableName: tableName,
   };
 }
 
@@ -339,7 +339,7 @@ async function batchGetDDBItems(allKeys: any[]) {
     const currentBatchKeys = allKeys.slice(i, i + batchSize);
     const request: BatchGetCommandInput = {
       RequestItems: {
-        [ddb_table_name]: {
+        [ddbTableName]: {
           Keys: currentBatchKeys,
         },
       },
@@ -347,7 +347,7 @@ async function batchGetDDBItems(allKeys: any[]) {
     const command = new BatchGetCommand(request);
     try {
       const response: BatchGetCommandOutput = await ddbDocClient.send(command);
-      batchResults.push(...response.Responses![ddb_table_name]);
+      batchResults.push(...response.Responses![ddbTableName]);
     } catch (error) {
       console.error(error);
       return null;

--- a/src/analytics/lambdas/scan-metadata-workflow/update-workflow-info.ts
+++ b/src/analytics/lambdas/scan-metadata-workflow/update-workflow-info.ts
@@ -1,0 +1,101 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import {
+  DynamoDBClient,
+} from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, PutCommand, PutCommandInput } from '@aws-sdk/lib-dynamodb';
+import { getWorkflowInfoKey } from './check-metadata-workflow-start';
+import { logger } from '../../../common/powertools';
+import { putStringToS3 } from '../../../common/s3';
+import { aws_sdk_client_common_config } from '../../../common/sdk-client-config';
+
+const pipelineS3BucketName = process.env.PIPELINE_S3_BUCKET_NAME!;
+const pipelineS3Prefix = process.env.PIPELINE_S3_PREFIX!;
+const projectId = process.env.PROJECT_ID!;
+
+const { ddbRegion, ddbTableName } = parseDynamoDBTableARN(process.env.METADATA_DDB_TABLE_ARN!);
+
+const metaDataDDBClient = new DynamoDBClient({
+  ...aws_sdk_client_common_config,
+  region: ddbRegion,
+});
+
+const metaDataDDBDocClient = DynamoDBDocumentClient.from(metaDataDDBClient);
+
+export interface UpdateWorkflowInfoEvent {
+  readonly lastJobStartTimestamp: number;
+  readonly lastScanEndDate: string;
+}
+
+/**
+ * The lambda function submit a SQL statement to scan metadata.
+ * @param event ScanMetadataEvent, the JSON format is as follows:
+ {
+    lastJobStartTimestamp: timestamp;
+    lastScanEndDate: '2023-10-26';
+  }
+  @returns.
+ */
+export const handler = async (event: UpdateWorkflowInfoEvent) => {
+  logger.debug('request event:', JSON.stringify(event));
+
+  try {
+    const lastJobStartTimestamp = event.lastJobStartTimestamp;
+    const lastScanEndDate = event.lastScanEndDate;
+
+    await updateWorkflowInfoToS3(lastJobStartTimestamp, lastScanEndDate);
+
+    await updateProjectSummaryToDDB(lastJobStartTimestamp, lastScanEndDate);
+
+  } catch (err) {
+    if (err instanceof Error) {
+      logger.error('Error when scan metadata.', err);
+    }
+    throw err;
+  }
+};
+
+async function updateWorkflowInfoToS3(lastJobStartTimestamp: number, lastScanEndDate: string) {
+  const workflowJobInfo = {
+    lastJobStartTimestamp: lastJobStartTimestamp,
+    lastScanEndDate: lastScanEndDate,
+  };
+
+  const workflowJobKey = getWorkflowInfoKey(pipelineS3Prefix, projectId);
+  await putStringToS3(JSON.stringify(workflowJobInfo), pipelineS3BucketName, workflowJobKey);
+}
+
+async function updateProjectSummaryToDDB(lastJobStartTimestamp: number, lastScanEndDate: string) {
+  const request: PutCommandInput = {
+    TableName: ddbTableName,
+    Item: {
+      id: `PROJECT_SUMMARY#${projectId}`,
+      month: '#000000',
+      latestScanDate: `${lastScanEndDate}T00:00:00.000Z`,
+      lastJobStartTimestamp: lastJobStartTimestamp,
+    },
+  };
+  await metaDataDDBDocClient.send(new PutCommand(request));
+}
+
+function parseDynamoDBTableARN(ddbArn: string) {
+  const arnComponents = ddbArn.split(':');
+  const region = arnComponents[3];
+  const tableName = arnComponents[5].split('/')[1];
+
+  return {
+    ddbRegion: region,
+    ddbTableName: tableName,
+  };
+}

--- a/src/analytics/parameter.ts
+++ b/src/analytics/parameter.ts
@@ -65,9 +65,11 @@ export interface RedshiftAnalyticsStackProps {
     scheduleExpression: string;
   };
   scanMetadataConfiguration: {
-    scheduleExpression: string;
     clickstreamAnalyticsMetadataDdbArn: string;
     topFrequentPropertiesLimit: string;
+    scanWorkflowMinInterval: string;
+    pipelineS3Bucket: string;
+    pipelineS3Prefix: string;
   };
   clearExpiredEventsConfiguration: {
     scheduleExpression: string;
@@ -260,6 +262,16 @@ export function createStackParameters(scope: Construct): {
     default: '',
   });
 
+  const pipelineS3BucketParam = Parameters.createS3BucketParameter(scope, 'PipelineS3Bucket', {
+    description: 'Pipeline S3 bucket name in which to save temporary result',
+    allowedPattern: `^${S3_BUCKET_NAME_PATTERN}$`,
+  });
+
+  const pipelineS3PrefixParam = Parameters.createS3PrefixParameter(scope, 'PipelineS3Prefix', {
+    description: 'Pipeline S3 prefix',
+    default: 'pipeline-temp/',
+  });
+
   new CfnRule(scope, 'S3BucketReadinessRule', {
     assertions: [
       {
@@ -276,6 +288,12 @@ export function createStackParameters(scope: Construct): {
             ),
             Fn.conditionNot(
               Fn.conditionEquals(loadWorkflowBucketPrefixParam.valueAsString, ''),
+            ),
+            Fn.conditionNot(
+              Fn.conditionEquals(pipelineS3BucketParam.valueAsString, ''),
+            ),
+            Fn.conditionNot(
+              Fn.conditionEquals(pipelineS3PrefixParam.valueAsString, ''),
             ),
           ),
         assertDescription:
@@ -574,14 +592,6 @@ export function createStackParameters(scope: Construct): {
   // Set scan metadata job parameters
   const scanMetadataWorkflowParamsGroup = [];
 
-  const scanMetadataWorkflowScheduleExpressionParam = new CfnParameter(scope, 'ScanMetadataScheduleExpression', {
-    description: 'The schedule expression at which the scan metadata job runs regularly. in days.',
-    type: 'String',
-    allowedPattern: SCHEDULE_EXPRESSION_PATTERN,
-    constraintDescription: 'Must be in the format cron(minutes,hours,day-of-month,month,day-of-week,year), when the task should run at any time on everyday.',
-    default: 'cron(0 1 * * ? *)',
-  });
-
   const clickstreamAnalyticsMetadataDdbArnParam = new CfnParameter(scope, 'ClickstreamAnalyticsMetadataDdbArn', {
     description: 'The arn of ClickstreamAnalyticsMetadata Dynamodb table.',
     type: 'String',
@@ -594,24 +604,39 @@ export function createStackParameters(scope: Construct): {
     default: 20,
   });
 
+  const scanWorkflowMinIntervalParam = new CfnParameter(scope, 'ScanWorkflowMinInterval', {
+    description: 'The minimum interval minutes of scan workflow execution (Default 1 day)',
+    type: 'Number',
+    default: '1440',
+    minValue: 60,
+  });
+
   scanMetadataWorkflowParamsGroup.push({
     Label: { default: 'Scan metadata job' },
     Parameters: [
-      scanMetadataWorkflowScheduleExpressionParam.logicalId,
       clickstreamAnalyticsMetadataDdbArnParam.logicalId,
       topFrequentPropertiesLimitParam.logicalId,
+      scanWorkflowMinIntervalParam.logicalId,
+      pipelineS3BucketParam.logicalId,
+      pipelineS3PrefixParam.logicalId,
     ],
   });
 
   const scanMetadataWorkflowParamsLabels = {
-    [scanMetadataWorkflowScheduleExpressionParam.logicalId]: {
-      default: 'Scan metadata schedule expression',
-    },
     [clickstreamAnalyticsMetadataDdbArnParam.logicalId]: {
       default: 'Scan metadata dynamodb table arn',
     },
     [topFrequentPropertiesLimitParam.logicalId]: {
       default: 'The number of top property values',
+    },
+    [scanWorkflowMinIntervalParam.logicalId]: {
+      default: 'The minimum interval minutes of scan workflow execution (Default 1 day)',
+    },
+    [pipelineS3BucketParam.logicalId]: {
+      default: 'Pipeline S3 bucket name',
+    },
+    [pipelineS3PrefixParam.logicalId]: {
+      default: 'Pipeline S3 prefix',
     },
   };
 
@@ -798,9 +823,11 @@ export function createStackParameters(scope: Construct): {
         scheduleExpression: upsertUsersWorkflowScheduleExpressionParam.valueAsString,
       },
       scanMetadataConfiguration: {
-        scheduleExpression: scanMetadataWorkflowScheduleExpressionParam.valueAsString,
         clickstreamAnalyticsMetadataDdbArn: clickstreamAnalyticsMetadataDdbArnParam.valueAsString,
         topFrequentPropertiesLimit: topFrequentPropertiesLimitParam.valueAsString,
+        scanWorkflowMinInterval: scanWorkflowMinIntervalParam.valueAsString,
+        pipelineS3Bucket: pipelineS3BucketParam.valueAsString,
+        pipelineS3Prefix: pipelineS3PrefixParam.valueAsString,
       },
       clearExpiredEventsConfiguration: {
         scheduleExpression: clearExpiredEventsWorkflowScheduleExpressionParam.valueAsString,

--- a/src/analytics/private/constant.ts
+++ b/src/analytics/private/constant.ts
@@ -17,6 +17,16 @@ export enum JobStatus {
   JOB_PROCESSING = 'PROCESSING',
 }
 
+export enum WorkflowStatus {
+  FAILED = 'FAILED',
+  ABORTED = 'ABORTED',
+  SKIP = 'SKIP',
+  CONTINUE = 'CONTINUE',
+  FINISHED = 'FINISHED',
+  SUCCEED = 'SUCCEED',
+  NO_JOBS = 'NO_JOBS',
+}
+
 export const DYNAMODB_TABLE_INDEX_NAME = 'status_timestamp_index';
 
 export const REDSHIFT_ODS_EVENTS_TABLE_NAME = 'ods_events';

--- a/src/analytics/private/metrics-common-workflow.ts
+++ b/src/analytics/private/metrics-common-workflow.ts
@@ -90,10 +90,11 @@ export function buildMetricsWidgetForWorkflows(scope: Construct, id: string, pro
     threshold: 1,
     evaluationPeriods: 1,
     treatMissingData: TreatMissingData.NOT_BREACHING,
-    metric: props.scanMetadataWorkflow.metricFailed({ period: Duration.hours(1) }),
+    metric: props.scanMetadataWorkflow.metricFailed({ period: Duration.hours(24) }),
     alarmDescription: `Scan metadata workflow failed, projectId: ${props.projectId}`,
     alarmName: getAlarmName(scope, props.projectId, 'Scan Metadata Workflow'),
   });
+  (scanMetadataWorkflowAlarm.node.defaultChild as CfnResource).addPropertyOverride('Period', processingJobInterval.getIntervalSeconds());
 
   const newFilesCountAlarm = new Alarm(scope, id + 'MaxFileAgeAlarm', {
     comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,

--- a/src/analytics/private/metrics-redshift-cluster.ts
+++ b/src/analytics/private/metrics-redshift-cluster.ts
@@ -23,7 +23,6 @@ export function createMetricsWidgetForRedshiftCluster(scope: Construct, props: {
   projectId: string;
   dataProcessingCronOrRateExpression: string;
   upsertUsersCronOrRateExpression: string;
-  scanMetadataCronOrRateExpression: string;
   redshiftClusterIdentifier: string;
   loadDataWorkflow: IStateMachine;
   upsertUsersWorkflow: IStateMachine;

--- a/src/analytics/private/metrics-redshift-serverless.ts
+++ b/src/analytics/private/metrics-redshift-serverless.ts
@@ -23,7 +23,6 @@ export function createMetricsWidgetForRedshiftServerless(scope: Construct, id: s
   projectId: string;
   dataProcessingCronOrRateExpression: string;
   upsertUsersCronOrRateExpression: string;
-  scanMetadataCronOrRateExpression: string;
   redshiftServerlessNamespace?: string;
   redshiftServerlessWorkgroupName: string;
   loadDataWorkflow: IStateMachine;

--- a/src/analytics/private/model.ts
+++ b/src/analytics/private/model.ts
@@ -45,9 +45,11 @@ export type UpsertUsersWorkflowData = {
 }
 
 export type ScanMetadataWorkflowData = {
-  readonly scheduleExpression: string;
   readonly clickstreamAnalyticsMetadataDdbArn: string;
   readonly topFrequentPropertiesLimit: string;
+  readonly scanWorkflowMinInterval: string;
+  readonly pipelineS3Bucket: string;
+  readonly pipelineS3Prefix: string;
 }
 
 export type ClearExpiredEventsWorkflowData = {
@@ -150,10 +152,6 @@ export interface ManifestBody {
 }
 
 export interface UpsertUsersBody {
-  readonly appId: string;
-}
-
-export interface ScanMetadataBody {
   readonly appId: string;
 }
 

--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -786,6 +786,16 @@ export class CDataModelingStack extends JSONObject {
     ODSEventFileSuffix?: string;
 
   @JSONObject.required
+    PipelineS3Bucket?: string;
+
+  @JSONObject.required
+  @JSONObject.custom( (_stack:any, key:string, value:string) => {
+    validatePattern(key, S3_PREFIX_PATTERN, value);
+    return value;
+  })
+    PipelineS3Prefix?: string;
+
+  @JSONObject.required
     LoadWorkflowBucket?: string;
 
   @JSONObject.required
@@ -988,6 +998,9 @@ export class CDataModelingStack extends JSONObject {
       ODSEventBucket: pipeline.dataModeling?.ods?.bucket.name ?? pipeline.bucket.name,
       ODSEventPrefix: getBucketPrefix(pipeline.projectId, BucketPrefix.DATA_ODS, pipeline.dataModeling?.ods?.bucket.prefix),
       ODSEventFileSuffix: pipeline.dataModeling?.ods?.fileSuffix,
+
+      PipelineS3Bucket: pipeline.dataProcessing?.pipelineBucket.name ?? pipeline.bucket.name,
+      PipelineS3Prefix: getBucketPrefix(pipeline.projectId, BucketPrefix.DATA_PIPELINE_TEMP, pipeline.dataProcessing?.pipelineBucket.prefix),
 
       LoadWorkflowBucket: pipeline.dataModeling?.loadWorkflow?.bucket?.name ?? pipeline.bucket.name,
       LoadWorkflowBucketPrefix: getBucketPrefix(pipeline.projectId, BucketPrefix.DATA_ODS, pipeline.dataModeling?.loadWorkflow?.bucket?.prefix),

--- a/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
@@ -608,6 +608,14 @@ const BASE_DATAANALYTICS_PARAMETERS = [
     ParameterValue: '.snappy.parquet',
   },
   {
+    ParameterKey: 'PipelineS3Bucket',
+    ParameterValue: 'EXAMPLE_BUCKET',
+  },
+  {
+    ParameterKey: 'PipelineS3Prefix',
+    ParameterValue: 'clickstream/project_8888_8888/data/pipeline-temp/',
+  },
+  {
     ParameterKey: 'LoadWorkflowBucket',
     ParameterValue: 'EXAMPLE_BUCKET',
   },

--- a/src/data-analytics-redshift-stack.ts
+++ b/src/data-analytics-redshift-stack.ts
@@ -132,9 +132,11 @@ export function createRedshiftAnalyticsStack(
       scheduleExpression: props.upsertUsersConfiguration.scheduleExpression,
     },
     scanMetadataWorkflowData: {
-      scheduleExpression: props.scanMetadataConfiguration.scheduleExpression,
       clickstreamAnalyticsMetadataDdbArn: props.scanMetadataConfiguration.clickstreamAnalyticsMetadataDdbArn,
       topFrequentPropertiesLimit: props.scanMetadataConfiguration.topFrequentPropertiesLimit,
+      scanWorkflowMinInterval: props.scanMetadataConfiguration.scanWorkflowMinInterval,
+      pipelineS3Bucket: props.scanMetadataConfiguration.pipelineS3Bucket,
+      pipelineS3Prefix: props.scanMetadataConfiguration.pipelineS3Prefix,
     },
     clearExpiredEventsWorkflowData: {
       scheduleExpression: props.clearExpiredEventsConfiguration.scheduleExpression,

--- a/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
+++ b/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
@@ -4822,7 +4822,12 @@ describe('Should set metrics widgets', () => {
       },
 
       TreatMissingData: TreatMissingData.NOT_BREACHING,
-      Period: 3600,
+      Period: {
+        'Fn::GetAtt': [
+          Match.anyValue(),
+          'intervalSeconds',
+        ],
+      },
     });
 
     newServerlessTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
@@ -4921,7 +4926,12 @@ describe('Should set metrics widgets', () => {
       },
 
       TreatMissingData: TreatMissingData.NOT_BREACHING,
-      Period: 3600,
+      Period: {
+        'Fn::GetAtt': [
+          Match.anyValue(),
+          'intervalSeconds',
+        ],
+      },
     });
 
     existingServerlessTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
@@ -5018,7 +5028,12 @@ describe('Should set metrics widgets', () => {
       },
 
       TreatMissingData: TreatMissingData.NOT_BREACHING,
-      Period: 3600,
+      Period: {
+        'Fn::GetAtt': [
+          Match.anyValue(),
+          'intervalSeconds',
+        ],
+      },
     });
 
     provisionTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {

--- a/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
+++ b/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
@@ -237,8 +237,8 @@ describe('DataAnalyticsRedshiftStack common parameter test', () => {
 
   test('Should has Rules S3BucketReadinessRule', () => {
     const rule = template.toJSON().Rules.S3BucketReadinessRule;
-    expect(rule.Assertions[0].Assert[CFN_FN.AND].length).toEqual(4);
-    const paramList = ['ODSEventBucket', 'ODSEventPrefix', 'LoadWorkflowBucket', 'LoadWorkflowBucketPrefix'];
+    expect(rule.Assertions[0].Assert[CFN_FN.AND].length).toEqual(6);
+    const paramList = ['ODSEventBucket', 'ODSEventPrefix', 'LoadWorkflowBucket', 'LoadWorkflowBucketPrefix', 'PipelineS3Bucket', 'PipelineS3Prefix'];
     var paramCount = 0;
     for (const element of rule.Assertions[0].Assert[CFN_FN.AND]) {
       paramList.forEach(p => {
@@ -340,7 +340,7 @@ describe('DataAnalyticsRedshiftStack common parameter test', () => {
     expect(cfnInterface.ParameterGroups).toBeDefined();
 
     const paramCount = Object.keys(cfnInterface.ParameterLabels).length;
-    expect(paramCount).toEqual(31);
+    expect(paramCount).toEqual(33);
   });
 
   test('Conditions for nested redshift stacks are created as expected', () => {
@@ -389,32 +389,6 @@ describe('DataAnalyticsRedshiftStack common parameter test', () => {
       expect(v).not.toMatch(regex);
     }
   });
-
-  test('Check ScanMetadataScheduleExpression pattern', () => {
-    const param = getParameter(template, 'ScanMetadataScheduleExpression');
-    const pattern = param.AllowedPattern;
-    const regex = new RegExp(`${pattern}`);
-    const validValues = [
-      'cron(0 1 * * ? *)',
-      'cron(59 23 * * ? *)',
-      'cron(0 */4 * * ? *)',
-      'cron(0/30 * * * ? *)',
-      'cron(0/30 */20 * * ? *)',
-    ];
-
-    for (const v of validValues) {
-      expect(v).toMatch(regex);
-    }
-
-    const invalidValues = [
-      '(0 1 * * ? *)',
-      'cron(0 1 * * ? *',
-    ];
-    for (const v of invalidValues) {
-      expect(v).not.toMatch(regex);
-    }
-  });
-
 });
 
 describe('DataAnalyticsRedshiftStack serverless parameter test', () => {
@@ -511,9 +485,11 @@ describe('DataAnalyticsRedshiftStack serverless parameter test', () => {
       'RedshiftServerlessNamespaceId',
       'MaxFilesLimit',
       'UpsertUsersScheduleExpression',
-      'ScanMetadataScheduleExpression',
       'ClickstreamAnalyticsMetadataDdbArn',
+      'PipelineS3Bucket',
+      'PipelineS3Prefix',
       'TopFrequentPropertiesLimit',
+      'ScanWorkflowMinInterval',
       'ClearExpiredEventsScheduleExpression',
       'ClearExpiredEventsRetentionRangeDays',
       'EMRServerlessApplicationId',
@@ -670,9 +646,11 @@ describe('DataAnalyticsRedshiftStack serverless parameter test', () => {
         scheduleExpression: 'cron(0 1 * * ? *)',
       },
       scanMetadataWorkflowData: {
-        scheduleExpression: 'cron(0 1 * * ? *)',
         clickstreamAnalyticsMetadataDdbArn: 'arn:aws:dynamodb:us-east-1:111122223333:table/ClickstreamAnalyticsMetadata',
         topFrequentPropertiesLimit: '20',
+        scanWorkflowMinInterval: '1440',
+        pipelineS3Bucket: 'pipeline-s3-bucket',
+        pipelineS3Prefix: 'pipelineS3Prefix',
       },
       clearExpiredEventsWorkflowData: {
         scheduleExpression: 'cron(0 17 * * ? *)',
@@ -724,9 +702,11 @@ describe('DataAnalyticsRedshiftStack serverless parameter test', () => {
         scheduleExpression: 'cron(0 1 * * ? *)',
       },
       scanMetadataWorkflowData: {
-        scheduleExpression: 'cron(0 1 * * ? *)',
         clickstreamAnalyticsMetadataDdbArn: 'arn:aws:dynamodb:us-east-1:111122223333:table/ClickstreamAnalyticsMetadata',
         topFrequentPropertiesLimit: '20',
+        scanWorkflowMinInterval: '1440',
+        pipelineS3Bucket: 'pipeline-s3-bucket',
+        pipelineS3Prefix: 'pipelineS3Prefix',
       },
       clearExpiredEventsWorkflowData: {
         scheduleExpression: 'cron(0 17 * * ? *)',
@@ -765,9 +745,11 @@ describe('DataAnalyticsRedshiftStack serverless parameter test', () => {
         scheduleExpression: 'cron(0 1 * * ? *)',
       },
       scanMetadataWorkflowData: {
-        scheduleExpression: 'cron(0 1 * * ? *)',
         clickstreamAnalyticsMetadataDdbArn: 'arn:aws:dynamodb:us-east-1:111122223333:table/ClickstreamAnalyticsMetadata',
         topFrequentPropertiesLimit: '20',
+        scanWorkflowMinInterval: '1440',
+        pipelineS3Bucket: 'pipeline-s3-bucket',
+        pipelineS3Prefix: 'pipelineS3Prefix',
       },
       clearExpiredEventsWorkflowData: {
         scheduleExpression: 'cron(0 17 * * ? *)',
@@ -3519,15 +3501,15 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
     }
   });
 
-  test('Check ScanMetadataWorkflowCheckScanMetadataJobStatusFnSG', () => {
+  test('Check ScanMetadataWorkflowCheckScanMetadataStatusFnSG', ()=>{
     if (stack.nestedStacks.redshiftServerlessStack) {
       const nestedTemplate = Template.fromStack(stack.nestedStacks.redshiftServerlessStack);
-      const sg = findFirstResourceByKeyPrefix(nestedTemplate, 'AWS::EC2::SecurityGroup', 'ScanMetadataWorkflowCheckScanMetadataJobStatusFnSG');
+      const sg = findFirstResourceByKeyPrefix(nestedTemplate, 'AWS::EC2::SecurityGroup', 'ScanMetadataWorkflowCheckScanMetadataStatusFnSG');
       expect(sg).toBeDefined();
     }
     if (stack.nestedStacks.redshiftProvisionedStack) {
       const nestedTemplate = Template.fromStack(stack.nestedStacks.redshiftProvisionedStack);
-      const sg = findFirstResourceByKeyPrefix(nestedTemplate, 'AWS::EC2::SecurityGroup', 'ScanMetadataWorkflowCheckScanMetadataJobStatusFnSG');
+      const sg = findFirstResourceByKeyPrefix(nestedTemplate, 'AWS::EC2::SecurityGroup', 'ScanMetadataWorkflowCheckScanMetadataStatusFnSG');
       expect(sg).toBeDefined();
     }
   });
@@ -3535,12 +3517,12 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
   test('Check ScanMetadataWorkflowCheckScanMetadataJobStatusRole', () => {
     if (stack.nestedStacks.redshiftServerlessStack) {
       const nestedTemplate = Template.fromStack(stack.nestedStacks.redshiftServerlessStack);
-      const role = findFirstResourceByKeyPrefix(nestedTemplate, 'AWS::IAM::Role', 'ScanMetadataWorkflowCheckScanMetadataJobStatusRole');
+      const role = findFirstResourceByKeyPrefix(nestedTemplate, 'AWS::IAM::Role', 'ScanMetadataWorkflowCheckScanMetadataStatusRole');
       expect(role).toBeDefined();
     }
     if (stack.nestedStacks.redshiftProvisionedStack) {
       const nestedTemplate = Template.fromStack(stack.nestedStacks.redshiftProvisionedStack);
-      const role = findFirstResourceByKeyPrefix(nestedTemplate, 'AWS::IAM::Role', 'ScanMetadataWorkflowCheckScanMetadataJobStatusRole');
+      const role = findFirstResourceByKeyPrefix(nestedTemplate, 'AWS::IAM::Role', 'ScanMetadataWorkflowCheckScanMetadataStatusRole');
       expect(role).toBeDefined();
     }
   });
@@ -3571,7 +3553,59 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
     }
   });
 
-  test('Check UpsertUsersWorkflowCheckUpsertJobStatusRoleDefaultPolicy', () => {
+  test('Check ScanMetadataWorkflowCheckWorkflowStartFnSG', ()=>{
+    if (stack.nestedStacks.redshiftServerlessStack) {
+      const nestedTemplate = Template.fromStack(stack.nestedStacks.redshiftServerlessStack);
+      const sg = findFirstResourceByKeyPrefix(nestedTemplate, 'AWS::EC2::SecurityGroup', 'ScanMetadataWorkflowCheckWorkflowStartFnSG');
+      expect(sg).toBeDefined();
+    }
+    if (stack.nestedStacks.redshiftProvisionedStack) {
+      const nestedTemplate = Template.fromStack(stack.nestedStacks.redshiftProvisionedStack);
+      const sg = findFirstResourceByKeyPrefix(nestedTemplate, 'AWS::EC2::SecurityGroup', 'ScanMetadataWorkflowCheckWorkflowStartFnSG');
+      expect(sg).toBeDefined();
+    }
+  });
+
+  test('Check ScanMetadataWorkflowCheckWorkflowRole', ()=>{
+    if (stack.nestedStacks.redshiftServerlessStack) {
+      const nestedTemplate = Template.fromStack(stack.nestedStacks.redshiftServerlessStack);
+      const role = findFirstResourceByKeyPrefix(nestedTemplate, 'AWS::IAM::Role', 'ScanMetadataWorkflowCheckWorkflowStartRole');
+      expect(role).toBeDefined();
+    }
+    if (stack.nestedStacks.redshiftProvisionedStack) {
+      const nestedTemplate = Template.fromStack(stack.nestedStacks.redshiftProvisionedStack);
+      const role = findFirstResourceByKeyPrefix(nestedTemplate, 'AWS::IAM::Role', 'ScanMetadataWorkflowCheckWorkflowStartRole');
+      expect(role).toBeDefined();
+    }
+  });
+
+  test('Check ScanMetadataWorkflowUpdateWorkflowInfoFnSG', ()=>{
+    if (stack.nestedStacks.redshiftServerlessStack) {
+      const nestedTemplate = Template.fromStack(stack.nestedStacks.redshiftServerlessStack);
+      const sg = findFirstResourceByKeyPrefix(nestedTemplate, 'AWS::EC2::SecurityGroup', 'ScanMetadataWorkflowUpdateWorkflowInfoFnSG');
+      expect(sg).toBeDefined();
+    }
+    if (stack.nestedStacks.redshiftProvisionedStack) {
+      const nestedTemplate = Template.fromStack(stack.nestedStacks.redshiftProvisionedStack);
+      const sg = findFirstResourceByKeyPrefix(nestedTemplate, 'AWS::EC2::SecurityGroup', 'ScanMetadataWorkflowUpdateWorkflowInfoFnSG');
+      expect(sg).toBeDefined();
+    }
+  });
+
+  test('Check ScanMetadataWorkflowUpdateWorkflowInfoRole', ()=>{
+    if (stack.nestedStacks.redshiftServerlessStack) {
+      const nestedTemplate = Template.fromStack(stack.nestedStacks.redshiftServerlessStack);
+      const role = findFirstResourceByKeyPrefix(nestedTemplate, 'AWS::IAM::Role', 'ScanMetadataWorkflowUpdateWorkflowInfoRole');
+      expect(role).toBeDefined();
+    }
+    if (stack.nestedStacks.redshiftProvisionedStack) {
+      const nestedTemplate = Template.fromStack(stack.nestedStacks.redshiftProvisionedStack);
+      const role = findFirstResourceByKeyPrefix(nestedTemplate, 'AWS::IAM::Role', 'ScanMetadataWorkflowUpdateWorkflowInfoRole');
+      expect(role).toBeDefined();
+    }
+  });
+
+  test('Check UpsertUsersWorkflowCheckUpsertJobStatusRoleDefaultPolicy', ()=>{
     if (stack.nestedStacks.redshiftServerlessStack) {
       const nestedTemplate = Template.fromStack(stack.nestedStacks.redshiftServerlessStack);
       nestedTemplate.hasResourceProperties('AWS::IAM::Policy', {
@@ -4781,6 +4815,21 @@ describe('Should set metrics widgets', () => {
         'Fn::Join': [
           '',
           [
+            'Scan metadata workflow failed, projectId: ',
+            Match.anyValue(),
+          ],
+        ],
+      },
+
+      TreatMissingData: TreatMissingData.NOT_BREACHING,
+      Period: 3600,
+    });
+
+    newServerlessTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmDescription: {
+        'Fn::Join': [
+          '',
+          [
             'Max file age more than ',
             {
               'Fn::GetAtt': [
@@ -4858,6 +4907,21 @@ describe('Should set metrics widgets', () => {
           'intervalSeconds',
         ],
       },
+    });
+
+    newServerlessTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmDescription: {
+        'Fn::Join': [
+          '',
+          [
+            'Scan metadata workflow failed, projectId: ',
+            Match.anyValue(),
+          ],
+        ],
+      },
+
+      TreatMissingData: TreatMissingData.NOT_BREACHING,
+      Period: 3600,
     });
 
     existingServerlessTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
@@ -4940,6 +5004,21 @@ describe('Should set metrics widgets', () => {
           'intervalSeconds',
         ],
       },
+    });
+
+    newServerlessTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmDescription: {
+        'Fn::Join': [
+          '',
+          [
+            'Scan metadata workflow failed, projectId: ',
+            Match.anyValue(),
+          ],
+        ],
+      },
+
+      TreatMissingData: TreatMissingData.NOT_BREACHING,
+      Period: 3600,
     });
 
     provisionTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {

--- a/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/check-workflow-start.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/check-workflow-start.test.ts
@@ -1,0 +1,174 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { Readable } from 'stream';
+import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
+import { sdkStreamMixin } from '@smithy/util-stream-node';
+import { mockClient } from 'aws-sdk-client-mock';
+import { handler, CheckMetadataWorkflowEvent } from '../../../../../src/analytics/lambdas/scan-metadata-workflow/check-metadata-workflow-start';
+import { WorkflowStatus } from '../../../../../src/analytics/private/constant';
+import 'aws-sdk-client-mock-jest';
+
+const checkMetadataWorkflowEvent: CheckMetadataWorkflowEvent = {
+  eventSource: 'LoadDataFlow',
+  scanStartDate: '2023-10-10',
+  scanEndDate: '2023-10-20',
+};
+
+describe('Lambda - check workflow start', () => {
+  const s3ClientMock = mockClient(S3Client);
+
+  beforeEach(() => {
+    s3ClientMock.reset();
+  });
+
+  test('workflow is triggered from upstream step function and first time', async () => {
+    jest.useFakeTimers().setSystemTime(new Date(1698330523913));
+    const emrObj = { endTimestamp: 1698330523913 };
+    const emrObjStream = new Readable();
+    emrObjStream.push(JSON.stringify(emrObj));
+    emrObjStream.push(null);
+    // wrap the Stream with SDK mixin
+    const emrObjSdkStream = sdkStreamMixin(emrObjStream);
+
+    s3ClientMock.on(GetObjectCommand)
+      .resolvesOnce(
+        {
+          Body: emrObjSdkStream,
+        },
+      )
+      .resolvesOnce({},
+      );
+
+    const resp = await handler(checkMetadataWorkflowEvent);
+    expect(resp).toEqual({
+      status: WorkflowStatus.CONTINUE,
+      scanEndDate: '2023-10-26',
+      jobStartTimestamp: 1698330523913,
+      scanStartDate: '',
+    });
+  });
+
+  test('workflow is not triggered because it is too close to last triggered', async () => {
+    jest.useFakeTimers().setSystemTime(new Date(1698330523913));
+
+    const emrObj = { endTimestamp: 1698330523913 };
+    const emrObjStream = new Readable();
+    emrObjStream.push(JSON.stringify(emrObj));
+    emrObjStream.push(null);
+    // wrap the Stream with SDK mixin
+    const emrObjSdkStream = sdkStreamMixin(emrObjStream);
+
+    const workflowObj = {
+      lastJobStartTimestamp: 1698330523913,
+      lastScanEndDate: '2023-10-26',
+    };
+    const workflowObjStream = new Readable();
+    workflowObjStream.push(JSON.stringify(workflowObj));
+    workflowObjStream.push(null);
+    // wrap the Stream with SDK mixin
+    const workflowObjSdkStream = sdkStreamMixin(workflowObjStream);
+
+    s3ClientMock.on(GetObjectCommand)
+      .resolvesOnce(
+        {
+          Body: emrObjSdkStream,
+        },
+      )
+      .resolvesOnce(
+        {
+          Body: workflowObjSdkStream,
+        },
+      );
+
+    const resp = await handler(checkMetadataWorkflowEvent);
+    expect(resp).toEqual({
+      status: WorkflowStatus.SKIP,
+    });
+  });
+
+  test('workflow is triggered from upstream step function and not first time', async () => {
+    jest.useFakeTimers().setSystemTime(new Date(1698416923914));
+
+    const emrObj = { endTimestamp: 1698416923914 };
+    const emrObjStream = new Readable();
+    emrObjStream.push(JSON.stringify(emrObj));
+    emrObjStream.push(null);
+    // wrap the Stream with SDK mixin
+    const emrObjSdkStream = sdkStreamMixin(emrObjStream);
+
+    const workflowObj = {
+      lastJobStartTimestamp: 1698330523913,
+      lastScanEndDate: '2023-10-24',
+    };
+    const workflowObjStream = new Readable();
+    workflowObjStream.push(JSON.stringify(workflowObj));
+    workflowObjStream.push(null);
+    // wrap the Stream with SDK mixin
+    const workflowObjSdkStream = sdkStreamMixin(workflowObjStream);
+
+    s3ClientMock.on(GetObjectCommand)
+      .resolvesOnce(
+        {
+          Body: emrObjSdkStream,
+        },
+      )
+      .resolvesOnce(
+        {
+          Body: workflowObjSdkStream,
+        },
+      );
+
+    const resp = await handler(checkMetadataWorkflowEvent);
+    expect(resp).toEqual({
+      status: WorkflowStatus.CONTINUE,
+      scanEndDate: '2023-10-27',
+      jobStartTimestamp: 1698416923914,
+      scanStartDate: '2023-10-24',
+    });
+  });
+
+  test('workflow is triggered manually with input', async () => {
+    jest.useFakeTimers().setSystemTime(new Date(1698416923914));
+    checkMetadataWorkflowEvent.eventSource = '';
+    const resp = await handler(checkMetadataWorkflowEvent);
+    expect(resp).toEqual({
+      status: WorkflowStatus.CONTINUE,
+      scanEndDate: '2023-10-20',
+      jobStartTimestamp: 1698416923914,
+      scanStartDate: '2023-10-10',
+    });
+  });
+
+  test('workflow is triggered manually, without input content', async () => {
+    jest.useFakeTimers().setSystemTime(new Date(1698416923914));
+    checkMetadataWorkflowEvent.eventSource = '';
+    checkMetadataWorkflowEvent.scanEndDate = '';
+    checkMetadataWorkflowEvent.scanStartDate = '';
+    const resp = await handler(checkMetadataWorkflowEvent);
+    expect(resp).toEqual({
+      status: WorkflowStatus.CONTINUE,
+      scanEndDate: '2023-10-27',
+      jobStartTimestamp: 1698416923914,
+      scanStartDate: '',
+    });
+  });
+
+  test('workflow is triggered manually, with invalid input content', async () => {
+    jest.useFakeTimers().setSystemTime(new Date(1698416923914));
+    checkMetadataWorkflowEvent.eventSource = '';
+    checkMetadataWorkflowEvent.scanEndDate = '2023-10-271';
+    checkMetadataWorkflowEvent.scanStartDate = 'addd';
+    await expect(handler(checkMetadataWorkflowEvent)).rejects.toThrow('input scan date format is not yyyy-mm-dd');
+  });
+});

--- a/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/update-workflow-info.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/update-workflow-info.test.ts
@@ -1,0 +1,54 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { mockClient } from 'aws-sdk-client-mock';
+import { handler, UpdateWorkflowInfoEvent } from '../../../../../src/analytics/lambdas/scan-metadata-workflow/update-workflow-info';
+import 'aws-sdk-client-mock-jest';
+
+
+const updateWorkflowInfoEvent: UpdateWorkflowInfoEvent = {
+  lastJobStartTimestamp: 1698330523913,
+  lastScanEndDate: '2023-10-26',
+};
+
+describe('Lambda - check workflow start', () => {
+  const dynamoDBMock = mockClient(DynamoDBDocumentClient);
+  const s3ClientMock = mockClient(S3Client);
+
+  beforeEach(() => {
+    dynamoDBMock.reset();
+    s3ClientMock.reset();
+  });
+
+  test('update workflow information', async () => {
+    dynamoDBMock.on(PutCommand).resolvesOnce({});
+    s3ClientMock.on(PutObjectCommand).resolvesOnce({});
+    await handler(updateWorkflowInfoEvent);
+    expect(s3ClientMock).toHaveReceivedNthCommandWith(1, PutObjectCommand, {
+      Bucket: 'test-pipe-line-bucket',
+      Key: 'pipeline-prefix/scan-metadata-job-info/project1/workflow-job-info.json',
+      Body: '{\"lastJobStartTimestamp\":1698330523913,\"lastScanEndDate\":\"2023-10-26\"}',
+    });
+    expect(dynamoDBMock).toHaveReceivedNthCommandWith(1, PutCommand, {
+      TableName: 'ClickstreamAnalyticsMetadata',
+      Item: {
+        id: 'PROJECT_SUMMARY#project1',
+        month: '#000000',
+        latestScanDate: '2023-10-26T00:00:00.000Z',
+        lastJobStartTimestamp: 1698330523913,
+      },
+    });
+  });
+});

--- a/test/jestEnv.js
+++ b/test/jestEnv.js
@@ -45,4 +45,7 @@ process.env.ODS_EVENT_BUCKET_PREFIX='project1/raw/'
 process.env.REDSHIFT_ODS_TABLE_NAME='ods_external_events'
 process.env.REDSHIFT_ROLE = 'arn:aws:iam::xxxxxxxxxxxx:role/redshift-serverless-s3-copyrole'
 process.env.METADATA_DDB_TABLE_ARN = 'arn:aws:dynamodb:us-east-1:111122223333:table/ClickstreamAnalyticsMetadata';
+process.env.WORKFLOW_INFO_DDB_TABLE_ARN = 'arn:aws:dynamodb:us-east-1:111122223333:table/ScanMetadataWorkflowInfo';
+process.env.PIPELINE_S3_BUCKET_NAME = 'test-pipe-line-bucket';
+process.env.PIPELINE_S3_PREFIX = 'pipeline-prefix/';
 process.env.REDSHIFT_DATABASE = 'project1'


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Refactor scan metadata feature.

## Implementation highlights

Refactor scan metadata feature:
1. Scan metadata workflow is triggered from upstream workflow.  Upstream workflow change is in #361 
2. Check last time of job execution, trigger workflow if more than 24 hours have passed since the last job execution.
3. If workflow is triggered manually, can set scan start date as below:
```
{
  "startScanDate": "2023-10-02"
}
```
4. @tyyzqmf  Store the Metadata summary into ddb per project, example as below:
```
{
  "id": {
    "S": "PROJECT_SUMMARY#projectId"
  },
  "month": {
    "S": "#000000"
  },
  "lastJobStartTimestamp": {
    "N": "1698416223647"
  },
  "latestScanDate": {
    "S": "2023-10-27T00:00:00.000Z"
  }
}
```
5. Add below two stack parameters for workflow get the last EMR job's date range.
- PipelineS3Bucket
- PipelineS3Prefix

6. Add scan metadata workflow metric and alarm

## Test checklist

- [x] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [x] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend