### PR TITLE
fix: compression value in query parameters in example generator

### DIFF
--- a/examples/standalone-data-generator/send_event.py
+++ b/examples/standalone-data-generator/send_event.py
@@ -24,10 +24,11 @@ def send_events_to_server(events):
     time.sleep(configure.REQUEST_SLEEP_TIME)
     headers = {'Content-Type': 'application/json; charset=utf-8'}
     global global_sequence_id
+    gzip = "gzip" if configure.IS_GZIP else ""
     request_param = {
         "platform": "Android",
         "appId": configure.APP_ID,
-        "compression": "gzip",
+        "compression": gzip,
         "fakeIp": utils.get_random_ip(),
         "event_bundle_sequence_id": global_sequence_id
     }

--- a/examples/standalone-data-generator/send_event_real_time.py
+++ b/examples/standalone-data-generator/send_event_real_time.py
@@ -28,10 +28,11 @@ def send_events_to_server(user, events):
         device = user.web_device
     else:
         device = user.mobile_device
+    gzip = "gzip" if configure.IS_GZIP else ""
     request_param = {
         "platform": "Android",
         "appId": configure.APP_ID,
-        "compression": "gzip",
+        "compression": gzip,
         "fakeIp": device.ip_address,
         "event_bundle_sequence_id": global_sequence_id
     }


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary
1. fix the value of compression in query parameters

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend