### PR TITLE
fix: load data to redshift error: conflict with concurrent transaction

### DIFF
--- a/src/analytics/lambdas/load-data-workflow/create-load-manifest.ts
+++ b/src/analytics/lambdas/load-data-workflow/create-load-manifest.ts
@@ -206,6 +206,7 @@ const doManifestFiles = async (candidateItems: Array<ODSEventItem>,
         appId: appId,
         manifestFileName: manifestFile,
         jobList: entries,
+        retryCount: 0,
       });
     }
   }

--- a/src/analytics/lambdas/load-data-workflow/load-manifest-to-redshift.ts
+++ b/src/analytics/lambdas/load-data-workflow/load-manifest-to-redshift.ts
@@ -76,8 +76,9 @@ const redshiftDataApiClient = getRedshiftClient(REDSHIFT_DATA_API_ROLE_ARN);
  * @returns The query_id and relevant properties.
  */
 export const handler = async (event: LoadManifestEvent, context: Context) => {
-  logger.debug('requestJson:', JSON.stringify(event, undefined, 2));
+  logger.debug('requestJson:', { event });
   logger.debug(`context.awsRequestId:${context.awsRequestId}`);
+  const retryCount = event.detail.retryCount;
   let appId = event.detail.appId;
   const manifestFileName = event.detail.manifestFileName;
   const jobList = event.detail.jobList;
@@ -135,6 +136,7 @@ export const handler = async (event: LoadManifestEvent, context: Context) => {
         appId: appId,
         manifestFileName: manifestFileName,
         jobList: jobList,
+        retryCount,
       },
     };
   } catch (err) {

--- a/src/analytics/private/model.ts
+++ b/src/analytics/private/model.ts
@@ -146,6 +146,7 @@ export interface ManifestItem {
 export interface ManifestBody {
   readonly appId: string;
   readonly manifestFileName: string;
+  readonly retryCount: number;
   readonly jobList: {
     readonly entries: Array<ManifestItem>;
   };

--- a/test/analytics/analytics-on-redshift/lambda/load-data/create-manifest.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/load-data/create-manifest.test.ts
@@ -133,6 +133,7 @@ describe('Lambda - Create manifest for Redshift COPY', () => {
           }],
         },
         manifestFileName: `s3://${process.env.MANIFEST_BUCKET}/${process.env.MANIFEST_BUCKET_PREFIX}manifest/app1-${context.awsRequestId}.manifest`,
+        retryCount: 0,
       }],
       count: 1,
     }));
@@ -142,8 +143,8 @@ describe('Lambda - Create manifest for Redshift COPY', () => {
     expect(s3ClientMock).toHaveReceivedCommandTimes(PutObjectCommand, 1);
     expect(addMetricMock).toBeCalledTimes(4);
     expect(publishStoredMetricsMock).toBeCalledTimes(1);
-
   });
+
 
   test('Get 4 new items with different applications from store then create three manifest', async () => {
     dynamoDBClientMock.on(QueryCommand).resolvesOnce({
@@ -218,14 +219,17 @@ describe('Lambda - Create manifest for Redshift COPY', () => {
             ]),
           },
           manifestFileName: `s3://${process.env.MANIFEST_BUCKET}/${process.env.MANIFEST_BUCKET_PREFIX}manifest/app1-${context.awsRequestId}.manifest`,
+          retryCount: 0,
         }),
         expect.objectContaining({
           appId: 'app2',
           manifestFileName: `s3://${process.env.MANIFEST_BUCKET}/${process.env.MANIFEST_BUCKET_PREFIX}manifest/app2-${context.awsRequestId}.manifest`,
+          retryCount: 0,
         }),
         expect.objectContaining({
           appId: 'app3',
           manifestFileName: `s3://${process.env.MANIFEST_BUCKET}/${process.env.MANIFEST_BUCKET_PREFIX}manifest/app3-${context.awsRequestId}.manifest`,
+          retryCount: 0,
         }),
       ]),
       count: 3,

--- a/test/analytics/analytics-on-redshift/lambda/load-data/skip-running-workflow.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/load-data/skip-running-workflow.test.ts
@@ -16,7 +16,7 @@ import { SFNClient, ListExecutionsCommand, ExecutionStatus } from '@aws-sdk/clie
 import { QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
-import { handler } from '../../../../../src/analytics/lambdas/load-data-workflow/has-running-workflow';
+import { handler } from '../../../../../src/analytics/lambdas/load-data-workflow/skip-running-workflow';
 import { JobStatus, REDSHIFT_TABLE_NAMES } from '../../../../../src/analytics/private/constant';
 import { PARTITION_APP } from '../../../../../src/common/constant';
 import { getMockContext } from '../../../../common/lambda-context';
@@ -132,6 +132,9 @@ test('Should have other running workflow', async () => {
     { countEnQ: 1, countNew: 1, countProcessing: 1, tableName: tableNames[4] },
   ]);
   expect(response.HasRunningWorkflow).toBeTruthy();
+  expect(response.SkipRunningWorkflow).toBeTruthy();
+  expect(response.PendingCount).toEqual(20);
+
   expect(snfClientMock).toReceiveNthCommandWith(1, ListExecutionsCommand, {
     stateMachineArn: 'arn:aws:states:us-east-1:xxxxxxxxx:stateMachine:stateMachineNameTest',
     statusFilter: ExecutionStatus.RUNNING,
@@ -193,6 +196,7 @@ test('Should get no other running workflow', async () => {
   const response = await handler(event, context);
   expect(response.FilesCountInfo.length).toEqual(5);
   expect(response.HasRunningWorkflow).toBeFalsy();
+  expect(response.SkipRunningWorkflow).toBeFalsy();
 
   expect(ddbClientMock).toHaveReceivedNthCommandWith(1, QueryCommand, {
     ExpressionAttributeValues: { ':job_status': 'event#ENQUEUE', ':s3_uri': 's3://bucket_test/test/prefix1/event/' },
@@ -203,5 +207,36 @@ test('Should get no other running workflow', async () => {
   expect(ddbClientMock).toHaveReceivedNthCommandWith(3, QueryCommand, {
     ExpressionAttributeValues: { ':job_status': 'event#NEW', ':s3_uri': 's3://bucket_test/test/prefix1/event/' },
   });
+});
 
+test('Should skip running workflow', async () => {
+  ddbClientMock.on(QueryCommand).resolves({
+    //@ts-ignore
+    Count: 0,
+    Items: [
+    ],
+  });
+  snfClientMock.on(ListExecutionsCommand).resolves({
+    executions: [
+    ],
+  });
+  const event = {
+    execution_id: 'arn:aws:states:us-east-1:xxxxxxxxx:execution:stateMachineNameTest:exec_id_0',
+    eventBucketName: 'bucket_test',
+    eventPrefix: 'test/prefix1/event',
+  };
+
+  const response = await handler(event, context);
+  const tableNames = REDSHIFT_TABLE_NAMES;
+
+  expect(response.FilesCountInfo).toEqual([
+    { countEnQ: 0, countNew: 0, countProcessing: 0, tableName: tableNames[0] },
+    { countEnQ: 0, countNew: 0, countProcessing: 0, tableName: tableNames[1] },
+    { countEnQ: 0, countNew: 0, countProcessing: 0, tableName: tableNames[2] },
+    { countEnQ: 0, countNew: 0, countProcessing: 0, tableName: tableNames[3] },
+    { countEnQ: 0, countNew: 0, countProcessing: 0, tableName: tableNames[4] },
+  ]);
+  expect(response.HasRunningWorkflow).toBeFalsy();
+  expect(response.SkipRunningWorkflow).toBeTruthy();
+  expect(response.PendingCount).toEqual(0);
 });


### PR DESCRIPTION
close https://github.com/awslabs/clickstream-analytics-on-aws/issues/412

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary
1. fix: https://github.com/awslabs/clickstream-analytics-on-aws/issues/412
2. skip triggering scan meta workflow when no files to be loaded

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend