### PR TITLE
ci: fix the backend zip package and template prefix in dict in pipeline

### DIFF
--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -155,7 +155,7 @@ update_dict() {
     sed -i'' -e 's/__DIST_OUTPUT_BUCKET__/'$TEMPLATE_OUTPUT_BUCKET'/g' src/control-plane/backend/config/dictionary.json
     sed -i'' -e 's~__TARGET__~'$target'~g' src/control-plane/backend/config/dictionary.json
     sed -i'' -e 's~__PREFIX__~'$prefix'~g' src/control-plane/backend/config/dictionary.json
-    sed -i'' -e 's/__SOLUTION_VERSION__/'$BUILD_VERSION'/g' src/control-plane/backend/config/dictionary.json
+    sed -i'' -e 's/__SOLUTION_VERSION__/'$VERSION'/g' src/control-plane/backend/config/dictionary.json
     cat src/control-plane/backend/config/dictionary.json
 
     cd $currDir
@@ -361,10 +361,6 @@ done
 echo "------------------------------------------------------------------------------"
 echo "${bold}[Packing] Source code artifacts${normal}"
 echo "------------------------------------------------------------------------------"
-
-# General cleanup of node_modules files
-echo "find $staging_dist_dir -iname "node_modules" -type d -exec rm -rf "{}" \; 2> /dev/null"
-find $staging_dist_dir -iname "node_modules" -type d -exec rm -rf "{}" \; 2> /dev/null
 
 # ... For each asset.* source code artifact in the temporary /staging folder...
 cd $staging_dist_dir


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] tested in test pipeline to deploy web console and data pipeline
- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend