### PR TITLE
chore: rollback stack with RetainExceptOnCreate

### DIFF
--- a/src/control-plane/backend/lambda/sfn-action/index.ts
+++ b/src/control-plane/backend/lambda/sfn-action/index.ts
@@ -306,8 +306,12 @@ export const doUpdate = async (region: string, input: UpdateStackCommandInput): 
     if (err instanceof CloudFormationServiceException &&
       err.name === 'ValidationError' &&
       err.message.includes('please use the disable-rollback parameter with update-stack API')) {
-      input.DisableRollback = true;
-      return doUpdate(region, input);
+      const rollbackInput = {
+        ...input,
+        DisableRollback: true,
+        RetainExceptOnCreate: true,
+      };
+      return doUpdate(region, rollbackInput);
     }
     throw Error((err as Error).message);
   }

--- a/test/control-plane/lambda/sfn-action.test.ts
+++ b/test/control-plane/lambda/sfn-action.test.ts
@@ -105,6 +105,18 @@ describe('SFN Action Lambda Function', () => {
     expect(resp.Result.StackName).toEqual('Clickstream-ETL-6972c135cb864885b25c5b7ebe584fdf');
     expect(resp.Result.StackStatus).toEqual(StackStatus.UPDATE_IN_PROGRESS);
     expect(cloudFormationMock).toHaveReceivedCommandTimes(UpdateStackCommand, 1);
+    expect(cloudFormationMock).toHaveReceivedNthSpecificCommandWith(1, UpdateStackCommand, {
+      StackName: event.Input.StackName,
+      Parameters: event.Input.Parameters,
+      DisableRollback: false,
+      UsePreviousTemplate: true,
+      Capabilities: [
+        Capability.CAPABILITY_IAM,
+        Capability.CAPABILITY_NAMED_IAM,
+        Capability.CAPABILITY_AUTO_EXPAND,
+      ],
+      Tags: event.Input.Tags,
+    });
     expect(s3Mock).toHaveReceivedCommandTimes(PutObjectCommand, 0);
   });
 
@@ -134,6 +146,31 @@ describe('SFN Action Lambda Function', () => {
     expect(resp.Result.StackName).toEqual('Clickstream-ETL-6972c135cb864885b25c5b7ebe584fdf');
     expect(resp.Result.StackStatus).toEqual(StackStatus.UPDATE_IN_PROGRESS);
     expect(cloudFormationMock).toHaveReceivedCommandTimes(UpdateStackCommand, 2);
+    expect(cloudFormationMock).toHaveReceivedNthSpecificCommandWith(1, UpdateStackCommand, {
+      StackName: event.Input.StackName,
+      Parameters: event.Input.Parameters,
+      DisableRollback: false,
+      UsePreviousTemplate: true,
+      Capabilities: [
+        Capability.CAPABILITY_IAM,
+        Capability.CAPABILITY_NAMED_IAM,
+        Capability.CAPABILITY_AUTO_EXPAND,
+      ],
+      Tags: event.Input.Tags,
+    });
+    expect(cloudFormationMock).toHaveReceivedNthSpecificCommandWith(2, UpdateStackCommand, {
+      StackName: event.Input.StackName,
+      Parameters: event.Input.Parameters,
+      DisableRollback: true,
+      RetainExceptOnCreate: true,
+      UsePreviousTemplate: true,
+      Capabilities: [
+        Capability.CAPABILITY_IAM,
+        Capability.CAPABILITY_NAMED_IAM,
+        Capability.CAPABILITY_AUTO_EXPAND,
+      ],
+      Tags: event.Input.Tags,
+    });
     expect(s3Mock).toHaveReceivedCommandTimes(PutObjectCommand, 0);
   });
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend