### PR TITLE
chore: validate non-working network configuration

### DIFF
--- a/.viperlightignore
+++ b/.viperlightignore
@@ -90,8 +90,6 @@ frontend/src/ts/constant-ln.ts:80
 frontend/src/ts/constant-ln.ts:83
 frontend/src/ts/constant-ln.ts:86
 frontend/src/ts/constant-ln.ts:89
-src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:52
-src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:53
 src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:54
 src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:55
 src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:56
@@ -100,6 +98,8 @@ src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:58
 src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:59
 src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:60
 src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:61
+src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:62
+src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:63
 src/control-plane/backend/lambda/api/common/constants.ts:14
 
 [node-yarnoutdated]

--- a/src/control-plane/backend/lambda/api/common/stack-params-valid.ts
+++ b/src/control-plane/backend/lambda/api/common/stack-params-valid.ts
@@ -141,7 +141,7 @@ export const validateIngestionServerNum = (serverSize: IngestionServerSizeProps)
 const getVpcEndpointServices = (region: string, services: string[]) => {
   let prefix = `com.amazonaws.${region}`;
   if (region.startsWith('cn')) {
-    prefix = 'cn.com.amazonaws.cn-northwest-1';
+    prefix = `cn.${prefix}`;
   }
   return services.map(s => `${prefix}.${s}`);
 };

--- a/src/control-plane/backend/lambda/api/common/stack-params-valid.ts
+++ b/src/control-plane/backend/lambda/api/common/stack-params-valid.ts
@@ -415,6 +415,7 @@ async function _checkVpcEndpointsForIsolatedSubnets(pipeline: IPipeline, vpcId: 
       _validateEndpointsForModules(pipeline, allSubnets, isolatedSubnetsAZ, selectedPrivateSubnet, vpcEndpoints, vpcEndpointSecurityGroupRules);
     } else {
       const vpcEndpointServices = vpcEndpoints.map(vpce => vpce.ServiceName!);
+      console.log('vpcEndpointServices', vpcEndpointServices);
       validateVpcEndpoint(
         allSubnets,
         privateSubnetsAZ,

--- a/src/control-plane/backend/lambda/api/common/stack-params-valid.ts
+++ b/src/control-plane/backend/lambda/api/common/stack-params-valid.ts
@@ -421,13 +421,10 @@ async function _checkVpcEndpointsForIsolatedSubnets(pipeline: IPipeline, vpcId: 
         selectedPrivateSubnet,
         vpcEndpoints,
         vpcEndpointSecurityGroupRules,
-        getVpcEndpointServices(pipeline.region, vpcEndpointServices),
+        vpcEndpointServices,
       );
     }
   }
-  throw new ClickStreamBadRequestError(
-    '111111111111111111',
-  );
 }
 
 

--- a/src/control-plane/backend/lambda/api/common/stack-params-valid.ts
+++ b/src/control-plane/backend/lambda/api/common/stack-params-valid.ts
@@ -415,7 +415,6 @@ async function _checkVpcEndpointsForIsolatedSubnets(pipeline: IPipeline, vpcId: 
       _validateEndpointsForModules(pipeline, allSubnets, isolatedSubnetsAZ, selectedPrivateSubnet, vpcEndpoints, vpcEndpointSecurityGroupRules);
     } else {
       const vpcEndpointServices = vpcEndpoints.map(vpce => vpce.ServiceName!);
-      console.log('vpcEndpointServices', vpcEndpointServices);
       validateVpcEndpoint(
         allSubnets,
         privateSubnetsAZ,

--- a/src/control-plane/backend/lambda/api/store/aws/ec2.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/ec2.ts
@@ -26,6 +26,8 @@ import {
   RouteTable, DescribeRegionsCommand,
   DescribeAvailabilityZonesCommand,
   Region,
+  paginateDescribeNatGateways,
+  NatGateway,
 } from '@aws-sdk/client-ec2';
 
 import { SecurityGroupRule } from '@aws-sdk/client-ec2/dist-types/models/models_0';
@@ -104,6 +106,22 @@ export const describeSubnets = async (region: string, vpcId: string) => {
   }];
   for await (const page of paginateDescribeSubnets({ client: ec2Client }, { Filters: filters })) {
     records.push(...page.Subnets as Subnet[]);
+  }
+  return records;
+};
+
+export const describeNatGateways = async (region: string, vpcId: string) => {
+  const ec2Client = new EC2Client({
+    ...aws_sdk_client_common_config,
+    region,
+  });
+  const records: NatGateway[] = [];
+  const filters: Filter[] = [{
+    Name: 'vpc-id',
+    Values: [vpcId],
+  }];
+  for await (const page of paginateDescribeNatGateways({ client: ec2Client }, { Filter: filters })) {
+    records.push(...page.NatGateways as NatGateway[]);
   }
   return records;
 };

--- a/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
@@ -62,6 +62,7 @@ export const AllowIAMUserPutObejectPolicyWithErrorService = '{"Version":"2012-10
 export const AllowIAMUserPutObejectPolicyInApSouthEast1 = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::027434742980:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/clickstream/*"},{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::114774131450:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws:s3:::EXAMPLE_BUCKET/clickstream/*"}]}';
 export const AllowIAMUserPutObjectPolicyInCnNorth1 = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws-cn:iam::638102146993:root"},"Action":["s3:PutObject","s3:PutObjectLegalHold","s3:PutObjectRetention","s3:PutObjectTagging","s3:PutObjectVersionTagging","s3:Abort*"],"Resource":"arn:aws-cn:s3:::EXAMPLE_BUCKET/clickstream/*"}]}';
 
+
 function userMock(ddbMock: any, userId: string, role: IUserRole, existed?: boolean): any {
   if (!existed) {
     return ddbMock.on(GetCommand, {
@@ -595,6 +596,21 @@ function createPipelineMock(
         },
       ],
     });
+
+  ec2Mock.on(DescribeNatGatewaysCommand).
+    resolves({
+      NatGateways: [
+        {
+          NatGatewayId: 'NatGatewayId1',
+          SubnetId: 'subnet-00000000000000010',
+          ConnectivityType: ConnectivityType.PUBLIC,
+        },
+      ],
+    });
+
+
+  const vpcEndpointsGroups = [{ GroupId: 'sg-00000000000000030' }];
+
   const defaultSubnets = [
     {
       SubnetId: 'subnet-00000000000000010',
@@ -633,17 +649,92 @@ function createPipelineMock(
     },
   ];
 
-  ec2Mock.on(DescribeNatGatewaysCommand).
-    resolves({
-      NatGateways: [
-        {
-          NatGatewayId: 'NatGatewayId1',
-          SubnetId: 'subnet-00000000000000010',
-          ConnectivityType: ConnectivityType.PUBLIC,
-        },
-      ],
-    });
-
+  const vpcEndpoints = [
+    {
+      VpcEndpointId: 'vpce-error',
+      ServiceName: 'com.amazonaws.ap-southeast-1.error',
+      VpcEndpointType: VpcEndpointType.Interface,
+      Groups: vpcEndpointsGroups,
+      SubnetIds: [],
+    },
+    {
+      VpcEndpointId: 'vpce-emr-serverless',
+      ServiceName: 'com.amazonaws.ap-southeast-1.emr-serverless',
+      VpcEndpointType: VpcEndpointType.Interface,
+      Groups: vpcEndpointsGroups,
+      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
+    },
+    {
+      VpcEndpointId: 'vpce-states',
+      ServiceName: 'com.amazonaws.ap-southeast-1.states',
+      VpcEndpointType: VpcEndpointType.Interface,
+      Groups: vpcEndpointsGroups,
+      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
+    },
+    {
+      VpcEndpointId: 'vpce-logs',
+      ServiceName: 'com.amazonaws.ap-southeast-1.logs',
+      VpcEndpointType: VpcEndpointType.Interface,
+      Groups: vpcEndpointsGroups,
+      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
+    },
+    {
+      VpcEndpointId: 'vpce-redshift-data',
+      ServiceName: 'com.amazonaws.ap-southeast-1.redshift-data',
+      VpcEndpointType: VpcEndpointType.Interface,
+      Groups: vpcEndpointsGroups,
+      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
+    },
+    {
+      VpcEndpointId: 'vpce-sts',
+      ServiceName: 'com.amazonaws.ap-southeast-1.sts',
+      VpcEndpointType: VpcEndpointType.Interface,
+      Groups: vpcEndpointsGroups,
+      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
+    },
+    {
+      VpcEndpointId: 'vpce-ecr-dkr',
+      ServiceName: 'com.amazonaws.ap-southeast-1.ecr.dkr',
+      VpcEndpointType: VpcEndpointType.Interface,
+      Groups: vpcEndpointsGroups,
+      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
+    },
+    {
+      VpcEndpointId: 'vpce-ecr-api',
+      ServiceName: 'com.amazonaws.ap-southeast-1.ecr.api',
+      VpcEndpointType: VpcEndpointType.Interface,
+      Groups: vpcEndpointsGroups,
+      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
+    },
+    {
+      VpcEndpointId: 'vpce-ecs',
+      ServiceName: 'com.amazonaws.ap-southeast-1.ecs',
+      VpcEndpointType: VpcEndpointType.Interface,
+      Groups: vpcEndpointsGroups,
+      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
+    },
+    {
+      VpcEndpointId: 'vpce-ecs-agent',
+      ServiceName: 'com.amazonaws.ap-southeast-1.ecs-agent',
+      VpcEndpointType: VpcEndpointType.Interface,
+      Groups: vpcEndpointsGroups,
+      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
+    },
+    {
+      VpcEndpointId: 'vpce-ecs-telemetry',
+      ServiceName: 'com.amazonaws.ap-southeast-1.ecs-telemetry',
+      VpcEndpointType: VpcEndpointType.Interface,
+      Groups: vpcEndpointsGroups,
+      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
+    },
+    {
+      VpcEndpointId: 'vpce-kinesis-streams',
+      ServiceName: 'com.amazonaws.ap-southeast-1.kinesis-streams',
+      VpcEndpointType: VpcEndpointType.Interface,
+      Groups: vpcEndpointsGroups,
+      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
+    },
+  ];
   let mockSubnets = defaultSubnets;
   if (!props?.publicAZContainPrivateAZ) {
     mockSubnets = [
@@ -742,93 +833,6 @@ function createPipelineMock(
       },
     ],
   });
-  const vpcEndpointsGroups = [{ GroupId: 'sg-00000000000000030' }];
-  const vpcEndpoints = [
-    {
-      VpcEndpointId: 'vpce-error',
-      ServiceName: 'com.amazonaws.ap-southeast-1.error',
-      VpcEndpointType: VpcEndpointType.Interface,
-      Groups: vpcEndpointsGroups,
-      SubnetIds: [],
-    },
-    {
-      VpcEndpointId: 'vpce-emr-serverless',
-      ServiceName: 'com.amazonaws.ap-southeast-1.emr-serverless',
-      VpcEndpointType: VpcEndpointType.Interface,
-      Groups: vpcEndpointsGroups,
-      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-    },
-    {
-      VpcEndpointId: 'vpce-states',
-      ServiceName: 'com.amazonaws.ap-southeast-1.states',
-      VpcEndpointType: VpcEndpointType.Interface,
-      Groups: vpcEndpointsGroups,
-      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-    },
-    {
-      VpcEndpointId: 'vpce-logs',
-      ServiceName: 'com.amazonaws.ap-southeast-1.logs',
-      VpcEndpointType: VpcEndpointType.Interface,
-      Groups: vpcEndpointsGroups,
-      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-    },
-    {
-      VpcEndpointId: 'vpce-redshift-data',
-      ServiceName: 'com.amazonaws.ap-southeast-1.redshift-data',
-      VpcEndpointType: VpcEndpointType.Interface,
-      Groups: vpcEndpointsGroups,
-      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-    },
-    {
-      VpcEndpointId: 'vpce-sts',
-      ServiceName: 'com.amazonaws.ap-southeast-1.sts',
-      VpcEndpointType: VpcEndpointType.Interface,
-      Groups: vpcEndpointsGroups,
-      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-    },
-    {
-      VpcEndpointId: 'vpce-ecr-dkr',
-      ServiceName: 'com.amazonaws.ap-southeast-1.ecr.dkr',
-      VpcEndpointType: VpcEndpointType.Interface,
-      Groups: vpcEndpointsGroups,
-      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-    },
-    {
-      VpcEndpointId: 'vpce-ecr-api',
-      ServiceName: 'com.amazonaws.ap-southeast-1.ecr.api',
-      VpcEndpointType: VpcEndpointType.Interface,
-      Groups: vpcEndpointsGroups,
-      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-    },
-    {
-      VpcEndpointId: 'vpce-ecs',
-      ServiceName: 'com.amazonaws.ap-southeast-1.ecs',
-      VpcEndpointType: VpcEndpointType.Interface,
-      Groups: vpcEndpointsGroups,
-      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-    },
-    {
-      VpcEndpointId: 'vpce-ecs-agent',
-      ServiceName: 'com.amazonaws.ap-southeast-1.ecs-agent',
-      VpcEndpointType: VpcEndpointType.Interface,
-      Groups: vpcEndpointsGroups,
-      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-    },
-    {
-      VpcEndpointId: 'vpce-ecs-telemetry',
-      ServiceName: 'com.amazonaws.ap-southeast-1.ecs-telemetry',
-      VpcEndpointType: VpcEndpointType.Interface,
-      Groups: vpcEndpointsGroups,
-      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-    },
-    {
-      VpcEndpointId: 'vpce-kinesis-streams',
-      ServiceName: 'com.amazonaws.ap-southeast-1.kinesis-streams',
-      VpcEndpointType: VpcEndpointType.Interface,
-      Groups: vpcEndpointsGroups,
-      SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-    },
-  ];
   let mockVpcEndpoints: any[] = [];
   if (!props?.noVpcEndpoint && props?.missVpcEndpoint) {
     mockVpcEndpoints = vpcEndpoints;
@@ -883,158 +887,7 @@ function createPipelineMock(
   });
 }
 
-function createPipelineMockForBJSRegion(ec2Mock: any, s3Mock: any) {
-  const defaultSubnets = [
-    {
-      SubnetId: 'subnet-00000000000000010',
-      AvailabilityZone: 'cn-north-1a',
-      CidrBlock: '10.0.16.0/20',
-    },
-    {
-      SubnetId: 'subnet-00000000000000011',
-      AvailabilityZone: 'cn-north-1b',
-      CidrBlock: '10.0.32.0/20',
-    },
-    {
-      SubnetId: 'subnet-00000000000000012',
-      AvailabilityZone: 'cn-north-1c',
-      CidrBlock: '10.0.48.0/20',
-    },
-    {
-      SubnetId: 'subnet-00000000000000013',
-      AvailabilityZone: 'cn-north-1d',
-      CidrBlock: '10.0.64.0/20',
-    },
-    {
-      SubnetId: 'subnet-00000000000000021',
-      AvailabilityZone: 'cn-north-1b',
-      CidrBlock: '10.0.64.0/20',
-    },
-    {
-      SubnetId: 'subnet-00000000000000022',
-      AvailabilityZone: 'cn-north-1c',
-      CidrBlock: '10.0.64.0/20',
-    },
-    {
-      SubnetId: 'subnet-00000000000000023',
-      AvailabilityZone: 'cn-north-1d',
-      CidrBlock: '10.0.64.0/20',
-    },
-  ];
-  ec2Mock.on(DescribeSubnetsCommand)
-    .resolves({
-      Subnets: defaultSubnets,
-    });
-  const vpcEndpointsGroups = [{ GroupId: 'sg-00000000000000030' }];
-  ec2Mock.on(DescribeVpcEndpointsCommand).resolves({
-    VpcEndpoints: [
-      {
-        VpcEndpointId: 'vpce-s3',
-        ServiceName: 'cn.com.amazonaws.cn-northwest-1.s3',
-        VpcEndpointType: VpcEndpointType.Gateway,
-        Groups: vpcEndpointsGroups,
-        SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-      },
-      {
-        VpcEndpointId: 'vpce-dynamodb',
-        ServiceName: 'cn.com.amazonaws.cn-northwest-1.dynamodb',
-        VpcEndpointType: VpcEndpointType.Gateway,
-        Groups: vpcEndpointsGroups,
-        SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-      },
-      {
-        VpcEndpointId: 'vpce-glue',
-        ServiceName: 'cn.com.amazonaws.cn-northwest-1.glue',
-        VpcEndpointType: VpcEndpointType.Interface,
-        Groups: [{ GroupId: 'sg-00000000000000031' }],
-        SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-      },
-      {
-        VpcEndpointId: 'vpce-error',
-        ServiceName: 'cn.com.amazonaws.cn-northwest-1.error',
-        VpcEndpointType: VpcEndpointType.Interface,
-        Groups: vpcEndpointsGroups,
-        SubnetIds: [],
-      },
-      {
-        VpcEndpointId: 'vpce-emr-serverless',
-        ServiceName: 'cn.com.amazonaws.cn-northwest-1.emr-serverless',
-        VpcEndpointType: VpcEndpointType.Interface,
-        Groups: vpcEndpointsGroups,
-        SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-      },
-      {
-        VpcEndpointId: 'vpce-states',
-        ServiceName: 'cn.com.amazonaws.cn-northwest-1.states',
-        VpcEndpointType: VpcEndpointType.Interface,
-        Groups: vpcEndpointsGroups,
-        SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-      },
-      {
-        VpcEndpointId: 'vpce-logs',
-        ServiceName: 'cn.com.amazonaws.cn-northwest-1.logs',
-        VpcEndpointType: VpcEndpointType.Interface,
-        Groups: vpcEndpointsGroups,
-        SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-      },
-      {
-        VpcEndpointId: 'vpce-redshift-data',
-        ServiceName: 'cn.com.amazonaws.cn-northwest-1.redshift-data',
-        VpcEndpointType: VpcEndpointType.Interface,
-        Groups: vpcEndpointsGroups,
-        SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-      },
-      {
-        VpcEndpointId: 'vpce-sts',
-        ServiceName: 'cn.com.amazonaws.cn-northwest-1.sts',
-        VpcEndpointType: VpcEndpointType.Interface,
-        Groups: vpcEndpointsGroups,
-        SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-      },
-      {
-        VpcEndpointId: 'vpce-ecr-dkr',
-        ServiceName: 'cn.com.amazonaws.cn-northwest-1.ecr.dkr',
-        VpcEndpointType: VpcEndpointType.Interface,
-        Groups: vpcEndpointsGroups,
-        SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-      },
-      {
-        VpcEndpointId: 'vpce-ecr-api',
-        ServiceName: 'cn.com.amazonaws.cn-northwest-1.ecr.api',
-        VpcEndpointType: VpcEndpointType.Interface,
-        Groups: vpcEndpointsGroups,
-        SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-      },
-      {
-        VpcEndpointId: 'vpce-ecs',
-        ServiceName: 'cn.com.amazonaws.cn-northwest-1.ecs',
-        VpcEndpointType: VpcEndpointType.Interface,
-        Groups: vpcEndpointsGroups,
-        SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-      },
-      {
-        VpcEndpointId: 'vpce-ecs-agent',
-        ServiceName: 'cn.com.amazonaws.cn-northwest-1.ecs-agent',
-        VpcEndpointType: VpcEndpointType.Interface,
-        Groups: vpcEndpointsGroups,
-        SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-      },
-      {
-        VpcEndpointId: 'vpce-ecs-telemetry',
-        ServiceName: 'cn.com.amazonaws.cn-northwest-1.ecs-telemetry',
-        VpcEndpointType: VpcEndpointType.Interface,
-        Groups: vpcEndpointsGroups,
-        SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-      },
-      {
-        VpcEndpointId: 'vpce-kinesis-streams',
-        ServiceName: 'cn.com.amazonaws.cn-northwest-1.kinesis-streams',
-        VpcEndpointType: VpcEndpointType.Interface,
-        Groups: vpcEndpointsGroups,
-        SubnetIds: defaultSubnets.map(subnet => subnet.SubnetId),
-      },
-    ],
-  });
+function createPipelineMockForBJSRegion(s3Mock: any) {
   s3Mock.on(GetBucketPolicyCommand).resolves({ Policy: AllowIAMUserPutObjectPolicyInCnNorth1 });
 }
 

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -242,6 +242,7 @@ describe('Pipeline test', () => {
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
         subnetsCross3AZ: true,
+        noVpcEndpoint: true,
       });
     ddbMock.on(PutCommand).resolves({});
     const res = await request(app)
@@ -285,6 +286,7 @@ describe('Pipeline test', () => {
         publicAZContainPrivateAZ: true,
         subnetsCross3AZ: true,
         subnetsIsolated: false,
+        noVpcEndpoint: true,
       });
     ddbMock.on(PutCommand).resolves({});
     const res = await request(app)
@@ -298,11 +300,39 @@ describe('Pipeline test', () => {
     expect(res.body.data).toHaveProperty('id');
     expect(res.body.message).toEqual('Pipeline added.');
     expect(res.body.success).toEqual(true);
-    expect(ec2Mock).toHaveReceivedCommandTimes(DescribeVpcEndpointsCommand, 0);
+    expect(ec2Mock).toHaveReceivedCommandTimes(DescribeVpcEndpointsCommand, 1);
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeSecurityGroupRulesCommand, 1);
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeSubnetsCommand, 1);
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeRouteTablesCommand, 1);
     expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
+  });
+  it('Create pipeline in private subnet with vpc endpoint', async () => {
+    tokenMock(ddbMock, false);
+    projectExistedMock(ddbMock, true);
+    dictionaryMock(ddbMock);
+    createPipelineMock(ddbMock, kafkaMock, redshiftServerlessMock, redshiftMock,
+      ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
+        publicAZContainPrivateAZ: true,
+        subnetsCross3AZ: true,
+        subnetsIsolated: false,
+        noVpcEndpoint: false,
+        missVpcEndpoint: false,
+      });
+    ddbMock.on(PutCommand).resolves({});
+    const res = await request(app)
+      .post('/api/pipeline')
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_QUICKSIGHT_PIPELINE,
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toEqual('Validation error: vpc endpoint error in subnet: subnet-00000000000000011, detail: [{\"service\":\"com.amazonaws.ap-southeast-1.error\",\"reason\":\"The Availability Zones (AZ) of VPC Endpoint (com.amazonaws.ap-southeast-1.error) subnets must contain Availability Zones (AZ) of isolated subnets.\"}].');
+    expect(ec2Mock).toHaveReceivedCommandTimes(DescribeVpcEndpointsCommand, 1);
+    expect(ec2Mock).toHaveReceivedCommandTimes(DescribeSecurityGroupRulesCommand, 1);
+    expect(ec2Mock).toHaveReceivedCommandTimes(DescribeSubnetsCommand, 1);
+    expect(ec2Mock).toHaveReceivedCommandTimes(DescribeRouteTablesCommand, 1);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
   });
   it('Create pipeline with ALB policy disable ', async () => {
     tokenMock(ddbMock, false);
@@ -512,6 +542,7 @@ describe('Pipeline test', () => {
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
         twoAZsInRegion: true,
+        noVpcEndpoint: true,
       });
     ddbMock.on(PutCommand).resolves({});
 
@@ -562,7 +593,7 @@ describe('Pipeline test', () => {
     expect(res.body.data).toHaveProperty('id');
     expect(res.body.message).toEqual('Pipeline added.');
     expect(res.body.success).toEqual(true);
-    expect(ec2Mock).toHaveReceivedCommandTimes(DescribeVpcEndpointsCommand, 0);
+    expect(ec2Mock).toHaveReceivedCommandTimes(DescribeVpcEndpointsCommand, 1);
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeSecurityGroupRulesCommand, 1);
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeSubnetsCommand, 1);
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeRouteTablesCommand, 1);
@@ -576,6 +607,7 @@ describe('Pipeline test', () => {
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
         twoAZsInRegion: true,
+        noVpcEndpoint: true,
       });
     ddbMock.on(PutCommand).resolves({});
 
@@ -687,6 +719,7 @@ describe('Pipeline test', () => {
         publicAZContainPrivateAZ: true,
         subnetsCross3AZ: true,
         sgError: true,
+        noVpcEndpoint: true,
       });
     ddbMock.on(PutCommand).resolves({});
 
@@ -699,7 +732,7 @@ describe('Pipeline test', () => {
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(201);
     expect(quickSightMock).toHaveReceivedCommandTimes(DescribeAccountSubscriptionCommand, 0);
-    expect(ec2Mock).toHaveReceivedCommandTimes(DescribeVpcEndpointsCommand, 0);
+    expect(ec2Mock).toHaveReceivedCommandTimes(DescribeVpcEndpointsCommand, 1);
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeSecurityGroupRulesCommand, 1);
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeSubnetsCommand, 1);
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeRouteTablesCommand, 1);
@@ -713,6 +746,7 @@ describe('Pipeline test', () => {
         publicAZContainPrivateAZ: true,
         subnetsCross3AZ: true,
         sgError: true,
+        noVpcEndpoint: true,
       });
     ddbMock.on(PutCommand).resolves({});
 
@@ -725,7 +759,7 @@ describe('Pipeline test', () => {
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(400);
     expect(res.body.message).toEqual('Validation error: Provisioned Redshift security groups missing rule for QuickSight access.');
-    expect(ec2Mock).toHaveReceivedCommandTimes(DescribeVpcEndpointsCommand, 0);
+    expect(ec2Mock).toHaveReceivedCommandTimes(DescribeVpcEndpointsCommand, 1);
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeSecurityGroupRulesCommand, 1);
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeSubnetsCommand, 1);
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeRouteTablesCommand, 1);
@@ -842,6 +876,7 @@ describe('Pipeline test', () => {
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
         subnetsCross3AZ: true,
+        noVpcEndpoint: true,
       });
     ddbMock.on(PutCommand).resolves({});
     const res = await request(app)
@@ -862,6 +897,7 @@ describe('Pipeline test', () => {
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
         subnetsCross3AZ: true,
+        noVpcEndpoint: true,
       });
     ddbMock.on(PutCommand).resolves({});
     const res = await request(app)
@@ -897,6 +933,7 @@ describe('Pipeline test', () => {
     createPipelineMock(ddbMock, kafkaMock, redshiftServerlessMock, redshiftMock,
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
+        noVpcEndpoint: true,
       });
     const res = await request(app)
       .post('/api/pipeline')
@@ -919,6 +956,7 @@ describe('Pipeline test', () => {
     createPipelineMock(ddbMock, kafkaMock, redshiftServerlessMock, redshiftMock,
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
+        noVpcEndpoint: true,
       });
     // Mock DynamoDB error
     ddbMock.on(TransactWriteItemsCommand).rejects(new Error('Mock DynamoDB error'));

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -190,11 +190,10 @@ describe('Pipeline test', () => {
     createPipelineMock(ddbMock, kafkaMock, redshiftServerlessMock, redshiftMock,
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
-        subnetsCross3AZ: true,
-        subnetsIsolated: true,
+        noVpcEndpoint: true,
       });
     ddbMock.on(PutCommand).resolves({});
-    createPipelineMockForBJSRegion(ec2Mock, s3Mock);
+    createPipelineMockForBJSRegion(s3Mock);
     const res = await request(app)
       .post('/api/pipeline')
       .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
@@ -208,9 +207,6 @@ describe('Pipeline test', () => {
     expect(res.body.message).toEqual('Pipeline added.');
     expect(res.body.success).toEqual(true);
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeVpcEndpointsCommand, 1);
-    expect(ec2Mock).toHaveReceivedCommandTimes(DescribeSecurityGroupRulesCommand, 1);
-    expect(ec2Mock).toHaveReceivedCommandTimes(DescribeSubnetsCommand, 1);
-    expect(ec2Mock).toHaveReceivedCommandTimes(DescribeRouteTablesCommand, 1);
     expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
   });
   it('Create pipeline with error RPU not increments of 8', async () => {

--- a/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
@@ -148,6 +148,7 @@ describe('Workflow test', () => {
     createPipelineMock(ddbMock, kafkaMock, redshiftServerlessMock, redshiftMock,
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
+        noVpcEndpoint: true,
       });
     const pipeline: CPipeline = new CPipeline({ ...S3_INGESTION_PIPELINE });
     const wf = await pipeline.generateWorkflow();
@@ -362,6 +363,7 @@ describe('Workflow test', () => {
     createPipelineMock(ddbMock, kafkaMock, redshiftServerlessMock, redshiftMock,
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
+        noVpcEndpoint: true,
       });
     const pipeline: CPipeline = new CPipeline({ ...KAFKA_INGESTION_PIPELINE });
     const wf = await pipeline.generateWorkflow();
@@ -467,6 +469,7 @@ describe('Workflow test', () => {
     createPipelineMock(ddbMock, kafkaMock, redshiftServerlessMock, redshiftMock,
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
+        noVpcEndpoint: true,
       });
     const pipeline: CPipeline = new CPipeline({ ...KAFKA_WITH_CONNECTOR_INGESTION_PIPELINE });
     const wf = await pipeline.generateWorkflow();
@@ -594,6 +597,7 @@ describe('Workflow test', () => {
     createPipelineMock(ddbMock, kafkaMock, redshiftServerlessMock, redshiftMock,
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
+        noVpcEndpoint: true,
       });
     createPipelineMockForBJSRegion(ec2Mock, s3Mock);
     const pipeline: CPipeline = new CPipeline({
@@ -725,6 +729,7 @@ describe('Workflow test', () => {
     createPipelineMock(ddbMock, kafkaMock, redshiftServerlessMock, redshiftMock,
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
+        noVpcEndpoint: true,
       });
     const pipeline: CPipeline = new CPipeline({ ...KINESIS_ON_DEMAND_INGESTION_PIPELINE });
     const wf = await pipeline.generateWorkflow();
@@ -830,6 +835,7 @@ describe('Workflow test', () => {
     createPipelineMock(ddbMock, kafkaMock, redshiftServerlessMock, redshiftMock,
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
+        noVpcEndpoint: true,
       });
     createPipelineMockForBJSRegion(ec2Mock, s3Mock);
     const pipeline: CPipeline = new CPipeline({
@@ -939,6 +945,7 @@ describe('Workflow test', () => {
     createPipelineMock(ddbMock, kafkaMock, redshiftServerlessMock, redshiftMock,
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
+        noVpcEndpoint: true,
       });
     const pipeline: CPipeline = new CPipeline({ ...S3_DATA_PROCESSING_PIPELINE });
     const wf = await pipeline.generateWorkflow();
@@ -1072,6 +1079,7 @@ describe('Workflow test', () => {
         publicAZContainPrivateAZ: true,
         subnetsIsolated: true,
         subnetsCross3AZ: true,
+        noVpcEndpoint: true,
       });
     const pipeline: CPipeline = new CPipeline({ ...S3_DATA_PROCESSING_WITH_SPECIFY_PREFIX_PIPELINE });
     const wf = await pipeline.generateWorkflow();
@@ -1596,6 +1604,7 @@ describe('Workflow test', () => {
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
         subnetsCross3AZ: true,
+        noVpcEndpoint: true,
       });
     const pipeline: CPipeline = new CPipeline({ ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE });
     const wf = await pipeline.generateWorkflow();
@@ -1748,6 +1757,7 @@ describe('Workflow test', () => {
     createPipelineMock(ddbMock, kafkaMock, redshiftServerlessMock, redshiftMock,
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
+        noVpcEndpoint: true,
       });
     const pipeline: CPipeline = new CPipeline({ ...KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_PIPELINE });
     const wf = await pipeline.generateWorkflow();
@@ -1921,6 +1931,7 @@ describe('Workflow test', () => {
     createPipelineMock(ddbMock, kafkaMock, redshiftServerlessMock, redshiftMock,
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
+        noVpcEndpoint: true,
       });
     const pipeline: CPipeline = new CPipeline({ ...KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_QUICKSIGHT_PIPELINE });
     const wf = await pipeline.generateWorkflow();
@@ -2116,6 +2127,7 @@ describe('Workflow test', () => {
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
         subnetsCross3AZ: true,
+        noVpcEndpoint: true,
       });
     const pipeline: CPipeline = new CPipeline({ ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_QUICKSIGHT_PIPELINE });
     const wf = await pipeline.generateWorkflow();
@@ -3324,6 +3336,7 @@ describe('Workflow test', () => {
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
         subnetsCross3AZ: true,
+        noVpcEndpoint: true,
       });
     const pipeline: CPipeline = new CPipeline({ ...S3_INGESTION_PIPELINE });
     await pipeline.generateWorkflow();
@@ -3338,6 +3351,7 @@ describe('Workflow test', () => {
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
         subnetsCross3AZ: true,
+        noVpcEndpoint: true,
       });
     ddbMock.on(GetCommand, {
       TableName: dictionaryTableName,
@@ -3399,6 +3413,7 @@ describe('Workflow test', () => {
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
         subnetsCross3AZ: true,
+        noVpcEndpoint: true,
       });
     process.env.AWS_REGION='us-east-1';
     const pipeline: CPipeline = new CPipeline({ ...S3_INGESTION_PIPELINE });
@@ -3443,6 +3458,7 @@ describe('Workflow test', () => {
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
         subnetsCross3AZ: true,
+        noVpcEndpoint: true,
       });
     process.env.AWS_REGION='us-east-1';
     const pipeline: CPipeline = new CPipeline({ ...S3_INGESTION_PIPELINE });

--- a/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
@@ -254,8 +254,9 @@ describe('Workflow test', () => {
     createPipelineMock(ddbMock, kafkaMock, redshiftServerlessMock, redshiftMock,
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
+        noVpcEndpoint: true,
       });
-    createPipelineMockForBJSRegion(ec2Mock, s3Mock);
+    createPipelineMockForBJSRegion(s3Mock);
     const pipeline: CPipeline = new CPipeline({
       ...S3_INGESTION_PIPELINE,
       region: 'cn-north-1',
@@ -599,7 +600,7 @@ describe('Workflow test', () => {
         publicAZContainPrivateAZ: true,
         noVpcEndpoint: true,
       });
-    createPipelineMockForBJSRegion(ec2Mock, s3Mock);
+    createPipelineMockForBJSRegion(s3Mock);
     const pipeline: CPipeline = new CPipeline({
       ...MSK_WITH_CONNECTOR_INGESTION_PIPELINE,
       region: 'cn-north-1',
@@ -837,7 +838,7 @@ describe('Workflow test', () => {
         publicAZContainPrivateAZ: true,
         noVpcEndpoint: true,
       });
-    createPipelineMockForBJSRegion(ec2Mock, s3Mock);
+    createPipelineMockForBJSRegion(s3Mock);
     const pipeline: CPipeline = new CPipeline({
       ...KINESIS_PROVISIONED_INGESTION_PIPELINE,
       region: 'cn-north-1',
@@ -1079,7 +1080,6 @@ describe('Workflow test', () => {
         publicAZContainPrivateAZ: true,
         subnetsIsolated: true,
         subnetsCross3AZ: true,
-        noVpcEndpoint: true,
       });
     const pipeline: CPipeline = new CPipeline({ ...S3_DATA_PROCESSING_WITH_SPECIFY_PREFIX_PIPELINE });
     const wf = await pipeline.generateWorkflow();


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. Check NAT is create in **private subnet** or `ConnectivityType=private`
2. Check VPC Endpoint even if NAT already exists in private subnet

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend