### PR TITLE
fix: embedded explore dashboard cannot be open

### DIFF
--- a/frontend/src/pages/analytics/comps/ExploreEmbedFrame.tsx
+++ b/frontend/src/pages/analytics/comps/ExploreEmbedFrame.tsx
@@ -25,6 +25,9 @@ const ExploreEmbedFrame: React.FC<ExploreEmbedFrameProps> = (
   const { embedType, embedUrl } = props;
 
   const embedContainer = async () => {
+    if (embedUrl === '') {
+      return;
+    }
     const embeddingContext = await createEmbeddingContext();
     switch (embedType) {
       case 'dashboard':

--- a/src/control-plane/backend/lambda/api/service/reporting.ts
+++ b/src/control-plane/backend/lambda/api/service/reporting.ts
@@ -54,7 +54,7 @@ import { AnalysisType, ExplorePathNodeType, ExploreRequestAction, ExploreTimeSco
 import { logger } from '../common/powertools';
 import { SDKClient } from '../common/sdk-client';
 import { ApiFail, ApiSuccess } from '../common/types';
-import { QuickSightUserArns, generateEmbedUrlForRegisteredUser, getClickstreamUserArn } from '../store/aws/quicksight';
+import { QuickSightUserArns, generateEmbedUrlForRegisteredUser, getClickstreamUserArn, waitDashboardSuccess } from '../store/aws/quicksight';
 
 const sdkClient: SDKClient = new SDKClient();
 
@@ -710,13 +710,16 @@ export class ReportingService {
 
       let dashboardEmbedUrl = '';
       if (query.action === ExploreRequestAction.PREVIEW) {
-        const embedUrl = await generateEmbedUrlForRegisteredUser(
-          dashboardCreateParameters.region,
-          dashboardCreateParameters.allowedDomain,
-          false,
-          query.dashboardId,
-        );
-        dashboardEmbedUrl = embedUrl.EmbedUrl!;
+        const dashboardSuccess = await waitDashboardSuccess(dashboardCreateParameters.region, query.dashboardId);
+        if (dashboardSuccess) {
+          const embedUrl = await generateEmbedUrlForRegisteredUser(
+            dashboardCreateParameters.region,
+            dashboardCreateParameters.allowedDomain,
+            false,
+            query.dashboardId,
+          );
+          dashboardEmbedUrl = embedUrl.EmbedUrl!;
+        }
       }
       result = {
         dashboardId: query.dashboardId,
@@ -809,13 +812,16 @@ export class ReportingService {
 
     let dashboardEmbedUrl = '';
     if (query.action === ExploreRequestAction.PREVIEW) {
-      const embedUrl = await generateEmbedUrlForRegisteredUser(
-        dashboardCreateParameters.region,
-        dashboardCreateParameters.allowedDomain,
-        false,
-        dashboardId,
-      );
-      dashboardEmbedUrl = embedUrl.EmbedUrl!;
+      const dashboardSuccess = await waitDashboardSuccess(dashboardCreateParameters.region, dashboardId);
+      if (dashboardSuccess) {
+        const embedUrl = await generateEmbedUrlForRegisteredUser(
+          dashboardCreateParameters.region,
+          dashboardCreateParameters.allowedDomain,
+          false,
+          dashboardId,
+        );
+        dashboardEmbedUrl = embedUrl.EmbedUrl!;
+      }
     }
     const result = {
       dashboardId,

--- a/src/control-plane/backend/lambda/api/test/api/reporting.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/reporting.test.ts
@@ -32,6 +32,8 @@ import {
   CreateDataSetCommand,
   ResizeOption,
   SheetContentType,
+  DescribeDashboardCommand,
+  ResourceStatus,
 } from '@aws-sdk/client-quicksight';
 import { BatchExecuteStatementCommand, DescribeStatementCommand, RedshiftDataClient, StatusString } from '@aws-sdk/client-redshift-data';
 import { AssumeRoleCommand, STSClient } from '@aws-sdk/client-sts';
@@ -136,6 +138,19 @@ describe('reporting test', () => {
     quickSightMock.on(GenerateEmbedUrlForRegisteredUserCommand).resolves({
       EmbedUrl: 'https://quicksight.aws.amazon.com/embed/4ui7xyvq73/studies/4a05631e-cbe6-477c-915d-1704aec9f101?isauthcode=true&identityprovider=quicksight&code=4a05631e-cbe6-477c-915d-1704aec9f101',
     });
+    quickSightMock.on(DescribeDashboardCommand).resolvesOnce({
+      Dashboard: {
+        Version: {
+          Status: ResourceStatus.CREATION_IN_PROGRESS,
+        },
+      },
+    }).resolves({
+      Dashboard: {
+        Version: {
+          Status: ResourceStatus.CREATION_SUCCESSFUL,
+        },
+      },
+    });
 
     const res = await request(app)
       .post('/api/reporting/funnel')
@@ -194,7 +209,7 @@ describe('reporting test', () => {
     expect(res.body.data.visualIds).toBeDefined();
     expect(res.body.data.visualIds.length).toEqual(2);
     expect(res.body.data.dashboardEmbedUrl).toEqual('https://quicksight.aws.amazon.com/embed/4ui7xyvq73/studies/4a05631e-cbe6-477c-915d-1704aec9f101?isauthcode=true&identityprovider=quicksight&code=4a05631e-cbe6-477c-915d-1704aec9f101');
-
+    expect(quickSightMock).toHaveReceivedCommandTimes(DescribeDashboardCommand, 2);
   });
 
   it('funnel visual - preview', async () => {
@@ -227,6 +242,19 @@ describe('reporting test', () => {
     });
     quickSightMock.on(GenerateEmbedUrlForRegisteredUserCommand).resolves({
       EmbedUrl: 'https://quicksight.aws.amazon.com/embed/4ui7xyvq73/studies/4a05631e-cbe6-477c-915d-1704aec9f101?isauthcode=true&identityprovider=quicksight&code=4a05631e-cbe6-477c-915d-1704aec9f101',
+    });
+    quickSightMock.on(DescribeDashboardCommand).resolvesOnce({
+      Dashboard: {
+        Version: {
+          Status: ResourceStatus.CREATION_IN_PROGRESS,
+        },
+      },
+    }).resolves({
+      Dashboard: {
+        Version: {
+          Status: ResourceStatus.CREATION_FAILED,
+        },
+      },
     });
 
     const res = await request(app)
@@ -286,8 +314,9 @@ describe('reporting test', () => {
     expect(res.body.data.dashboardId).toBeDefined();
     expect(res.body.data.visualIds).toBeDefined();
     expect(res.body.data.visualIds.length).toEqual(2);
-    expect(res.body.data.dashboardEmbedUrl).toEqual('https://quicksight.aws.amazon.com/embed/4ui7xyvq73/studies/4a05631e-cbe6-477c-915d-1704aec9f101?isauthcode=true&identityprovider=quicksight&code=4a05631e-cbe6-477c-915d-1704aec9f101');
-
+    expect(res.body.data.dashboardEmbedUrl).toEqual('');
+    expect(quickSightMock).toHaveReceivedCommandTimes(DescribeDashboardCommand, 2);
+    expect(quickSightMock).toHaveReceivedCommandTimes(GenerateEmbedUrlForRegisteredUserCommand, 0);
   });
 
   it('funnel visual - publish', async () => {
@@ -420,6 +449,19 @@ describe('reporting test', () => {
     quickSightMock.on(GenerateEmbedUrlForRegisteredUserCommand).resolves({
       EmbedUrl: 'https://quicksight.aws.amazon.com/embed/4ui7xyvq73/studies/4a05631e-cbe6-477c-915d-1704aec9f101?isauthcode=true&identityprovider=quicksight&code=4a05631e-cbe6-477c-915d-1704aec9f101',
     });
+    quickSightMock.on(DescribeDashboardCommand).resolvesOnce({
+      Dashboard: {
+        Version: {
+          Status: ResourceStatus.CREATION_IN_PROGRESS,
+        },
+      },
+    }).resolves({
+      Dashboard: {
+        Version: {
+          Status: ResourceStatus.CREATION_SUCCESSFUL,
+        },
+      },
+    });
 
     const res = await request(app)
       .post('/api/reporting/event')
@@ -479,8 +521,7 @@ describe('reporting test', () => {
     expect(res.body.data.visualIds).toBeDefined();
     expect(res.body.data.visualIds.length).toEqual(2);
     expect(res.body.data.dashboardEmbedUrl).toEqual('https://quicksight.aws.amazon.com/embed/4ui7xyvq73/studies/4a05631e-cbe6-477c-915d-1704aec9f101?isauthcode=true&identityprovider=quicksight&code=4a05631e-cbe6-477c-915d-1704aec9f101');
-
-
+    expect(quickSightMock).toHaveReceivedCommandTimes(DescribeDashboardCommand, 2);
   });
 
   it('event visual - preview - twice request with group condition', async () => {
@@ -514,6 +555,19 @@ describe('reporting test', () => {
     });
     quickSightMock.on(GenerateEmbedUrlForRegisteredUserCommand).resolves({
       EmbedUrl: 'https://quicksight.aws.amazon.com/embed/4ui7xyvq73/studies/4a05631e-cbe6-477c-915d-1704aec9f101?isauthcode=true&identityprovider=quicksight&code=4a05631e-cbe6-477c-915d-1704aec9f101',
+    });
+    quickSightMock.on(DescribeDashboardCommand).resolvesOnce({
+      Dashboard: {
+        Version: {
+          Status: ResourceStatus.CREATION_IN_PROGRESS,
+        },
+      },
+    }).resolves({
+      Dashboard: {
+        Version: {
+          Status: ResourceStatus.CREATION_SUCCESSFUL,
+        },
+      },
     });
 
     const requestBody = {
@@ -578,6 +632,7 @@ describe('reporting test', () => {
     expect(res2.statusCode).toBe(201);
     expect(res2.body.success).toEqual(true);
     expect(quickSightMock).toHaveReceivedNthSpecificCommandWith(2, CreateDataSetCommand, {});
+    expect(quickSightMock).toHaveReceivedCommandTimes(DescribeDashboardCommand, 3);
   });
 
   it('event visual - publish', async () => {
@@ -712,6 +767,19 @@ describe('reporting test', () => {
     quickSightMock.on(GenerateEmbedUrlForRegisteredUserCommand).resolves({
       EmbedUrl: 'https://quicksight.aws.amazon.com/embed/4ui7xyvq73/studies/4a05631e-cbe6-477c-915d-1704aec9f101?isauthcode=true&identityprovider=quicksight&code=4a05631e-cbe6-477c-915d-1704aec9f101',
     });
+    quickSightMock.on(DescribeDashboardCommand).resolvesOnce({
+      Dashboard: {
+        Version: {
+          Status: ResourceStatus.CREATION_IN_PROGRESS,
+        },
+      },
+    }).resolves({
+      Dashboard: {
+        Version: {
+          Status: ResourceStatus.CREATION_SUCCESSFUL,
+        },
+      },
+    });
 
     const res = await request(app)
       .post('/api/reporting/path')
@@ -774,7 +842,7 @@ describe('reporting test', () => {
     expect(res.body.data.visualIds).toBeDefined();
     expect(res.body.data.visualIds.length).toEqual(1);
     expect(res.body.data.dashboardEmbedUrl).toEqual('https://quicksight.aws.amazon.com/embed/4ui7xyvq73/studies/4a05631e-cbe6-477c-915d-1704aec9f101?isauthcode=true&identityprovider=quicksight&code=4a05631e-cbe6-477c-915d-1704aec9f101');
-
+    expect(quickSightMock).toHaveReceivedCommandTimes(DescribeDashboardCommand, 2);
   });
 
   it('path visual - publish', async () => {


### PR DESCRIPTION

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Occasional situation where embedded explore dashboard cannot be open. Wait explore dashboard status SUCCESS before create embedding URL.

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend