### PR TITLE
fix: DDB ExpressionAttributeValues empty error

### DIFF
--- a/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-metadata-store.ts
+++ b/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-metadata-store.ts
@@ -213,7 +213,7 @@ export class DynamoDbMetadataStore implements MetadataStore {
       },
       UpdateExpression: updateExpression,
       ExpressionAttributeNames: expressionAttributeNames,
-      ExpressionAttributeValues: expressionAttributeValues,
+      ExpressionAttributeValues: Object.fromEntries(expressionAttributeValues),
       ReturnValues: 'ALL_NEW',
     });
     await docClient.send(params);

--- a/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-store.ts
+++ b/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-store.ts
@@ -226,7 +226,7 @@ export class DynamoDbStore implements ClickStreamStore {
       // Define expressions for the new or updated attributes
       UpdateExpression: updateExpression,
       ExpressionAttributeNames: expressionAttributeNames,
-      ExpressionAttributeValues: expressionAttributeValues,
+      ExpressionAttributeValues: Object.fromEntries(expressionAttributeValues),
       ReturnValues: 'ALL_NEW',
     });
     await docClient.send(params);
@@ -358,7 +358,7 @@ export class DynamoDbStore implements ClickStreamStore {
       // Define expressions for the new or updated attributes
       UpdateExpression: updateExpression,
       ExpressionAttributeNames: expressionAttributeNames,
-      ExpressionAttributeValues: expressionAttributeValues,
+      ExpressionAttributeValues: Object.fromEntries(expressionAttributeValues),
       ReturnValues: 'ALL_NEW',
     });
     await docClient.send(params);
@@ -747,7 +747,7 @@ export class DynamoDbStore implements ClickStreamStore {
       ExpressionAttributeNames: {
         '#prefix': 'prefix',
       },
-      ExpressionAttributeValues: expressionAttributeValues,
+      ExpressionAttributeValues: Object.fromEntries(expressionAttributeValues),
       ScanIndexForward: order === 'asc',
     };
     const records = await query(input);
@@ -929,7 +929,7 @@ export class DynamoDbStore implements ClickStreamStore {
       // Define expressions for the new or updated attributes
       UpdateExpression: updateExpression,
       ExpressionAttributeNames: expressionAttributeNames,
-      ExpressionAttributeValues: expressionAttributeValues,
+      ExpressionAttributeValues: Object.fromEntries(expressionAttributeValues),
       ReturnValues: 'ALL_NEW',
     });
     await docClient.send(params);
@@ -994,7 +994,7 @@ export class DynamoDbStore implements ClickStreamStore {
       ExpressionAttributeNames: {
         '#prefix': 'prefix',
       },
-      ExpressionAttributeValues: expressionAttributeValues,
+      ExpressionAttributeValues: Object.fromEntries(expressionAttributeValues),
       ScanIndexForward: order === 'asc',
     };
     const records = await query(input);
@@ -1102,7 +1102,7 @@ export class DynamoDbStore implements ClickStreamStore {
       // Define expressions for the new or updated attributes
       UpdateExpression: updateExpression,
       ExpressionAttributeNames: expressionAttributeNames,
-      ExpressionAttributeValues: expressionAttributeValues,
+      ExpressionAttributeValues: Object.fromEntries(expressionAttributeValues),
       ReturnValues: 'ALL_NEW',
     });
     await docClient.send(params);

--- a/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
@@ -403,12 +403,12 @@ function createPipelineMock(
   ddbMock.on(QueryCommand, {
     ExclusiveStartKey: undefined,
     ExpressionAttributeNames: { '#prefix': 'prefix' },
-    ExpressionAttributeValues: new Map<string, any>([
-      [':d', false],
-      [':prefix', 'PIPELINE'],
-      [':vt', 'latest'],
-      [':p', MOCK_PROJECT_ID],
-    ]),
+    ExpressionAttributeValues: {
+      ':d': false,
+      ':prefix': 'PIPELINE',
+      ':vt': 'latest',
+      ':p': MOCK_PROJECT_ID,
+    },
     FilterExpression: 'deleted = :d AND versionTag=:vt AND id = :p',
     IndexName: prefixTimeGSIName,
     KeyConditionExpression: '#prefix= :prefix',
@@ -458,10 +458,10 @@ function createPipelineMock(
   ddbMock.on(QueryCommand, {
     ExclusiveStartKey: undefined,
     ExpressionAttributeNames: { '#prefix': 'prefix' },
-    ExpressionAttributeValues: new Map<string, any>([
-      [':d', false],
-      [':prefix', 'PLUGIN'],
-    ]),
+    ExpressionAttributeValues: {
+      ':d': false,
+      ':prefix': 'PLUGIN',
+    },
     FilterExpression: 'deleted = :d',
     IndexName: prefixTimeGSIName,
     KeyConditionExpression: '#prefix= :prefix',

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -1017,10 +1017,10 @@ describe('Pipeline test', () => {
       ExclusiveStartKey: undefined,
       ExpressionAttributeNames:
         { '#prefix': 'prefix' },
-      ExpressionAttributeValues: new Map<string, any>([
-        [':d', false],
-        [':prefix', 'PLUGIN'],
-      ]),
+      ExpressionAttributeValues: {
+        ':d': false,
+        ':prefix': 'PLUGIN',
+      },
       FilterExpression: 'deleted = :d',
       KeyConditionExpression:
     '#prefix= :prefix',
@@ -1162,10 +1162,10 @@ describe('Pipeline test', () => {
       ExclusiveStartKey: undefined,
       ExpressionAttributeNames:
         { '#prefix': 'prefix' },
-      ExpressionAttributeValues: new Map<string, any>([
-        [':d', false],
-        [':prefix', 'PLUGIN'],
-      ]),
+      ExpressionAttributeValues: {
+        ':d': false,
+        ':prefix': 'PLUGIN',
+      },
       FilterExpression: 'deleted = :d',
       KeyConditionExpression:
         '#prefix= :prefix',
@@ -1277,12 +1277,12 @@ describe('Pipeline test', () => {
       ExclusiveStartKey: undefined,
       ExpressionAttributeNames:
         { '#prefix': 'prefix' },
-      ExpressionAttributeValues: new Map<string, any>([
-        [':d', false],
-        [':prefix', 'PIPELINE'],
-        [':vt', 'latest'],
-        [':p', MOCK_PROJECT_ID],
-      ]),
+      ExpressionAttributeValues: {
+        ':d': false,
+        ':prefix': 'PIPELINE',
+        ':vt': 'latest',
+        ':p': MOCK_PROJECT_ID,
+      },
       FilterExpression: 'deleted = :d AND versionTag=:vt AND id = :p',
       KeyConditionExpression: '#prefix= :prefix',
       Limit: undefined,
@@ -1297,10 +1297,10 @@ describe('Pipeline test', () => {
       ExclusiveStartKey: undefined,
       ExpressionAttributeNames:
         { '#prefix': 'prefix' },
-      ExpressionAttributeValues: new Map<string, any>([
-        [':d', false],
-        [':prefix', 'PLUGIN'],
-      ]),
+      ExpressionAttributeValues: {
+        ':d': false,
+        ':prefix': 'PLUGIN',
+      },
       FilterExpression: 'deleted = :d',
       KeyConditionExpression:
         '#prefix= :prefix',
@@ -1385,12 +1385,12 @@ describe('Pipeline test', () => {
       ExclusiveStartKey: undefined,
       ExpressionAttributeNames:
         { '#prefix': 'prefix' },
-      ExpressionAttributeValues: new Map<string, any>([
-        [':d', false],
-        [':prefix', 'PIPELINE'],
-        [':vt', 'latest'],
-        [':p', MOCK_PROJECT_ID],
-      ]),
+      ExpressionAttributeValues: {
+        ':d': false,
+        ':prefix': 'PIPELINE',
+        ':vt': 'latest',
+        ':p': MOCK_PROJECT_ID,
+      },
       FilterExpression: 'deleted = :d AND versionTag=:vt AND id = :p',
       KeyConditionExpression: '#prefix= :prefix',
       Limit: undefined,


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend