### PR TITLE
fix: updatable sql scripts are not executed when upgrading the data modeling stack

### DIFF
--- a/src/analytics/private/model.ts
+++ b/src/analytics/private/model.ts
@@ -106,6 +106,7 @@ export type CreateDatabaseAndSchemas = CustomProperties & {
   readonly redshiftBIUsernamePrefix: string;
   readonly reportingViewsDef: SQLViewDef[];
   readonly schemaDefs: SQLDef[];
+  readonly lastModifiedTime: number;
 }
 export type CreateMappingRoleUser = Omit<CustomProperties, 'provisionedRedshiftProps'> & {
   readonly dataRoleName: string;

--- a/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
+++ b/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
@@ -3786,6 +3786,7 @@ describe('DataAnalyticsRedshiftStack serverless custom resource test', () => {
         },
         databaseName: RefAnyValue,
         dataAPIRole: RefAnyValue,
+        lastModifiedTime: Match.anyValue(),
         serverlessRedshiftProps: {
           databaseName: RefAnyValue,
           namespaceId: RefAnyValue,

--- a/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
@@ -59,6 +59,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
       redshiftBIUsernamePrefix: biUserNamePrefix,
       reportingViewsDef,
       schemaDefs,
+      lastModifiedTime: 1699345775001,
     },
   };
 


### PR DESCRIPTION
…change


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Fix the issue that schema cannot be updated if there is no parameter change

## Implementation highlights

Fix the issue that schema cannot be updated if there is no parameter change

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend