### PR TITLE
chore: clean tmp analysis filter with status

### DIFF
--- a/src/control-plane/backend/lambda/api/service/reporting.ts
+++ b/src/control-plane/backend/lambda/api/service/reporting.ts
@@ -13,7 +13,7 @@
 
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { AnalysisDefinition, ConflictException, DashboardVersionDefinition, DataSetIdentifierDeclaration, InputColumn, QuickSight, ThrottlingException } from '@aws-sdk/client-quicksight';
+import { AnalysisDefinition, ConflictException, DashboardVersionDefinition, DataSetIdentifierDeclaration, InputColumn, QuickSight, ResourceStatus, ThrottlingException } from '@aws-sdk/client-quicksight';
 import { BatchExecuteStatementCommand, DescribeStatementCommand, StatusString } from '@aws-sdk/client-redshift-data';
 import { v4 as uuidv4 } from 'uuid';
 import { DataSetProps } from './quicksight/dashboard-ln';
@@ -972,7 +972,9 @@ async function _deletedAnalyses(quickSight: QuickSight) {
 
   if (analyses.AnalysisSummaryList) {
     for (const [_index, analysis] of analyses.AnalysisSummaryList.entries()) {
-      if (analysis.Name?.startsWith(TEMP_RESOURCE_NAME_PREFIX) && (new Date().getTime() - analysis.CreatedTime!.getTime()) > 60 * 60 * 1000) {
+      if (analysis.Status !== ResourceStatus.DELETED &&
+        analysis.Name?.startsWith(TEMP_RESOURCE_NAME_PREFIX) &&
+        (new Date().getTime() - analysis.CreatedTime!.getTime()) > 60 * 60 * 1000) {
         const deletedRes = await quickSight.deleteAnalysis({
           AwsAccountId: awsAccountId,
           AnalysisId: analysis.AnalysisId,

--- a/src/control-plane/backend/lambda/api/test/api/reporting.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/reporting.test.ts
@@ -1182,12 +1182,22 @@ describe('reporting test', () => {
     });
 
     quickSightMock.on(ListAnalysesCommand).resolves({
-      AnalysisSummaryList: [{
-        Arn: 'arn:aws:quicksight:us-east-1:11111111:analysis/analysis-aaaaaaaa',
-        Name: '_tmp_aaaaaaa',
-        CreatedTime: new Date((new Date()).getTime() - 80*60*1000),
-        AnalysisId: 'analysis_aaaaaaa',
-      }],
+      AnalysisSummaryList: [
+        {
+          Arn: 'arn:aws:quicksight:us-east-1:11111111:analysis/analysis-aaaaaaaa',
+          Name: '_tmp_aaaaaaa',
+          CreatedTime: new Date((new Date()).getTime() - 80*60*1000),
+          AnalysisId: 'analysis_aaaaaaa',
+          Status: ResourceStatus.UPDATE_SUCCESSFUL,
+        },
+        {
+          Arn: 'arn:aws:quicksight:us-east-1:11111111:analysis/analysis-bbbbbb',
+          Name: '_tmp_bbbbbb',
+          CreatedTime: new Date((new Date()).getTime() - 80*60*1000),
+          AnalysisId: 'analysis_bbbbbb',
+          Status: ResourceStatus.DELETED,
+        },
+      ],
     });
 
     quickSightMock.on(DeleteAnalysisCommand).resolves({
@@ -1221,6 +1231,9 @@ describe('reporting test', () => {
     expect(res.body.data.deletedDashBoards[0]).toEqual('dashboard-aaaaaaaa');
     expect(res.body.data.deletedAnalyses[0]).toEqual('analysis-aaaaaaaa');
     expect(res.body.data.deletedDatasets[0]).toEqual('dataset-aaaaaaaa');
+    expect(quickSightMock).toHaveReceivedCommandTimes(DeleteDashboardCommand, 1);
+    expect(quickSightMock).toHaveReceivedCommandTimes(DeleteAnalysisCommand, 1);
+    expect(quickSightMock).toHaveReceivedCommandTimes(DeleteDataSetCommand, 1);
 
   });
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend