### PR TITLE
feat: Reassign QuickSight users (PublishUser, ExploreUser)

### DIFF
--- a/frontend/public/locales/en-US/pipeline.json
+++ b/frontend/public/locales/en-US/pipeline.json
@@ -46,7 +46,6 @@
     "redshiftProvisionedClusterEmptyError": "Please select a cluster",
     "redshiftProvisionedDBUserEmptyError": "Please input the database user.",
     "redshiftProvisionedDBUserFormatError": "Database user format error",
-    "quickSightUserEmptyError": "Please select a QuickSight user.",
     "emailInvalid": "Email invalid."
   },
   "create": {
@@ -221,8 +220,6 @@
     "quickSightNotEnterprise": "QuickSight edition is not enterprise in your account",
     "quickSightNotEnterpriseDesc": "The solution dashboard need the QuickSight Enterprise, you can upgrade edition in QuickSight Management Console.",
     "quickSightSubscription": "Subscription",
-    "quickSightUser": "QuickSight user",
-    "quickSightUserDesc": "Select a QuickSight user for the solution to create datasets and analyses. Click “Create new” button to create a new user.",
     "quickSIghtPlaceholder": "Select a quicksight user",
     "ingestSettings": "Ingestion setting",
     "clusterSize": "Cluster Size",

--- a/frontend/public/locales/zh-CN/pipeline.json
+++ b/frontend/public/locales/zh-CN/pipeline.json
@@ -46,7 +46,6 @@
     "redshiftProvisionedClusterEmptyError": "请选择群集",
     "redshiftProvisionedDBUserEmptyError": "请输入数据库用户。",
     "redshiftProvisionedDBUserFormatError": "数据库用户格式错误",
-    "quickSightUserEmptyError": "请选择 QuickSight 用户。",
     "emailInvalid": "电子邮件无效。"
   },
   "create": {
@@ -221,8 +220,6 @@
     "quickSightNotEnterprise": "您的账户中的 QuickSight 版本不是企业版",
     "quickSightNotEnterpriseDesc": "解决方案控制面板需要 QuickSight Enterprise，你可以在 QuickSight 管理控制台中升级版本。",
     "quickSightSubscription": "订阅",
-    "quickSightUser": "QuickSight 用户",
-    "quickSightUserDesc": "为解决方案选择 QuickSight 用户以创建数据集和分析。单击 “新建” 按钮创建新用户。",
     "quickSIghtPlaceholder": "选择 quicksight 用户",
     "ingestSettings": "摄取设置",
     "clusterSize": "集群大小",

--- a/frontend/src/apis/resource.ts
+++ b/frontend/src/apis/resource.ts
@@ -98,11 +98,6 @@ const getQuickSightStatus = async () => {
   return result;
 };
 
-const getQuickSightUsers = async () => {
-  const result: any = await apiRequest('get', `/env/quicksight/users`);
-  return result;
-};
-
 const unsubscribQuickSight = async () => {
   const result: any = await apiRequest(
     'post',
@@ -120,14 +115,6 @@ const subscribQuickSight = async (params: {
     `/env/quicksight/subscription`,
     params
   );
-  return result;
-};
-
-const createQuickSightUser = async (params: {
-  email: string;
-  accountName: string;
-}) => {
-  const result: any = await apiRequest('post', `/env/quicksight/user`, params);
   return result;
 };
 
@@ -191,14 +178,12 @@ const checkServicesAvailable = async (params: { region: string }) => {
 
 export {
   fetchStatusWithType,
-  createQuickSightUser,
   get3AZVPCList,
   getCertificates,
   getHostedZoneList,
   getMSKList,
   getQuickSightDetail,
   getQuickSightStatus,
-  getQuickSightUsers,
   getRedshiftCluster,
   getRedshiftServerlessWorkgroup,
   getRegionList,

--- a/frontend/src/pages/analytics/dashboard/create/CreateDashboard.tsx
+++ b/frontend/src/pages/analytics/dashboard/create/CreateDashboard.tsx
@@ -84,7 +84,6 @@ const CreateDashboard: React.FC<CreateDashboardProps> = (
         projectId: projectId,
         appId: appId,
         region: pipeline.region,
-        ownerPrincipal: pipeline.reporting?.quickSight?.arn,
         defaultDataSourceArn:
           reportingOutputs.get(OUTPUT_REPORTING_QUICKSIGHT_DATA_SOURCE_ARN) ??
           '',

--- a/frontend/src/pages/pipelines/create/steps/Reporting.tsx
+++ b/frontend/src/pages/pipelines/create/steps/Reporting.tsx
@@ -13,30 +13,17 @@
 
 import {
   Alert,
-  Box,
-  Button,
   Container,
   FormField,
   Header,
-  Input,
   Link,
-  Modal,
-  Select,
-  SelectProps,
   SpaceBetween,
   Spinner,
   Toggle,
 } from '@cloudscape-design/components';
-import {
-  createQuickSightUser,
-  getQuickSightDetail,
-  getQuickSightStatus,
-  getQuickSightUsers,
-} from 'apis/resource';
+import { getQuickSightDetail, getQuickSightStatus } from 'apis/resource';
 import { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { MAX_USER_INPUT_LENGTH } from 'ts/const';
-import { EMAIL_PATTERN, XSS_PATTERN } from 'ts/constant-ln';
 import {
   buildDocumentLink,
   buildQuickSightSubscriptionLink,
@@ -45,15 +32,13 @@ import {
   PIPELINE_QUICKSIGHT_GUIDE_LINK_EN,
   PIPELINE_QUICKSIGHT_GUIDE_LINK_CN,
 } from 'ts/url';
-import { checkStringValidRegex, isDisabled } from 'ts/utils';
+import { isDisabled } from 'ts/utils';
 
 interface ReportingProps {
   update?: boolean;
   pipelineInfo: IExtPipeline;
   changeEnableReporting: (enable: boolean) => void;
-  changeQuickSightSelectedUser: (user: SelectProps.Option) => void;
   changeQuickSightAccountName: (accountName: string) => void;
-  quickSightUserEmptyError: boolean;
   changeLoadingQuickSight?: (loading: boolean) => void;
 }
 
@@ -63,24 +48,12 @@ const Reporting: React.FC<ReportingProps> = (props: ReportingProps) => {
     update,
     pipelineInfo,
     changeEnableReporting,
-    changeQuickSightSelectedUser,
     changeQuickSightAccountName,
-    quickSightUserEmptyError,
     changeLoadingQuickSight,
   } = props;
-  const [quickSightRoleOptions, setQuickSightRoleOptions] =
-    useState<SelectProps.Options>([]);
-  const [loadingUsers, setLoadingUsers] = useState(false);
-
   const [loadingQuickSight, setLoadingQuickSight] = useState(false);
-  const [loadingCreateUser, setLoadingCreateUser] = useState(false);
   const [quickSightEnabled, setQuickSightEnabled] = useState(false);
   const [quickSightEnterprise, setQuickSightEnterprise] = useState(false);
-  const [userActiveLink, setUserActiveLink] = useState('');
-
-  const [newUserEmail, setNewUserEmail] = useState('');
-  const [emailInvalid, setEmailInvalid] = useState(false);
-  const [showCreateUser, setShowCreateUser] = useState(false);
 
   // get quicksight details
   const getTheQuickSightDetail = async () => {
@@ -104,7 +77,7 @@ const Reporting: React.FC<ReportingProps> = (props: ReportingProps) => {
     }
   };
 
-  // get quicksight users
+  // get quicksight status
   const checkTheQuickSightStatus = async () => {
     setLoadingQuickSight(true);
     try {
@@ -120,64 +93,10 @@ const Reporting: React.FC<ReportingProps> = (props: ReportingProps) => {
     }
   };
 
-  // get quicksight users
-  const getQuickSightUserList = async () => {
-    setLoadingUsers(true);
-    try {
-      const { success, data }: ApiResponse<QuickSightUserResponse[]> =
-        await getQuickSightUsers();
-      if (success) {
-        const userOptions: SelectProps.Options = data.map((element) => ({
-          label: element.userName,
-          value: JSON.stringify(element),
-          description: element.email,
-          labelTag: element.role,
-        }));
-        setQuickSightRoleOptions(userOptions);
-        setLoadingUsers(false);
-      }
-    } catch (error) {
-      setLoadingUsers(false);
-    }
-  };
-
-  // create quicksight user
-  const createNewQuickSightUser = async () => {
-    if (!checkStringValidRegex(newUserEmail, new RegExp(EMAIL_PATTERN))) {
-      setEmailInvalid(true);
-      return;
-    }
-    setLoadingCreateUser(true);
-    try {
-      const { success, data }: ApiResponse<string> = await createQuickSightUser(
-        {
-          email: newUserEmail,
-          accountName: pipelineInfo.reporting.quickSight.accountName,
-        }
-      );
-      setLoadingCreateUser(false);
-      if (success && data) {
-        setNewUserEmail('');
-        setUserActiveLink(data);
-      }
-    } catch (error) {
-      setLoadingCreateUser(false);
-    }
-  };
-
-  const closeNewUserModal = () => {
-    setUserActiveLink('');
-    setShowCreateUser(false);
-  };
-
   useEffect(() => {
-    if (quickSightEnabled) {
-      getQuickSightUserList();
+    if (changeLoadingQuickSight) {
+      changeLoadingQuickSight(loadingQuickSight);
     }
-  }, [quickSightEnabled]);
-
-  useEffect(() => {
-    changeLoadingQuickSight && changeLoadingQuickSight(loadingQuickSight);
   }, [loadingQuickSight]);
 
   useEffect(() => {
@@ -204,9 +123,9 @@ const Reporting: React.FC<ReportingProps> = (props: ReportingProps) => {
               <Toggle
                 controlId="test-quicksight-id"
                 disabled={
-                  isDisabled(update, pipelineInfo) ||
-                  !pipelineInfo.serviceStatus?.QUICK_SIGHT ||
-                  !pipelineInfo.enableRedshift
+                  isDisabled(update, pipelineInfo) ??
+                  (!pipelineInfo.serviceStatus?.QUICK_SIGHT ||
+                    !pipelineInfo.enableRedshift)
                 }
                 onChange={({ detail }) => changeEnableReporting(detail.checked)}
                 checked={pipelineInfo.enableReporting}
@@ -270,129 +189,9 @@ const Reporting: React.FC<ReportingProps> = (props: ReportingProps) => {
                       {t('pipeline:create.quickSightNotEnterpriseDesc')}
                     </Alert>
                   )}
-
-                  {quickSightEnabled && quickSightEnterprise && (
-                    <>
-                      <FormField
-                        label={t('pipeline:create.quickSightUser')}
-                        description={t('pipeline:create.quickSightUserDesc')}
-                        errorText={
-                          quickSightUserEmptyError
-                            ? t('pipeline:valid.quickSightUserEmptyError')
-                            : ''
-                        }
-                      >
-                        <div className="flex">
-                          <div className="flex-1">
-                            <Select
-                              statusType={loadingUsers ? 'loading' : 'finished'}
-                              placeholder={
-                                t('pipeline:create.quickSIghtPlaceholder') || ''
-                              }
-                              selectedOption={
-                                pipelineInfo.selectedQuickSightUser
-                              }
-                              onChange={({ detail }) =>
-                                changeQuickSightSelectedUser(
-                                  detail.selectedOption
-                                )
-                              }
-                              options={quickSightRoleOptions}
-                              filteringType="auto"
-                            />
-                          </div>
-                          <div className="ml-10">
-                            <Button
-                              loading={loadingUsers}
-                              onClick={() => {
-                                getQuickSightUserList();
-                              }}
-                              iconName="refresh"
-                            />
-                          </div>
-                          <div className="ml-10">
-                            <Button
-                              onClick={() => {
-                                setShowCreateUser(true);
-                              }}
-                            >
-                              {t('button.createNew')}
-                            </Button>
-                          </div>
-                        </div>
-                      </FormField>
-                    </>
-                  )}
                 </>
               ))}
           </SpaceBetween>
-
-          {/* Create User Modal */}
-          <Modal
-            onDismiss={() => {
-              closeNewUserModal();
-            }}
-            visible={showCreateUser}
-            footer={
-              <Box float="right">
-                <SpaceBetween direction="horizontal" size="xs">
-                  <Button
-                    variant="link"
-                    onClick={() => {
-                      closeNewUserModal();
-                    }}
-                  >
-                    {t('button.close')}
-                  </Button>
-                </SpaceBetween>
-              </Box>
-            }
-            header={t('pipeline:create.createQSUser')}
-          >
-            <FormField
-              label={t('pipeline:create.qsUserEmail')}
-              description={t('pipeline:create.qsCreateUserDesc')}
-              errorText={emailInvalid ? t('pipeline:valid.emailInvalid') : ''}
-            >
-              <div className="flex">
-                <div className="flex-1">
-                  <Input
-                    placeholder="email@example.com"
-                    value={newUserEmail}
-                    onChange={(e) => {
-                      setEmailInvalid(false);
-                      if (
-                        new RegExp(XSS_PATTERN).test(e.detail.value) ||
-                        e.detail.value.length > MAX_USER_INPUT_LENGTH
-                      ) {
-                        return false;
-                      }
-                      setNewUserEmail(e.detail.value);
-                    }}
-                  />
-                </div>
-                <div className="ml-10">
-                  <Button
-                    loading={loadingCreateUser}
-                    onClick={() => {
-                      createNewQuickSightUser();
-                    }}
-                  >
-                    {t('button.create')}
-                  </Button>
-                </div>
-              </div>
-              <div className="mt-10">
-                {userActiveLink && (
-                  <Alert header={t('pipeline:create.qsUserActive')}>
-                    <Link external href={userActiveLink}>
-                      {userActiveLink}
-                    </Link>
-                  </Alert>
-                )}
-              </div>
-            </FormField>
-          </Modal>
         </>
       ) : (
         <Alert header={t('pipeline:create.reportNotSupported')}>

--- a/frontend/src/pages/pipelines/detail/comps/Reporting.tsx
+++ b/frontend/src/pages/pipelines/detail/comps/Reporting.tsx
@@ -97,12 +97,6 @@ const Reporting: React.FC<TabContentProps> = (props: TabContentProps) => {
                 {pipelineInfo?.reporting?.quickSight?.accountName || '-'}
               </div>
             </div>
-            <div>
-              <Box variant="awsui-key-label">
-                {t('pipeline:create.quickSightUser')}
-              </Box>
-              <div>{pipelineInfo?.reporting?.quickSight?.user || '-'}</div>
-            </div>
           </SpaceBetween>
         </>
       )}

--- a/frontend/src/ts/init.ts
+++ b/frontend/src/ts/init.ts
@@ -142,8 +142,6 @@ export const INIT_EXT_PIPELINE_DATA: IExtPipeline = {
   reporting: {
     quickSight: {
       accountName: '',
-      user: '',
-      arn: '',
     },
   },
 
@@ -180,7 +178,6 @@ export const INIT_EXT_PIPELINE_DATA: IExtPipeline = {
   selectedTransformPlugins: [],
   selectedEnrichPlugins: [],
   enableReporting: true,
-  selectedQuickSightUser: null,
   arnAccountId: '',
   enableAuthentication: false,
   redshiftType: 'serverless',

--- a/frontend/src/types/analytics.d.ts
+++ b/frontend/src/types/analytics.d.ts
@@ -197,7 +197,6 @@ declare global {
     readonly description: string;
     readonly region: string;
     readonly sheets: IAnalyticsDashboardSheet[];
-    readonly ownerPrincipal: string;
     readonly defaultDataSourceArn: string;
     readonly embedUrl?: string;
 

--- a/frontend/src/types/pipeline.d.ts
+++ b/frontend/src/types/pipeline.d.ts
@@ -155,8 +155,6 @@ declare global {
     reporting: {
       quickSight: {
         accountName: string;
-        user: string;
-        arn: string;
       };
     };
     status?: {
@@ -218,7 +216,6 @@ declare global {
     selectedEnrichPlugins: IPlugin[];
 
     enableReporting: boolean;
-    selectedQuickSightUser: SelectProps.Option | null;
     arnAccountId: string;
     enableAuthentication: boolean;
 

--- a/frontend/src/types/resources.d.ts
+++ b/frontend/src/types/resources.d.ts
@@ -110,14 +110,6 @@ declare global {
       | 'VALIDATION_TIMED_OUT';
   }
 
-  interface QuickSightUserResponse {
-    active: boolean;
-    arn: string;
-    email: string;
-    role: string;
-    userName: string;
-  }
-
   interface SubscribeQuickSightResponse {
     IAMUser: boolean;
     accountName: string;

--- a/frontend/test/msk-redshift.test.tsx
+++ b/frontend/test/msk-redshift.test.tsx
@@ -137,13 +137,9 @@ describe('Test data processing settings', () => {
         changeEnableReporting={() => {
           return;
         }}
-        changeQuickSightSelectedUser={() => {
-          return;
-        }}
         changeQuickSightAccountName={() => {
           return;
         }}
-        quickSightUserEmptyError={false}
       />
     );
 
@@ -265,13 +261,9 @@ describe('Test redsfhit settings', () => {
         changeEnableReporting={() => {
           return;
         }}
-        changeQuickSightSelectedUser={() => {
-          return;
-        }}
         changeQuickSightAccountName={() => {
           return;
         }}
-        quickSightUserEmptyError={false}
       />
     );
 
@@ -395,13 +387,9 @@ describe('Test redsfhit settings', () => {
         changeEnableReporting={() => {
           return;
         }}
-        changeQuickSightSelectedUser={() => {
-          return;
-        }}
         changeQuickSightAccountName={() => {
           return;
         }}
-        quickSightUserEmptyError={false}
       />
     );
 
@@ -527,13 +515,9 @@ describe('Test MSK kafkaConnector settings', () => {
         changeEnableReporting={() => {
           return;
         }}
-        changeQuickSightSelectedUser={() => {
-          return;
-        }}
         changeQuickSightAccountName={() => {
           return;
         }}
-        quickSightUserEmptyError={false}
       />
     );
 
@@ -668,13 +652,9 @@ describe('Test MSK kafkaConnector settings', () => {
         changeEnableReporting={() => {
           return;
         }}
-        changeQuickSightSelectedUser={() => {
-          return;
-        }}
         changeQuickSightAccountName={() => {
           return;
         }}
-        quickSightUserEmptyError={false}
       />
     );
 

--- a/frontend/test/service-available.test.tsx
+++ b/frontend/test/service-available.test.tsx
@@ -407,13 +407,9 @@ describe('Test QuickSight service available', () => {
         changeEnableReporting={() => {
           return;
         }}
-        changeQuickSightSelectedUser={() => {
-          return;
-        }}
         changeQuickSightAccountName={() => {
           return;
         }}
-        quickSightUserEmptyError={false}
       />
     );
 
@@ -455,13 +451,9 @@ describe('Test QuickSight service available', () => {
         changeEnableReporting={() => {
           return;
         }}
-        changeQuickSightSelectedUser={() => {
-          return;
-        }}
         changeQuickSightAccountName={() => {
           return;
         }}
-        quickSightUserEmptyError={false}
       />
     );
 

--- a/frontend/test/update-pipeline.test.tsx
+++ b/frontend/test/update-pipeline.test.tsx
@@ -142,13 +142,9 @@ describe('Test update pipeline when not eanble data processing or data modeling'
         changeEnableReporting={() => {
           return;
         }}
-        changeQuickSightSelectedUser={() => {
-          return;
-        }}
         changeQuickSightAccountName={() => {
           return;
         }}
-        quickSightUserEmptyError={false}
       />
     );
 
@@ -279,13 +275,9 @@ describe('Test update pipeline when not eanble data processing or data modeling'
         changeEnableReporting={() => {
           return;
         }}
-        changeQuickSightSelectedUser={() => {
-          return;
-        }}
         changeQuickSightAccountName={() => {
           return;
         }}
-        quickSightUserEmptyError={false}
       />
     );
 

--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -46,7 +46,7 @@ import { StackManager } from '../service/stack';
 import { describeStack } from '../store/aws/cloudformation';
 import { listMSKClusterBrokers } from '../store/aws/kafka';
 
-import { registerClickstreamUser } from '../store/aws/quicksight';
+import { QuickSightUserArns, registerClickstreamUser } from '../store/aws/quicksight';
 import { getRedshiftInfo } from '../store/aws/redshift';
 import { ClickStreamStore } from '../store/click-stream-store';
 import { DynamoDbStore } from '../store/dynamodb/dynamodb-store';
@@ -167,8 +167,6 @@ export interface DataModeling {
 export interface Reporting {
   readonly quickSight?: {
     readonly accountName: string;
-    readonly user: string;
-    readonly arn: string;
     readonly namespace?: string;
     readonly vpcConnection?: string;
   };
@@ -235,6 +233,7 @@ export interface CPipelineResources {
   solution?: IDictionary;
   templates?: IDictionary;
   quickSightSubnetIds?: string[];
+  quickSightUser?: QuickSightUserArns;
 }
 
 export class CPipeline {
@@ -436,7 +435,11 @@ export class CPipeline {
     }
 
     if (this.pipeline.reporting) {
-      await registerClickstreamUser();
+      const quickSightUser = await registerClickstreamUser();
+      this.resources = {
+        ...this.resources,
+        quickSightUser: quickSightUser,
+      };
     }
   }
 

--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -1111,9 +1111,9 @@ export class CReportingStack extends JSONObject {
       _pipeline: pipeline,
       _resources: resources,
 
-      QuickSightUserParam: pipeline.reporting?.quickSight?.user,
+      QuickSightUserParam: resources.quickSightUser?.publishUserName,
       QuickSightNamespaceParam: pipeline.reporting?.quickSight?.namespace,
-      QuickSightPrincipalParam: pipeline.reporting?.quickSight?.arn,
+      QuickSightPrincipalParam: resources.quickSightUser?.publishUserArn,
       RedshiftDBParam: pipeline.projectId,
       RedShiftDBSchemaParam: resources.appIds?.join(','),
       QuickSightVpcConnectionSubnetParam: resources.quickSightSubnetIds?.join(','),

--- a/src/control-plane/backend/lambda/api/router/project.ts
+++ b/src/control-plane/backend/lambda/api/router/project.ts
@@ -47,7 +47,6 @@ router_project.post(
   '/:projectId/:appId/dashboard',
   validate([
     body().custom(isValidEmpty).custom(isXSSRequest),
-    body('ownerPrincipal').custom(isValidEmpty),
     body('defaultDataSourceArn').custom(isValidEmpty),
     param('projectId').custom(isProjectExisted),
     header('X-Click-Stream-Request-Id').custom(isRequestIdExisted),

--- a/src/control-plane/backend/lambda/api/service/project.ts
+++ b/src/control-plane/backend/lambda/api/service/project.ts
@@ -84,7 +84,7 @@ export class ProjectServ {
 
   public async createDashboard(req: any, res: any, next: any) {
     try {
-      const dashboardId = uuidv4().replace(/-/g, '');
+      const dashboardId = `clickstream-analysis-${uuidv4().replace(/-/g, '')}`;
       req.body.id = dashboardId;
       req.body.operator = res.get('X-Click-Stream-Operator');
       const dashboard: IDashboard = req.body;

--- a/src/control-plane/backend/lambda/api/service/project.ts
+++ b/src/control-plane/backend/lambda/api/service/project.ts
@@ -148,7 +148,7 @@ export class ProjectServ {
           ParameterDeclarations: [],
         },
         Permissions: [{
-          Principal: principals.dashboardOwner,
+          Principal: principals.publishUserArn,
           Actions: [
             'quicksight:DescribeDashboard',
             'quicksight:ListDashboardVersions',
@@ -158,12 +158,6 @@ export class ProjectServ {
             'quicksight:UpdateDashboardPermissions',
             'quicksight:DescribeDashboardPermissions',
             'quicksight:UpdateDashboardPublishedVersion',
-          ],
-        },
-        {
-          Principal: principals.embedOwner,
-          Actions: [
-            'quicksight:DescribeDashboard', 'quicksight:QueryDashboard', 'quicksight:ListDashboardVersions',
           ],
         }],
       };
@@ -243,7 +237,7 @@ export class ProjectServ {
       const embed = await generateEmbedUrlForRegisteredUser(
         latestPipeline.region,
         allowedDomain,
-        false,
+        true,
       );
       return res.json(new ApiSuccess(embed));
     } catch (error) {

--- a/src/control-plane/backend/lambda/api/service/reporting.ts
+++ b/src/control-plane/backend/lambda/api/service/reporting.ts
@@ -623,7 +623,7 @@ export class ReportingService {
     for (const datasetProps of datasetPropsArray) {
       const datasetOutput = await createDataSet(
         quickSight, awsAccountId!,
-        principals.dashboardOwner,
+        principals.exploreUserArn,
         dashboardCreateParameters.quickSight.dataSourceArn,
         datasetProps,
       );
@@ -771,7 +771,7 @@ export class ReportingService {
       AnalysisId: analysisId,
       Name: `${resourceName}`,
       Permissions: [{
-        Principal: principals.dashboardOwner,
+        Principal: principals.exploreUserArn,
         Actions: [
           'quicksight:DescribeAnalysis',
           'quicksight:QueryAnalysis',
@@ -792,7 +792,7 @@ export class ReportingService {
       DashboardId: dashboardId,
       Name: `${resourceName}`,
       Permissions: [{
-        Principal: principals.dashboardOwner,
+        Principal: principals.exploreUserArn,
         Actions: [
           'quicksight:DescribeDashboard',
           'quicksight:ListDashboardVersions',
@@ -802,12 +802,6 @@ export class ReportingService {
           'quicksight:UpdateDashboardPermissions',
           'quicksight:DescribeDashboardPermissions',
           'quicksight:UpdateDashboardPublishedVersion',
-        ],
-      },
-      {
-        Principal: principals.embedOwner,
-        Actions: [
-          'quicksight:DescribeDashboard', 'quicksight:QueryDashboard', 'quicksight:ListDashboardVersions',
         ],
       }],
       Definition: dashboard,

--- a/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
@@ -46,6 +46,7 @@ import {
   DataSetImportMode,
   SheetDefinition,
   ResourcePermission,
+  CreateFolderCommandOutput,
 } from '@aws-sdk/client-quicksight';
 import { APIRoleName, awsAccountId, awsRegion, QUICKSIGHT_CONTROL_PLANE_REGION, QUICKSIGHT_EMBED_NO_REPLY_EMAIL, QuickSightEmbedRoleArn } from '../../common/constants';
 import { getPaginatedResults } from '../../common/paginator';
@@ -407,7 +408,7 @@ export const searchFolder = async (
     }
     return;
   } catch (err) {
-    logger.error('Create Folder Error.', { err });
+    logger.error('Search Folder Error.', { err });
     throw err;
   }
 };
@@ -415,7 +416,7 @@ export const searchFolder = async (
 export const createFolder = async (
   region: string,
   name: string,
-): Promise<string | undefined> => {
+): Promise<CreateFolderCommandOutput> => {
   try {
     const quickSightClient = sdkClient.QuickSightClient({
       region: region,
@@ -425,8 +426,7 @@ export const createFolder = async (
       FolderId: randomUUID(),
       Name: name,
     });
-    const res = await quickSightClient.send(command);
-    return res.FolderId;
+    return await quickSightClient.send(command);
   } catch (err) {
     logger.error('Create Folder Error.', { err });
     throw err;
@@ -458,7 +458,8 @@ export const moveToFolder = async (
   try {
     let folderId = await searchFolder(region, folderName);
     if (!folderId) {
-      folderId = await createFolder(region, folderName);
+      const folderRes = await createFolder(region, folderName);
+      folderId = folderRes.FolderId;
     }
     await createFolderMembership(
       region,

--- a/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
@@ -441,6 +441,13 @@ export const createProjectFolder = async (
     });
     return await quickSightClient.send(command);
   } catch (err) {
+    if (err instanceof ResourceExistsException) {
+      const res: CreateFolderCommandOutput = {
+        $metadata: {},
+        FolderId: getFolderIdFromProjectId(projectId),
+      };
+      return res;
+    }
     logger.error('Create Folder Error.', { err });
     throw err;
   }
@@ -469,12 +476,8 @@ export const moveToProjectFolder = async (
   resourceType: MemberType,
 ): Promise<any> => {
   try {
-    const folderId = getFolderIdFromProjectId(projectId);
-    const folder = await describeFolder(region, folderId);
-    if (!folder || !folder.Folder) {
-      console.log(region, projectId);
-      await createProjectFolder(region, projectId);
-    }
+    const folder = await createProjectFolder(region, projectId);
+    const folderId = folder.FolderId;
     await createFolderMembership(
       region,
       {

--- a/src/control-plane/backend/lambda/api/test/api/analytics-dashboard.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/analytics-dashboard.test.ts
@@ -93,11 +93,6 @@ describe('Analytics dashboard test', () => {
         {
           location: 'body',
           msg: 'Value is empty.',
-          param: 'ownerPrincipal',
-        },
-        {
-          location: 'body',
-          msg: 'Value is empty.',
           param: 'defaultDataSourceArn',
         },
       ],

--- a/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
@@ -624,8 +624,6 @@ export const KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_QUICKSIGHT_PIPELINE: I
   reporting: {
     quickSight: {
       accountName: 'clickstream-acc-xxx',
-      user: 'Admin/clickstream-user-xxx',
-      arn: 'arn:aws:quicksight:us-west-2:555555555555:user/default/clickstream-user-xxx',
     },
   },
 };
@@ -671,8 +669,6 @@ export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_QUICKSIGHT_PIPELINE: IPipeline
   reporting: {
     quickSight: {
       accountName: 'clickstream-acc-xxx',
-      user: 'clickstream-user-xxx@example.com',
-      arn: 'arn:aws:quicksight:us-west-2:555555555555:user/default/clickstream-user-xxx',
     },
   },
 };

--- a/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
@@ -769,7 +769,7 @@ export const MSK_DATA_PROCESSING_PROVISIONED_REDSHIFT_DATAANALYTICS_PARAMETERS =
 const BASE_REPORTING_PARAMETERS = [
   {
     ParameterKey: 'QuickSightUserParam',
-    ParameterValue: 'Admin/clickstream-user-xxx',
+    ParameterValue: 'QuickSightEmbeddingRole/ClickstreamPublishUser',
   },
   {
     ParameterKey: 'QuickSightNamespaceParam',
@@ -777,7 +777,7 @@ const BASE_REPORTING_PARAMETERS = [
   },
   {
     ParameterKey: 'QuickSightPrincipalParam',
-    ParameterValue: 'arn:aws:quicksight:us-west-2:555555555555:user/default/clickstream-user-xxx',
+    ParameterValue: 'arn:aws:quicksight:us-east-1:555555555555:user/default/QuickSightEmbeddingRole/ClickstreamPublishUser',
   },
   {
     ParameterKey: 'RedshiftDBParam',
@@ -821,7 +821,7 @@ export const REPORTING_WITH_PROVISIONED_REDSHIFT_PARAMETERS = [
 export const REPORTING_WITH_NEW_REDSHIFT_PARAMETERS = [
   {
     ParameterKey: 'QuickSightUserParam',
-    ParameterValue: 'clickstream-user-xxx@example.com',
+    ParameterValue: 'QuickSightEmbeddingRole/ClickstreamPublishUser',
   },
   {
     ParameterKey: 'QuickSightNamespaceParam',
@@ -829,7 +829,7 @@ export const REPORTING_WITH_NEW_REDSHIFT_PARAMETERS = [
   },
   {
     ParameterKey: 'QuickSightPrincipalParam',
-    ParameterValue: 'arn:aws:quicksight:us-west-2:555555555555:user/default/clickstream-user-xxx',
+    ParameterValue: 'arn:aws:quicksight:us-east-1:555555555555:user/default/QuickSightEmbeddingRole/ClickstreamPublishUser',
   },
   {
     ParameterKey: 'RedshiftDBParam',

--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -855,7 +855,7 @@ const createFolder = async (quickSight: QuickSight, awsAccountId: string, princi
               'quicksight:DescribeFolderPermissions',
               'quicksight:UpdateFolderPermissions',
             ],
-          }
+          },
         ],
       });
     }

--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -27,8 +27,6 @@ import {
   DeleteDashboardCommandOutput,
   GeoSpatialDataRole,
   DataSetImportMode,
-  FilterOperator,
-  FolderFilterAttribute,
   MemberType,
 } from '@aws-sdk/client-quicksight';
 import { Context, CloudFormationCustomResourceEvent, CloudFormationCustomResourceUpdateEvent, CloudFormationCustomResourceCreateEvent, CloudFormationCustomResourceDeleteEvent, CdkCustomResourceResponse } from 'aws-lambda';

--- a/test/jestEnv.js
+++ b/test/jestEnv.js
@@ -27,6 +27,7 @@ process.env.PREFIX_TIME_GSI_NAME = 'prefix-time-gsi-name'
 process.env.CLICK_STREAM_TABLE_NAME = 'click-stream-table-name'
 process.env.ANALYTICS_METADATA_TABLE_NAME = 'analytics-metadata-table-name'
 process.env.DICTIONARY_TABLE_NAME = 'dictionary-table-name'
+process.env.QUICKSIGHT_EMBED_ROLE_ARN = 'arn:aws:iam::555555555555:role/QuickSightEmbeddingRole'
 
 // controlplane bundling
 process.env.IS_SKIP_ASSET_BUNDLE = 'true'

--- a/test/reporting/quicksight/lambda/quicksight-resource.test.ts
+++ b/test/reporting/quicksight/lambda/quicksight-resource.test.ts
@@ -15,21 +15,15 @@ import {
   CreateAnalysisCommand,
   CreateDashboardCommand,
   CreateDataSetCommand,
-  CreateFolderCommand,
-  CreateFolderMembershipCommand,
   DeleteAnalysisCommand,
   DeleteDashboardCommand,
   DeleteDataSetCommand,
-  DeleteFolderCommand,
-  DeleteFolderMembershipCommand,
   DescribeAnalysisCommand,
   DescribeDashboardCommand,
   DescribeDataSetCommand,
-  ListFolderMembersCommand,
   QuickSightClient,
   ResourceExistsException,
   ResourceNotFoundException,
-  DescribeFolderCommand,
   UpdateAnalysisCommand,
   UpdateDashboardCommand,
   UpdateDataSetCommand,
@@ -247,15 +241,7 @@ describe('QuickSight Lambda function', () => {
   });
 
   test('Create QuickSight dashboard - Empty app ids', async () => {
-    quickSightClientMock.on(DescribeFolderCommand).resolves({
-      Folder: undefined,
-    });
-    quickSightClientMock.on(CreateFolderCommand).resolves({});
-    quickSightClientMock.on(CreateFolderMembershipCommand).resolves({});
     const resp = await handler(emptyAppIdEvent, context) as CdkCustomResourceResponse;
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeFolderCommand, 1);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderCommand, 1);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 0);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateDataSetCommand, 0);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateAnalysisCommand, 0);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateDashboardCommand, 0);
@@ -302,16 +288,8 @@ describe('QuickSight Lambda function', () => {
       DashboardId: 'dashboard_0',
       Status: 200,
     });
-    quickSightClientMock.on(DescribeFolderCommand).resolves({
-      Folder: undefined,
-    });
-    quickSightClientMock.on(CreateFolderCommand).resolves({});
-    quickSightClientMock.on(CreateFolderMembershipCommand).resolves({});
 
     const resp = await handler(basicEvent, context) as CdkCustomResourceResponse;
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeFolderCommand, 1);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderCommand, 1);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 4);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeAnalysisCommand, 1);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeDashboardCommand, 1);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeDataSetCommand, 2);
@@ -399,20 +377,8 @@ describe('QuickSight Lambda function', () => {
       DashboardId: 'dashboard_1',
       Status: 200,
     });
-    quickSightClientMock.on(DescribeFolderCommand).resolvesOnce({
-      Folder: undefined,
-    }).resolves({
-      Folder: {
-        FolderId: 'clickstream_folder_xxx',
-      },
-    });
-    quickSightClientMock.on(CreateFolderCommand).resolves({});
-    quickSightClientMock.on(CreateFolderMembershipCommand).resolves({});
 
     const resp = await handler(multiAppIdEvent, context) as CdkCustomResourceResponse;
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeFolderCommand, 1);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderCommand, 1);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 8);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeAnalysisCommand, 2);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeDashboardCommand, 2);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeDataSetCommand, 4);
@@ -434,21 +400,10 @@ describe('QuickSight Lambda function', () => {
   });
 
   test('Create QuickSight dashboard - dataset already exist', async () => {
-
-    quickSightClientMock.on(DescribeFolderCommand).resolvesOnce({
-      Folder: {
-        FolderId: 'clickstream_folder_xxx',
-      },
-    });
-    quickSightClientMock.on(CreateFolderCommand).resolves({});
-    quickSightClientMock.on(CreateFolderMembershipCommand).resolves({});
     quickSightClientMock.on(CreateDataSetCommand).rejectsOnce(existError);
     try {
       await handler(basicEvent, context);
     } catch (e) {
-      expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeFolderCommand, 1);
-      expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderCommand, 0);
-      expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 0);
       expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateDataSetCommand, 1);
       expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateAnalysisCommand, 0);
       expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateDashboardCommand, 0);
@@ -459,14 +414,6 @@ describe('QuickSight Lambda function', () => {
   });
 
   test('Create QuickSight dashboard - analysis already exist', async () => {
-
-    quickSightClientMock.on(DescribeFolderCommand).resolvesOnce({
-      Folder: {
-        FolderId: 'clickstream_folder_xxx',
-      },
-    });
-    quickSightClientMock.on(CreateFolderCommand).resolves({});
-    quickSightClientMock.on(CreateFolderMembershipCommand).resolves({});
     quickSightClientMock.on(DescribeDataSetCommand).resolvesOnce({
       DataSet: {
         DataSetId: 'dataset_0',
@@ -490,9 +437,6 @@ describe('QuickSight Lambda function', () => {
     try {
       await handler(basicEvent, context);
     } catch (e) {
-      expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeFolderCommand, 1);
-      expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderCommand, 0);
-      expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 0);
       expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateDataSetCommand, 2);
       expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateAnalysisCommand, 1);
       expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateDashboardCommand, 0);
@@ -504,14 +448,6 @@ describe('QuickSight Lambda function', () => {
   });
 
   test('Create QuickSight dashboard - dashboard already exist', async () => {
-
-    quickSightClientMock.on(DescribeFolderCommand).resolvesOnce({
-      Folder: {
-        FolderId: 'clickstream_folder_xxx',
-      },
-    });
-    quickSightClientMock.on(CreateFolderCommand).resolves({});
-    quickSightClientMock.on(CreateFolderMembershipCommand).resolves({});
     quickSightClientMock.on(DescribeDataSetCommand).resolvesOnce({
       DataSet: {
         DataSetId: 'dataset_0',
@@ -545,9 +481,6 @@ describe('QuickSight Lambda function', () => {
     try {
       await handler(basicEvent, context);
     } catch (e) {
-      expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeFolderCommand, 1);
-      expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderCommand, 0);
-      expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 0);
       expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateDataSetCommand, 2);
       expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateAnalysisCommand, 1);
       expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateDashboardCommand, 1);
@@ -571,26 +504,7 @@ describe('QuickSight Lambda function', () => {
     quickSightClientMock.on(DescribeDashboardCommand).rejects(notExistError);
     quickSightClientMock.on(DeleteDashboardCommand).resolves({});
 
-    quickSightClientMock.on(ListFolderMembersCommand).resolves({
-      FolderMemberList: [
-        {
-          MemberId: 'clickstream_dataset_a',
-        },
-        {
-          MemberId: 'clickstream_analysis_',
-        },
-        {
-          MemberId: 'clickstream_dashboard_',
-        },
-      ],
-    });
-    quickSightClientMock.on(DeleteFolderCommand).resolves({});
-    quickSightClientMock.on(DeleteFolderMembershipCommand).resolves({});
-
     const resp = await handler(deleteEvent, context) as CdkCustomResourceResponse;
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(ListFolderMembersCommand, 5);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(DeleteFolderCommand, 1);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(DeleteFolderMembershipCommand, 3);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeDataSetCommand, 2);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(DeleteDataSetCommand, 2);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateDataSetCommand, 0);
@@ -795,17 +709,7 @@ describe('QuickSight Lambda function', () => {
         DashboardId: 'dashboard_0',
       },
     });
-
-    quickSightClientMock.on(DescribeFolderCommand).resolves({
-      Folder: undefined,
-    });
-    quickSightClientMock.on(CreateFolderCommand).resolves({});
-    quickSightClientMock.on(CreateFolderMembershipCommand).resolves({});
-
     const resp = await handler(updateFromEmptyEvent, context) as CdkCustomResourceResponse;
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeFolderCommand, 0);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderCommand, 0);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 4);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeAnalysisCommand, 1);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeDashboardCommand, 1);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeDataSetCommand, 2);
@@ -921,37 +825,7 @@ describe('QuickSight Lambda function', () => {
     quickSightClientMock.on(DeleteDashboardCommand).resolvesOnce({});
     quickSightClientMock.on(DescribeDashboardCommand).rejectsOnce(notExistError);
 
-    quickSightClientMock.on(DescribeFolderCommand).resolvesOnce({
-      Folder: {
-        FolderId: 'clickstream_folder_xxx',
-      },
-    });
-    quickSightClientMock.on(CreateFolderCommand).resolves({});
-    quickSightClientMock.on(CreateFolderMembershipCommand).resolves({});
-
-    quickSightClientMock.on(ListFolderMembersCommand).resolves({
-      FolderMemberList: [
-        {
-          MemberId: 'clickstream_dataset_a',
-        },
-        {
-          MemberId: 'clickstream_analysis_',
-        },
-        {
-          MemberId: 'clickstream_dashboard_',
-        },
-      ],
-    });
-    quickSightClientMock.on(DeleteFolderCommand).resolves({});
-    quickSightClientMock.on(DeleteFolderMembershipCommand).resolves({});
-
     const resp = await handler(multiSchemaUpdateWithDeleteEvent, context) as CdkCustomResourceResponse;
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeFolderCommand, 0);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderCommand, 0);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 0);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(ListFolderMembersCommand, 4);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(DeleteFolderCommand, 0);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(DeleteFolderMembershipCommand, 0);
 
     expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeAnalysisCommand, 1);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeDashboardCommand, 1);
@@ -1035,37 +909,7 @@ describe('QuickSight Lambda function', () => {
       })
       .rejectsOnce(notExistError);
 
-    quickSightClientMock.on(DescribeFolderCommand).resolvesOnce({
-      Folder: {
-        FolderId: 'clickstream_folder_xxx',
-      },
-    });
-    quickSightClientMock.on(CreateFolderCommand).resolves({});
-    quickSightClientMock.on(CreateFolderMembershipCommand).resolves({});
-
-    quickSightClientMock.on(ListFolderMembersCommand).resolves({
-      FolderMemberList: [
-        {
-          MemberId: 'clickstream_dataset_a',
-        },
-        {
-          MemberId: 'clickstream_analysis_',
-        },
-        {
-          MemberId: 'clickstream_dashboard_',
-        },
-      ],
-    });
-    quickSightClientMock.on(DeleteFolderCommand).resolves({});
-    quickSightClientMock.on(DeleteFolderMembershipCommand).resolves({});
-
     const resp = await handler(multiSchemaUpdateWithDeleteAndCreateEvent, context) as CdkCustomResourceResponse;
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeFolderCommand, 0);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderCommand, 0);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 4);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(ListFolderMembersCommand, 4);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(DeleteFolderCommand, 0);
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(DeleteFolderMembershipCommand, 0);
 
     expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeAnalysisCommand, 2);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeDashboardCommand, 2);

--- a/test/reporting/quicksight/lambda/quicksight-resource.test.ts
+++ b/test/reporting/quicksight/lambda/quicksight-resource.test.ts
@@ -29,7 +29,7 @@ import {
   QuickSightClient,
   ResourceExistsException,
   ResourceNotFoundException,
-  SearchFoldersCommand,
+  DescribeFolderCommand,
   UpdateAnalysisCommand,
   UpdateDashboardCommand,
   UpdateDataSetCommand,
@@ -247,13 +247,13 @@ describe('QuickSight Lambda function', () => {
   });
 
   test('Create QuickSight dashboard - Empty app ids', async () => {
-    quickSightClientMock.on(SearchFoldersCommand).resolves({
-      FolderSummaryList: [],
+    quickSightClientMock.on(DescribeFolderCommand).resolves({
+      Folder: undefined,
     });
     quickSightClientMock.on(CreateFolderCommand).resolves({});
     quickSightClientMock.on(CreateFolderMembershipCommand).resolves({});
     const resp = await handler(emptyAppIdEvent, context) as CdkCustomResourceResponse;
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(SearchFoldersCommand, 1);
+    expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeFolderCommand, 1);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderCommand, 1);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 0);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateDataSetCommand, 0);
@@ -302,14 +302,14 @@ describe('QuickSight Lambda function', () => {
       DashboardId: 'dashboard_0',
       Status: 200,
     });
-    quickSightClientMock.on(SearchFoldersCommand).resolves({
-      FolderSummaryList: [],
+    quickSightClientMock.on(DescribeFolderCommand).resolves({
+      Folder: undefined,
     });
     quickSightClientMock.on(CreateFolderCommand).resolves({});
     quickSightClientMock.on(CreateFolderMembershipCommand).resolves({});
 
     const resp = await handler(basicEvent, context) as CdkCustomResourceResponse;
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(SearchFoldersCommand, 1);
+    expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeFolderCommand, 1);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderCommand, 1);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 4);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeAnalysisCommand, 1);
@@ -399,18 +399,18 @@ describe('QuickSight Lambda function', () => {
       DashboardId: 'dashboard_1',
       Status: 200,
     });
-    quickSightClientMock.on(SearchFoldersCommand).resolvesOnce({
-      FolderSummaryList: [],
+    quickSightClientMock.on(DescribeFolderCommand).resolvesOnce({
+      Folder: undefined,
     }).resolves({
-      FolderSummaryList: [{
+      Folder: {
         FolderId: 'clickstream_folder_xxx',
-      }],
+      },
     });
     quickSightClientMock.on(CreateFolderCommand).resolves({});
     quickSightClientMock.on(CreateFolderMembershipCommand).resolves({});
 
     const resp = await handler(multiAppIdEvent, context) as CdkCustomResourceResponse;
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(SearchFoldersCommand, 1);
+    expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeFolderCommand, 1);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderCommand, 1);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 8);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeAnalysisCommand, 2);
@@ -435,10 +435,10 @@ describe('QuickSight Lambda function', () => {
 
   test('Create QuickSight dashboard - dataset already exist', async () => {
 
-    quickSightClientMock.on(SearchFoldersCommand).resolvesOnce({
-      FolderSummaryList: [{
+    quickSightClientMock.on(DescribeFolderCommand).resolvesOnce({
+      Folder: {
         FolderId: 'clickstream_folder_xxx',
-      }],
+      },
     });
     quickSightClientMock.on(CreateFolderCommand).resolves({});
     quickSightClientMock.on(CreateFolderMembershipCommand).resolves({});
@@ -446,7 +446,7 @@ describe('QuickSight Lambda function', () => {
     try {
       await handler(basicEvent, context);
     } catch (e) {
-      expect(quickSightClientMock).toHaveReceivedCommandTimes(SearchFoldersCommand, 1);
+      expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeFolderCommand, 1);
       expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderCommand, 0);
       expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 0);
       expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateDataSetCommand, 1);
@@ -460,10 +460,10 @@ describe('QuickSight Lambda function', () => {
 
   test('Create QuickSight dashboard - analysis already exist', async () => {
 
-    quickSightClientMock.on(SearchFoldersCommand).resolvesOnce({
-      FolderSummaryList: [{
+    quickSightClientMock.on(DescribeFolderCommand).resolvesOnce({
+      Folder: {
         FolderId: 'clickstream_folder_xxx',
-      }],
+      },
     });
     quickSightClientMock.on(CreateFolderCommand).resolves({});
     quickSightClientMock.on(CreateFolderMembershipCommand).resolves({});
@@ -490,7 +490,7 @@ describe('QuickSight Lambda function', () => {
     try {
       await handler(basicEvent, context);
     } catch (e) {
-      expect(quickSightClientMock).toHaveReceivedCommandTimes(SearchFoldersCommand, 1);
+      expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeFolderCommand, 1);
       expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderCommand, 0);
       expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 0);
       expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateDataSetCommand, 2);
@@ -505,10 +505,10 @@ describe('QuickSight Lambda function', () => {
 
   test('Create QuickSight dashboard - dashboard already exist', async () => {
 
-    quickSightClientMock.on(SearchFoldersCommand).resolvesOnce({
-      FolderSummaryList: [{
+    quickSightClientMock.on(DescribeFolderCommand).resolvesOnce({
+      Folder: {
         FolderId: 'clickstream_folder_xxx',
-      }],
+      },
     });
     quickSightClientMock.on(CreateFolderCommand).resolves({});
     quickSightClientMock.on(CreateFolderMembershipCommand).resolves({});
@@ -545,7 +545,7 @@ describe('QuickSight Lambda function', () => {
     try {
       await handler(basicEvent, context);
     } catch (e) {
-      expect(quickSightClientMock).toHaveReceivedCommandTimes(SearchFoldersCommand, 1);
+      expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeFolderCommand, 1);
       expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderCommand, 0);
       expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 0);
       expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateDataSetCommand, 2);
@@ -796,14 +796,14 @@ describe('QuickSight Lambda function', () => {
       },
     });
 
-    quickSightClientMock.on(SearchFoldersCommand).resolves({
-      FolderSummaryList: [],
+    quickSightClientMock.on(DescribeFolderCommand).resolves({
+      Folder: undefined,
     });
     quickSightClientMock.on(CreateFolderCommand).resolves({});
     quickSightClientMock.on(CreateFolderMembershipCommand).resolves({});
 
     const resp = await handler(updateFromEmptyEvent, context) as CdkCustomResourceResponse;
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(SearchFoldersCommand, 0);
+    expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeFolderCommand, 0);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderCommand, 0);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 4);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeAnalysisCommand, 1);
@@ -921,10 +921,10 @@ describe('QuickSight Lambda function', () => {
     quickSightClientMock.on(DeleteDashboardCommand).resolvesOnce({});
     quickSightClientMock.on(DescribeDashboardCommand).rejectsOnce(notExistError);
 
-    quickSightClientMock.on(SearchFoldersCommand).resolvesOnce({
-      FolderSummaryList: [{
+    quickSightClientMock.on(DescribeFolderCommand).resolvesOnce({
+      Folder: {
         FolderId: 'clickstream_folder_xxx',
-      }],
+      },
     });
     quickSightClientMock.on(CreateFolderCommand).resolves({});
     quickSightClientMock.on(CreateFolderMembershipCommand).resolves({});
@@ -946,7 +946,7 @@ describe('QuickSight Lambda function', () => {
     quickSightClientMock.on(DeleteFolderMembershipCommand).resolves({});
 
     const resp = await handler(multiSchemaUpdateWithDeleteEvent, context) as CdkCustomResourceResponse;
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(SearchFoldersCommand, 0);
+    expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeFolderCommand, 0);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderCommand, 0);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 0);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(ListFolderMembersCommand, 4);
@@ -1035,10 +1035,10 @@ describe('QuickSight Lambda function', () => {
       })
       .rejectsOnce(notExistError);
 
-    quickSightClientMock.on(SearchFoldersCommand).resolvesOnce({
-      FolderSummaryList: [{
+    quickSightClientMock.on(DescribeFolderCommand).resolvesOnce({
+      Folder: {
         FolderId: 'clickstream_folder_xxx',
-      }],
+      },
     });
     quickSightClientMock.on(CreateFolderCommand).resolves({});
     quickSightClientMock.on(CreateFolderMembershipCommand).resolves({});
@@ -1060,7 +1060,7 @@ describe('QuickSight Lambda function', () => {
     quickSightClientMock.on(DeleteFolderMembershipCommand).resolves({});
 
     const resp = await handler(multiSchemaUpdateWithDeleteAndCreateEvent, context) as CdkCustomResourceResponse;
-    expect(quickSightClientMock).toHaveReceivedCommandTimes(SearchFoldersCommand, 0);
+    expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeFolderCommand, 0);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderCommand, 0);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 4);
     expect(quickSightClientMock).toHaveReceivedCommandTimes(ListFolderMembersCommand, 4);


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. Frontend: delete **QuickSight user** select in last step when create pipeline.
2. Backend: create two user (**PublishUser**, **ExploreUser**).
3. Preset dashboard and dashboards that management by control-plane are create at PublishUser.
4. Explore dashboards are create at ExploreUser.

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [x] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend