### PR TITLE
fix: empty embedding QuickSight iframe

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "@types/node": "^16.18.36",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",
-    "amazon-quicksight-embedding-sdk": "^2.2.2",
+    "amazon-quicksight-embedding-sdk": "2.3.1",
     "axios": "^1.4.0",
     "babel-jest": "^27.4.2",
     "babel-loader": "^8.2.3",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3953,12 +3953,11 @@ ajv@^8.0.0, ajv@^8.6.0, ajv@^8.9.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-amazon-quicksight-embedding-sdk@^2.2.2:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/amazon-quicksight-embedding-sdk/-/amazon-quicksight-embedding-sdk-2.4.0.tgz#9d620a039ba61eff2e753a0f2b57f9be31772125"
-  integrity sha512-z4WIyl3INY/YfKN3omBlVzFQQ0fb390S4x/95z1QGrINwaIcbvZ1sdjhpNTXqRmv3dYtiS82ofVZ0HI/UilYsQ==
+amazon-quicksight-embedding-sdk@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/amazon-quicksight-embedding-sdk/-/amazon-quicksight-embedding-sdk-2.3.1.tgz#88dde4a999307b844c5361f56455a49401e1af16"
+  integrity sha512-J0vgNuwx1F6CUDIsWvUfmvWgz47i+AwRV7wZLToBJ71DQc1gXn165SLwxHN221jVcGpBOPI1Ef8LVHdhMDk93g==
   dependencies:
-    "@babel/runtime" "^7.20.6"
     punycode "^2.1.1"
     uuid "^9.0.0"
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

lock embed sdk version. 

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend