### PR TITLE
fix: missing i18n string in backend

### DIFF
--- a/src/control-plane/backend/lambda/api/i18n.ts
+++ b/src/control-plane/backend/lambda/api/i18n.ts
@@ -11,6 +11,7 @@
  *  and limitations under the License.
  */
 
+import { join } from 'path';
 import i18next from 'i18next';
 import fsBackend from 'i18next-fs-backend';
 import { logger } from './common/powertools';
@@ -21,7 +22,7 @@ i18next
     lng: 'en-US',
     fallbackLng: 'en-US',
     backend: {
-      loadPath: './locales/{{lng}}.json',
+      loadPath: join(__dirname, './locales/{{lng}}.json'),
     },
   }).catch(err => {
     logger.error(`i18next init failed with error: ${err}`);


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend