### PR TITLE
fix: create service linked role for Service Catalog AppRegistry

### DIFF
--- a/src/common/solution-info.ts
+++ b/src/common/solution-info.ts
@@ -11,6 +11,11 @@
  *  and limitations under the License.
  */
 
+interface VersionProps {
+  readonly full: string;
+  readonly short: string;
+  readonly buildId: string;
+};
 
 export class SolutionInfo {
 
@@ -19,30 +24,27 @@ export class SolutionInfo {
   static SOLUTION_SHORT_NAME = 'Clickstream';
   static SOLUTION_VERSION = process.env.SOLUTION_VERSION || 'v1.0.0';
   static SOLUTION_VERSION_DETAIL = versionDetail(SolutionInfo.SOLUTION_VERSION);
-  static SOLUTION_VERSION_SHORT = versionShort(SolutionInfo.SOLUTION_VERSION);
+  static SOLUTION_VERSION_SHORT = parseVersion(SolutionInfo.SOLUTION_VERSION).short;
   static DESCRIPTION = `(${SolutionInfo.SOLUTION_ID}) ${SolutionInfo.SOLUTION_NAME} ${SolutionInfo.SOLUTION_VERSION_DETAIL}`;
   static SOLUTION_TYPE = 'AWS-Solutions';
 }
 
-function versionDetail(version: string): string {
+function parseVersion(version: string): VersionProps {
   const versionPattern = /^(v\d+\.\d+\.\d+)-?(.*)/;
   const match = version.match(versionPattern);
 
   if (match) {
-    const buildId = match[2] ? `(Build ${match[2]})` : '';
-    return `(Version ${match[1]})${buildId}`;
+    return {
+      full: version,
+      short: match[1],
+      buildId: match[2],
+    };
   }
 
   throw new Error(`Illegal version string '${version}'.`);
 }
 
-function versionShort(version: string): string {
-  const versionPattern = /^(v\d+\.\d+\.\d+)-?(.*)/;
-  const match = version.match(versionPattern);
-
-  if (match) {
-    return match[1];
-  }
-
-  throw new Error(`Illegal version string '${version}'.`);
+export function versionDetail(version: string): string {
+  const { short, buildId } = parseVersion(version);
+  return `(Version ${short})${buildId ? `(Build ${buildId})` : ''}`;
 }

--- a/src/common/solution-info.ts
+++ b/src/common/solution-info.ts
@@ -19,6 +19,7 @@ export class SolutionInfo {
   static SOLUTION_SHORT_NAME = 'Clickstream';
   static SOLUTION_VERSION = process.env.SOLUTION_VERSION || 'v1.0.0';
   static SOLUTION_VERSION_DETAIL = versionDetail(SolutionInfo.SOLUTION_VERSION);
+  static SOLUTION_VERSION_SHORT = versionShort(SolutionInfo.SOLUTION_VERSION);
   static DESCRIPTION = `(${SolutionInfo.SOLUTION_ID}) ${SolutionInfo.SOLUTION_NAME} ${SolutionInfo.SOLUTION_VERSION_DETAIL}`;
   static SOLUTION_TYPE = 'AWS-Solutions';
 }
@@ -30,6 +31,17 @@ function versionDetail(version: string): string {
   if (match) {
     const buildId = match[2] ? `(Build ${match[2]})` : '';
     return `(Version ${match[1]})${buildId}`;
+  }
+
+  throw new Error(`Illegal version string '${version}'.`);
+}
+
+function versionShort(version: string): string {
+  const versionPattern = /^(v\d+\.\d+\.\d+)-?(.*)/;
+  const match = version.match(versionPattern);
+
+  if (match) {
+    return match[1];
   }
 
   throw new Error(`Illegal version string '${version}'.`);

--- a/src/control-plane/backend/stack-action-state-machine-construct.ts
+++ b/src/control-plane/backend/stack-action-state-machine-construct.ts
@@ -133,6 +133,7 @@ export class StackActionStateMachine extends Construct {
             `arn:${Aws.PARTITION}:iam::${Aws.ACCOUNT_ID}:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS`,
             `arn:${Aws.PARTITION}:iam::${Aws.ACCOUNT_ID}:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing`,
             `arn:${Aws.PARTITION}:iam::${Aws.ACCOUNT_ID}:role/aws-service-role/globalaccelerator.amazonaws.com/AWSServiceRoleForGlobalAccelerator`,
+            `arn:${Aws.PARTITION}:iam::${Aws.ACCOUNT_ID}:role/aws-service-role/servicecatalog-appregistry.amazonaws.com/AWSServiceRoleForAWSServiceCatalogAppRegistry`,
           ],
         }),
         // This list of actions is to ensure the call stack can be created/updated/deleted successfully.

--- a/src/service-catalog-appregistry-stack.ts
+++ b/src/service-catalog-appregistry-stack.ts
@@ -52,7 +52,7 @@ export class ServiceCatalogAppregistryStack extends Stack {
     // Add tags for AppRegistry application
     Tags.of(application).add('Solutions:SolutionID', SolutionInfo.SOLUTION_ID);
     Tags.of(application).add('Solutions:SolutionName', SolutionInfo.SOLUTION_NAME);
-    Tags.of(application).add('Solutions:SolutionVersion', SolutionInfo.SOLUTION_VERSION);
+    Tags.of(application).add('Solutions:SolutionVersion', SolutionInfo.SOLUTION_VERSION_SHORT);
     Tags.of(application).add('Solutions:ApplicationType', SolutionInfo.SOLUTION_TYPE);
 
     new CfnOutput(this, OUTPUT_SERVICE_CATALOG_APPREGISTRY_APPLICATION_ARN, {

--- a/test/common/solution-info.test.ts
+++ b/test/common/solution-info.test.ts
@@ -1,0 +1,21 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { versionDetail } from '../../src/common/solution-info';
+
+test ('parse solution version', () => {
+  expect(versionDetail('v1.1.0-dev-main-202311081606-58f342d5'))
+    .toEqual('(Version v1.1.0)(Build dev-main-202311081606-58f342d5)');
+
+  expect(versionDetail('v1.1.0')).toEqual('(Version v1.1.0)');
+});

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -984,6 +984,22 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
                   ],
                 ],
               },
+              {
+                'Fn::Join': [
+                  '',
+                  [
+                    'arn:',
+                    {
+                      Ref: 'AWS::Partition',
+                    },
+                    ':iam::',
+                    {
+                      Ref: 'AWS::AccountId',
+                    },
+                    ':role/aws-service-role/servicecatalog-appregistry.amazonaws.com/AWSServiceRoleForAWSServiceCatalogAppRegistry',
+                  ],
+                ],
+              },
             ],
           },
           {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

* Create service linked role for Service Catalog AppRegistry
* Use short version (e.g., v1.1.0) in Service Catalog AppRegistry application tag

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend