### PR TITLE
feat: add new role AnalystReader

### DIFF
--- a/frontend/public/locales/en-US/user.json
+++ b/frontend/public/locales/en-US/user.json
@@ -24,12 +24,15 @@
     "settingUserOperatorRoleNames": "Operator Role Names",
     "settingUserOperatorRoleNamesDesc": "The roles in OIDC are mapped to operators in Click stream, with multiple role names separated by commas, for example: operator,others",
     "settingUserAnalystRoleNames": "Analyst Role Names",
-    "settingUserAnalystRoleNamesDesc": "The roles in OIDC are mapped to analyst in Click stream, with multiple role names separated by commas, for example: analyst,others"
+    "settingUserAnalystRoleNamesDesc": "The roles in OIDC are mapped to analyst in Click stream, with multiple role names separated by commas, for example: analyst,others",
+    "settingUserAnalystReaderRoleNames": "Analyst Reader Role Names",
+    "settingUserAnalystReaderRoleNamesDesc": "The roles in OIDC are mapped to analyst reader in Click stream, with multiple role names separated by commas, for example: analystReader,others"
   },
   "options": {
     "admin": "Administrator",
     "operator": "Operator",
     "analyst": "Analyst",
+    "analystReader": "AnalystReader",
     "noIdentity": "NoIdentity"
   },
   "valid": {

--- a/frontend/public/locales/en-US/user.json
+++ b/frontend/public/locales/en-US/user.json
@@ -22,11 +22,11 @@
     "settingUserRoleJsonPath": "User Role Json Path",
     "settingUserRoleJsonPathDesc": "Obtain user role or group information from id_token, for example: $.realm_access.roles",
     "settingUserOperatorRoleNames": "Operator Role Names",
-    "settingUserOperatorRoleNamesDesc": "The roles in OIDC are mapped to operators in Click stream, with multiple role names separated by commas, for example: operator,others",
+    "settingUserOperatorRoleNamesDesc": "The roles in OIDC are mapped to operators in Clickstream, with multiple role names separated by commas, for example: operator,others",
     "settingUserAnalystRoleNames": "Analyst Role Names",
-    "settingUserAnalystRoleNamesDesc": "The roles in OIDC are mapped to analyst in Click stream, with multiple role names separated by commas, for example: analyst,others",
+    "settingUserAnalystRoleNamesDesc": "The roles in OIDC are mapped to analyst in Clickstream, with multiple role names separated by commas, for example: analyst,others",
     "settingUserAnalystReaderRoleNames": "Analyst Reader Role Names",
-    "settingUserAnalystReaderRoleNamesDesc": "The roles in OIDC are mapped to analyst reader in Click stream, with multiple role names separated by commas, for example: analystReader,others"
+    "settingUserAnalystReaderRoleNamesDesc": "The roles in OIDC are mapped to analyst reader in Clickstream, with multiple role names separated by commas, for example: analystReader,others"
   },
   "options": {
     "admin": "Administrator",

--- a/frontend/public/locales/zh-CN/user.json
+++ b/frontend/public/locales/zh-CN/user.json
@@ -22,14 +22,17 @@
     "settingUserRoleJsonPath": "获取用户角色的JsonPath",
     "settingUserRoleJsonPathDesc": "从id_token中获取用户角色或者组信息的JsonPath，例如：$.realm_access.roles",
     "settingUserOperatorRoleNames": "操作员角色名称",
-    "settingUserOperatorRoleNamesDesc": "OIDC中的角色映射为Click stream中的操作员，多个角色名称用逗号分隔，例如：operator,operator2",
-    "settingUserAnalystRoleNames": "分析员角色名称",
-    "settingUserAnalystRoleNamesDesc": "OIDC中的角色映射为Click stream中的分析员，多个角色名称用逗号分隔，例如：analyst,analyst2"
+    "settingUserOperatorRoleNamesDesc": "OIDC中的角色映射为Clickstream中的操作员，多个角色名称用逗号分隔，例如：operator,others",
+    "settingUserAnalystRoleNames": "分析师角色名称",
+    "settingUserAnalystRoleNamesDesc": "OIDC中的角色映射为Clickstream中的分析师，多个角色名称用逗号分隔，例如：analyst,others",
+    "settingUserAnalystReaderRoleNames": "分析师读者角色名称",
+    "settingUserAnalystReaderRoleNamesDesc": "OIDC中的角色映射为Clickstream中的分析师读者，多个角色名称用逗号分隔，例如：analystReader,others"
   },
   "options": {
     "admin": "管理员",
     "operator": "IT运维",
     "analyst": "分析师",
+    "analystReader": "分析师读者",
     "noIdentity": "无身份"
   },
   "valid": {

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -222,7 +222,11 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
               <RoleRoute
                 layout="none"
                 auth={auth}
-                roles={[IUserRole.ADMIN, IUserRole.ANALYST]}
+                roles={[
+                  IUserRole.ADMIN,
+                  IUserRole.ANALYST,
+                  IUserRole.ANALYST_READER,
+                ]}
               >
                 <AnalyticsHome auth={auth} />
               </RoleRoute>
@@ -234,7 +238,11 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
               <RoleRoute
                 layout="analytics"
                 auth={auth}
-                roles={[IUserRole.ADMIN, IUserRole.ANALYST]}
+                roles={[
+                  IUserRole.ADMIN,
+                  IUserRole.ANALYST,
+                  IUserRole.ANALYST_READER,
+                ]}
               >
                 <AnalyticsDataManagement />
               </RoleRoute>
@@ -246,7 +254,11 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
               <RoleRoute
                 layout="analytics"
                 auth={auth}
-                roles={[IUserRole.ADMIN, IUserRole.ANALYST]}
+                roles={[
+                  IUserRole.ADMIN,
+                  IUserRole.ANALYST,
+                  IUserRole.ANALYST_READER,
+                ]}
               >
                 <AnalyticsRealtime />
               </RoleRoute>
@@ -258,7 +270,11 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
               <RoleRoute
                 layout="analytics"
                 auth={auth}
-                roles={[IUserRole.ADMIN, IUserRole.ANALYST]}
+                roles={[
+                  IUserRole.ADMIN,
+                  IUserRole.ANALYST,
+                  IUserRole.ANALYST_READER,
+                ]}
               >
                 <AnalyticsExplore />
               </RoleRoute>
@@ -282,7 +298,11 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
               <RoleRoute
                 layout="analytics"
                 auth={auth}
-                roles={[IUserRole.ADMIN, IUserRole.ANALYST]}
+                roles={[
+                  IUserRole.ADMIN,
+                  IUserRole.ANALYST,
+                  IUserRole.ANALYST_READER,
+                ]}
               >
                 <AnalyticsDashboard />
               </RoleRoute>
@@ -294,7 +314,11 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
               <RoleRoute
                 layout="analytics"
                 auth={auth}
-                roles={[IUserRole.ADMIN, IUserRole.ANALYST]}
+                roles={[
+                  IUserRole.ADMIN,
+                  IUserRole.ANALYST,
+                  IUserRole.ANALYST_READER,
+                ]}
               >
                 <AnalyticsDashboardDetail />
               </RoleRoute>
@@ -306,7 +330,11 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
               <RoleRoute
                 layout="none"
                 auth={auth}
-                roles={[IUserRole.ADMIN, IUserRole.ANALYST]}
+                roles={[
+                  IUserRole.ADMIN,
+                  IUserRole.ANALYST,
+                  IUserRole.ANALYST_READER,
+                ]}
               >
                 <AnalyticsDashboardFullWindow />
               </RoleRoute>

--- a/frontend/src/components/layouts/AnalyticsNavigation.tsx
+++ b/frontend/src/components/layouts/AnalyticsNavigation.tsx
@@ -13,11 +13,12 @@
 
 import { Icon } from '@cloudscape-design/components';
 import ExtendIcon from 'components/common/ExtendIcon';
-import React, { useState } from 'react';
+import { UserContext } from 'context/UserContext';
+import React, { useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import { ANALYTICS_NAV_STATUS } from 'ts/const';
-import { defaultStr } from 'ts/utils';
+import { ANALYTICS_NAV_STATUS, IUserRole } from 'ts/const';
+import { defaultStr, getUserInfoFromLocalStorage } from 'ts/utils';
 
 interface INavigationProps {
   activeHref: string;
@@ -34,6 +35,7 @@ const AnalyticsNavigation: React.FC<INavigationProps> = (
 ) => {
   const { activeHref } = props;
   const { t } = useTranslation();
+  const currentUser = useContext(UserContext) ?? getUserInfoFromLocalStorage();
   const { projectId, appId } = useParams();
   const [isExpanded, setIsExpanded] = useState<boolean>(
     localStorage.getItem(ANALYTICS_NAV_STATUS) === 'close' ? false : true
@@ -67,10 +69,17 @@ const AnalyticsNavigation: React.FC<INavigationProps> = (
     },
   ];
 
+  const getNavItems = () => {
+    if (currentUser.role === IUserRole.ANALYST_READER) {
+      return [...analyticsNavItems.slice(0, 2), ...analyticsNavItems.slice(3)];
+    }
+    return analyticsNavItems;
+  };
+
   return (
     <div className={`sidebar ${isExpanded ? 'expanded' : ''}`}>
       <ul>
-        {analyticsNavItems.map((item: IAnalyticsItemType) => (
+        {getNavItems().map((item: IAnalyticsItemType) => (
           <li
             key={item.href}
             className={item.href === activeHref ? 'active' : ''}

--- a/frontend/src/pages/analytics/comps/DashboardHeader.tsx
+++ b/frontend/src/pages/analytics/comps/DashboardHeader.tsx
@@ -20,11 +20,13 @@ import {
 import { deleteAnalyticsDashboard } from 'apis/analytics';
 import InfoLink from 'components/common/InfoLink';
 import { DispatchContext } from 'context/StateContext';
+import { UserContext } from 'context/UserContext';
 import { HelpInfoActionType, HelpPanelType } from 'context/reducer';
 import React, { useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import { defaultStr } from 'ts/utils';
+import { IUserRole } from 'ts/const';
+import { defaultStr, getUserInfoFromLocalStorage } from 'ts/utils';
 
 interface DashboardHeaderProps {
   totalNum: number;
@@ -46,6 +48,7 @@ const DashboardHeader: React.FC<DashboardHeaderProps> = (
     refreshPage,
   } = props;
   const { projectId, appId } = useParams();
+  const currentUser = useContext(UserContext) ?? getUserInfoFromLocalStorage();
   const [loadingDelete, setLoadingDelete] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const dispatch = useContext(DispatchContext);
@@ -118,21 +121,25 @@ const DashboardHeader: React.FC<DashboardHeaderProps> = (
         }
         actions={
           <SpaceBetween size="xs" direction="horizontal">
-            <Button
-              disabled={!dashboard?.id}
-              onClick={() => {
-                setShowDeleteModal(true);
-              }}
-            >
-              {t('button.delete')}
-            </Button>
-            <Button
-              data-testid="header-btn-create"
-              variant="primary"
-              onClick={onClickCreate}
-            >
-              {t('common:button.createDashboard')}
-            </Button>
+            {currentUser.role !== IUserRole.ANALYST_READER && (
+              <>
+                <Button
+                  disabled={!dashboard?.id}
+                  onClick={() => {
+                    setShowDeleteModal(true);
+                  }}
+                >
+                  {t('button.delete')}
+                </Button>
+                <Button
+                  data-testid="header-btn-create"
+                  variant="primary"
+                  onClick={onClickCreate}
+                >
+                  {t('common:button.createDashboard')}
+                </Button>
+              </>
+            )}
           </SpaceBetween>
         }
       >

--- a/frontend/src/pages/analytics/event/AnalyticsEvent.tsx
+++ b/frontend/src/pages/analytics/event/AnalyticsEvent.tsx
@@ -38,11 +38,12 @@ import {
 } from 'components/eventselect/AnalyticsType';
 import EventsSelect from 'components/eventselect/EventSelect';
 import SegmentationFilter from 'components/eventselect/SegmentationFilter';
+import { UserContext } from 'context/UserContext';
 import { cloneDeep } from 'lodash';
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import { COMMON_ALERT_TYPE } from 'ts/const';
+import { COMMON_ALERT_TYPE, IUserRole } from 'ts/const';
 import {
   QUICKSIGHT_ANALYSIS_INFIX,
   QUICKSIGHT_DASHBOARD_INFIX,
@@ -59,6 +60,7 @@ import {
   defaultStr,
   generateStr,
   getEventParameters,
+  getUserInfoFromLocalStorage,
 } from 'ts/utils';
 import {
   getDashboardCreateParameters,
@@ -106,6 +108,7 @@ const AnalyticsEvent: React.FC<AnalyticsEventProps> = (
     loadingEvents,
   } = props;
   const { appId } = useParams();
+  const currentUser = useContext(UserContext) ?? getUserInfoFromLocalStorage();
   const [loadingData, setLoadingData] = useState(loading);
   const [loadingChart, setLoadingChart] = useState(false);
   const [selectDashboardModalVisible, setSelectDashboardModalVisible] =
@@ -346,15 +349,17 @@ const AnalyticsEvent: React.FC<AnalyticsEventProps> = (
                   >
                     {t('button.reset')}
                   </Button>
-                  <Button
-                    variant="primary"
-                    loading={loadingData}
-                    onClick={() => {
-                      setSelectDashboardModalVisible(true);
-                    }}
-                  >
-                    {t('button.saveToDashboard')}
-                  </Button>
+                  {currentUser.role !== IUserRole.ANALYST_READER && (
+                    <Button
+                      variant="primary"
+                      loading={loadingData}
+                      onClick={() => {
+                        setSelectDashboardModalVisible(true);
+                      }}
+                    >
+                      {t('button.saveToDashboard')}
+                    </Button>
+                  )}
                 </SpaceBetween>
               }
             >

--- a/frontend/src/pages/analytics/funnel/AnalyticsFunnel.tsx
+++ b/frontend/src/pages/analytics/funnel/AnalyticsFunnel.tsx
@@ -41,11 +41,12 @@ import {
 } from 'components/eventselect/AnalyticsType';
 import EventsSelect from 'components/eventselect/EventSelect';
 import SegmentationFilter from 'components/eventselect/SegmentationFilter';
+import { UserContext } from 'context/UserContext';
 import { cloneDeep } from 'lodash';
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import { COMMON_ALERT_TYPE } from 'ts/const';
+import { COMMON_ALERT_TYPE, IUserRole } from 'ts/const';
 import {
   QUICKSIGHT_ANALYSIS_INFIX,
   QUICKSIGHT_DASHBOARD_INFIX,
@@ -62,6 +63,7 @@ import {
   defaultStr,
   generateStr,
   getEventParameters,
+  getUserInfoFromLocalStorage,
 } from 'ts/utils';
 import {
   parametersConvertToCategoryItemType,
@@ -110,6 +112,7 @@ const AnalyticsFunnel: React.FC<AnalyticsFunnelProps> = (
     loadingEvents,
   } = props;
   const { appId } = useParams();
+  const currentUser = useContext(UserContext) ?? getUserInfoFromLocalStorage();
   const [loadingData, setLoadingData] = useState(loading);
   const [loadingChart, setLoadingChart] = useState(false);
   const [selectDashboardModalVisible, setSelectDashboardModalVisible] =
@@ -416,15 +419,17 @@ const AnalyticsFunnel: React.FC<AnalyticsFunnelProps> = (
                   >
                     {t('button.reset')}
                   </Button>
-                  <Button
-                    variant="primary"
-                    loading={loadingData}
-                    onClick={() => {
-                      setSelectDashboardModalVisible(true);
-                    }}
-                  >
-                    {t('button.saveToDashboard')}
-                  </Button>
+                  {currentUser.role !== IUserRole.ANALYST_READER && (
+                    <Button
+                      variant="primary"
+                      loading={loadingData}
+                      onClick={() => {
+                        setSelectDashboardModalVisible(true);
+                      }}
+                    >
+                      {t('button.saveToDashboard')}
+                    </Button>
+                  )}
                 </SpaceBetween>
               }
             >

--- a/frontend/src/pages/analytics/metadata/event-parameters/MetadataParameterSplitPanel.tsx
+++ b/frontend/src/pages/analytics/metadata/event-parameters/MetadataParameterSplitPanel.tsx
@@ -28,11 +28,12 @@ import {
   updateMetadataDisplay,
 } from 'apis/analytics';
 import Loading from 'components/common/Loading';
-import React, { useEffect, useState } from 'react';
+import { UserContext } from 'context/UserContext';
+import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import { EVENT_PARAMETER_DISPLAY_PREFIX } from 'ts/const';
-import { defaultStr } from 'ts/utils';
+import { EVENT_PARAMETER_DISPLAY_PREFIX, IUserRole } from 'ts/const';
+import { defaultStr, getUserInfoFromLocalStorage } from 'ts/utils';
 import MetadataPlatformFC from '../comps/MetadataPlatform';
 import MetadataSourceFC from '../comps/MetadataSource';
 import MetadataDetailsTable from '../table/MetadataDetailsTable';
@@ -47,6 +48,7 @@ const MetadataParameterSplitPanel: React.FC<
 > = (props: MetadataParameterSplitPanelProps) => {
   const { t } = useTranslation();
   const { projectId, appId } = useParams();
+  const currentUser = useContext(UserContext) ?? getUserInfoFromLocalStorage();
   const { parameter } = props;
   const SPLIT_PANEL_I18NSTRINGS = {
     preferencesTitle: t('splitPanel.preferencesTitle'),
@@ -190,62 +192,69 @@ const MetadataParameterSplitPanel: React.FC<
                 {t('analytics:metadata.eventParameter.tableColumnDisplayName')}
               </Box>
               <div>
-                {!isEditingDisplayName && (
+                {currentUser.role === IUserRole.ANALYST_READER && (
                   <div className="flex align-center">
                     <div>{parameterDetails.displayName}</div>
-                    <Button
-                      onClick={() => {
-                        setIsEditingDisplayName(true);
-                      }}
-                      variant="icon"
-                      iconName="edit"
-                    />
                   </div>
                 )}
-                {isEditingDisplayName && (
-                  <div>
-                    <FormField>
-                      <Textarea
-                        rows={3}
-                        value={parameterDetails.displayName}
-                        onChange={(e) => {
-                          setParameterDetails((prev) => {
-                            return {
-                              ...prev,
-                              displayName: e.detail.value,
-                            };
-                          });
+                {currentUser.role !== IUserRole.ANALYST_READER &&
+                  !isEditingDisplayName && (
+                    <div className="flex align-center">
+                      <div>{parameterDetails.displayName}</div>
+                      <Button
+                        onClick={() => {
+                          setIsEditingDisplayName(true);
                         }}
+                        variant="icon"
+                        iconName="edit"
                       />
-                    </FormField>
-                    <div className="mt-5">
-                      <SpaceBetween direction="horizontal" size="xs">
-                        <Button
-                          onClick={() => {
+                    </div>
+                  )}
+                {currentUser.role !== IUserRole.ANALYST_READER &&
+                  isEditingDisplayName && (
+                    <div>
+                      <FormField>
+                        <Textarea
+                          rows={3}
+                          value={parameterDetails.displayName}
+                          onChange={(e) => {
                             setParameterDetails((prev) => {
                               return {
                                 ...prev,
-                                displayName: prevDisplayName,
+                                displayName: e.detail.value,
                               };
                             });
-                            setIsEditingDisplayName(false);
                           }}
-                        >
-                          {t('button.cancel')}
-                        </Button>
-                        <Button
-                          loading={loadingUpdateDisplayName}
-                          variant="primary"
-                          onClick={() => {
-                            updateEventInfo('displayName');
-                          }}
-                        >
-                          {t('button.save')}
-                        </Button>
-                      </SpaceBetween>
+                        />
+                      </FormField>
+                      <div className="mt-5">
+                        <SpaceBetween direction="horizontal" size="xs">
+                          <Button
+                            onClick={() => {
+                              setParameterDetails((prev) => {
+                                return {
+                                  ...prev,
+                                  displayName: prevDisplayName,
+                                };
+                              });
+                              setIsEditingDisplayName(false);
+                            }}
+                          >
+                            {t('button.cancel')}
+                          </Button>
+                          <Button
+                            loading={loadingUpdateDisplayName}
+                            variant="primary"
+                            onClick={() => {
+                              updateEventInfo('displayName');
+                            }}
+                          >
+                            {t('button.save')}
+                          </Button>
+                        </SpaceBetween>
+                      </div>
                     </div>
-                  </div>
-                )}
+                  )}
               </div>
             </div>
             <div>
@@ -267,62 +276,69 @@ const MetadataParameterSplitPanel: React.FC<
                 {t('analytics:metadata.eventParameter.tableColumnDescription')}
               </Box>
               <div>
-                {!isEditingDesc && (
+                {currentUser.role === IUserRole.ANALYST_READER && (
                   <div className="flex align-center">
                     <div>{parameterDetails.description}</div>
-                    <Button
-                      onClick={() => {
-                        setIsEditingDesc(true);
-                      }}
-                      variant="icon"
-                      iconName="edit"
-                    />
                   </div>
                 )}
-                {isEditingDesc && (
-                  <div>
-                    <FormField>
-                      <Textarea
-                        rows={3}
-                        value={parameterDetails.description}
-                        onChange={(e) => {
-                          setParameterDetails((prev) => {
-                            return {
-                              ...prev,
-                              description: e.detail.value,
-                            };
-                          });
+                {currentUser.role !== IUserRole.ANALYST_READER &&
+                  !isEditingDesc && (
+                    <div className="flex align-center">
+                      <div>{parameterDetails.description}</div>
+                      <Button
+                        onClick={() => {
+                          setIsEditingDesc(true);
                         }}
+                        variant="icon"
+                        iconName="edit"
                       />
-                    </FormField>
-                    <div className="mt-5">
-                      <SpaceBetween direction="horizontal" size="xs">
-                        <Button
-                          onClick={() => {
+                    </div>
+                  )}
+                {currentUser.role !== IUserRole.ANALYST_READER &&
+                  isEditingDesc && (
+                    <div>
+                      <FormField>
+                        <Textarea
+                          rows={3}
+                          value={parameterDetails.description}
+                          onChange={(e) => {
                             setParameterDetails((prev) => {
                               return {
                                 ...prev,
-                                description: prevDesc,
+                                description: e.detail.value,
                               };
                             });
-                            setIsEditingDesc(false);
                           }}
-                        >
-                          {t('button.cancel')}
-                        </Button>
-                        <Button
-                          loading={loadingUpdateDesc}
-                          variant="primary"
-                          onClick={() => {
-                            updateEventInfo('description');
-                          }}
-                        >
-                          {t('button.save')}
-                        </Button>
-                      </SpaceBetween>
+                        />
+                      </FormField>
+                      <div className="mt-5">
+                        <SpaceBetween direction="horizontal" size="xs">
+                          <Button
+                            onClick={() => {
+                              setParameterDetails((prev) => {
+                                return {
+                                  ...prev,
+                                  description: prevDesc,
+                                };
+                              });
+                              setIsEditingDesc(false);
+                            }}
+                          >
+                            {t('button.cancel')}
+                          </Button>
+                          <Button
+                            loading={loadingUpdateDesc}
+                            variant="primary"
+                            onClick={() => {
+                              updateEventInfo('description');
+                            }}
+                          >
+                            {t('button.save')}
+                          </Button>
+                        </SpaceBetween>
+                      </div>
                     </div>
-                  </div>
-                )}
+                  )}
               </div>
             </div>
             <div>

--- a/frontend/src/pages/analytics/metadata/events/MetadataEventSplitPanel.tsx
+++ b/frontend/src/pages/analytics/metadata/events/MetadataEventSplitPanel.tsx
@@ -25,12 +25,13 @@ import {
 } from '@cloudscape-design/components';
 import { getMetadataEventDetails, updateMetadataDisplay } from 'apis/analytics';
 import Loading from 'components/common/Loading';
-import React, { useEffect, useState } from 'react';
+import { UserContext } from 'context/UserContext';
+import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import { EVENT_DISPLAY_PREFIX } from 'ts/const';
+import { EVENT_DISPLAY_PREFIX, IUserRole } from 'ts/const';
 import { MetadataSource } from 'ts/explore-types';
-import { defaultStr } from 'ts/utils';
+import { defaultStr, getUserInfoFromLocalStorage } from 'ts/utils';
 import MetadataPlatformFC from '../comps/MetadataPlatform';
 import MetadataSdkFC from '../comps/MetadataSDK';
 import MetadataSourceFC from '../comps/MetadataSource';
@@ -44,6 +45,7 @@ const MetadataEventSplitPanel: React.FC<MetadataEventSplitPanelProps> = (
   props: MetadataEventSplitPanelProps
 ) => {
   const { t } = useTranslation();
+  const currentUser = useContext(UserContext) ?? getUserInfoFromLocalStorage();
   const { projectId, appId } = useParams();
   const { event } = props;
   const SPLIT_PANEL_I18NSTRINGS = {
@@ -189,62 +191,69 @@ const MetadataEventSplitPanel: React.FC<MetadataEventSplitPanelProps> = (
                 {t('analytics:metadata.event.tableColumnDisplayName')}
               </Box>
               <div>
-                {!isEditingDisplayName && (
+                {currentUser.role === IUserRole.ANALYST_READER && (
                   <div className="flex align-center">
                     <div>{eventDetails.displayName}</div>
-                    <Button
-                      onClick={() => {
-                        setIsEditingDisplayName(true);
-                      }}
-                      variant="icon"
-                      iconName="edit"
-                    />
                   </div>
                 )}
-                {isEditingDisplayName && (
-                  <div>
-                    <FormField>
-                      <Textarea
-                        rows={3}
-                        value={eventDetails.displayName}
-                        onChange={(e) => {
-                          setEventDetails((prev) => {
-                            return {
-                              ...prev,
-                              displayName: e.detail.value,
-                            };
-                          });
+                {currentUser.role !== IUserRole.ANALYST_READER &&
+                  !isEditingDisplayName && (
+                    <div className="flex align-center">
+                      <div>{eventDetails.displayName}</div>
+                      <Button
+                        onClick={() => {
+                          setIsEditingDisplayName(true);
                         }}
+                        variant="icon"
+                        iconName="edit"
                       />
-                    </FormField>
-                    <div className="mt-5">
-                      <SpaceBetween direction="horizontal" size="xs">
-                        <Button
-                          onClick={() => {
+                    </div>
+                  )}
+                {currentUser.role !== IUserRole.ANALYST_READER &&
+                  isEditingDisplayName && (
+                    <div>
+                      <FormField>
+                        <Textarea
+                          rows={3}
+                          value={eventDetails.displayName}
+                          onChange={(e) => {
                             setEventDetails((prev) => {
                               return {
                                 ...prev,
-                                displayName: prevDisplayName,
+                                displayName: e.detail.value,
                               };
                             });
-                            setIsEditingDisplayName(false);
                           }}
-                        >
-                          {t('button.cancel')}
-                        </Button>
-                        <Button
-                          loading={loadingUpdateDisplayName}
-                          variant="primary"
-                          onClick={() => {
-                            updateEventInfo('displayName');
-                          }}
-                        >
-                          {t('button.save')}
-                        </Button>
-                      </SpaceBetween>
+                        />
+                      </FormField>
+                      <div className="mt-5">
+                        <SpaceBetween direction="horizontal" size="xs">
+                          <Button
+                            onClick={() => {
+                              setEventDetails((prev) => {
+                                return {
+                                  ...prev,
+                                  displayName: prevDisplayName,
+                                };
+                              });
+                              setIsEditingDisplayName(false);
+                            }}
+                          >
+                            {t('button.cancel')}
+                          </Button>
+                          <Button
+                            loading={loadingUpdateDisplayName}
+                            variant="primary"
+                            onClick={() => {
+                              updateEventInfo('displayName');
+                            }}
+                          >
+                            {t('button.save')}
+                          </Button>
+                        </SpaceBetween>
+                      </div>
                     </div>
-                  </div>
-                )}
+                  )}
               </div>
             </div>
             <div>
@@ -266,62 +275,69 @@ const MetadataEventSplitPanel: React.FC<MetadataEventSplitPanelProps> = (
                 {t('analytics:metadata.event.tableColumnDescription')}
               </Box>
               <div>
-                {!isEditingDesc && (
+                {currentUser.role === IUserRole.ANALYST_READER && (
                   <div className="flex align-center">
                     <div>{eventDetails.description}</div>
-                    <Button
-                      onClick={() => {
-                        setIsEditingDesc(true);
-                      }}
-                      variant="icon"
-                      iconName="edit"
-                    />
                   </div>
                 )}
-                {isEditingDesc && (
-                  <div>
-                    <FormField>
-                      <Textarea
-                        rows={3}
-                        value={eventDetails.description}
-                        onChange={(e) => {
-                          setEventDetails((prev) => {
-                            return {
-                              ...prev,
-                              description: e.detail.value,
-                            };
-                          });
+                {currentUser.role !== IUserRole.ANALYST_READER &&
+                  !isEditingDesc && (
+                    <div className="flex align-center">
+                      <div>{eventDetails.description}</div>
+                      <Button
+                        onClick={() => {
+                          setIsEditingDesc(true);
                         }}
+                        variant="icon"
+                        iconName="edit"
                       />
-                    </FormField>
-                    <div className="mt-5">
-                      <SpaceBetween direction="horizontal" size="xs">
-                        <Button
-                          onClick={() => {
+                    </div>
+                  )}
+                {currentUser.role !== IUserRole.ANALYST_READER &&
+                  isEditingDesc && (
+                    <div>
+                      <FormField>
+                        <Textarea
+                          rows={3}
+                          value={eventDetails.description}
+                          onChange={(e) => {
                             setEventDetails((prev) => {
                               return {
                                 ...prev,
-                                description: prevDesc,
+                                description: e.detail.value,
                               };
                             });
-                            setIsEditingDesc(false);
                           }}
-                        >
-                          {t('button.cancel')}
-                        </Button>
-                        <Button
-                          loading={loadingUpdateDesc}
-                          variant="primary"
-                          onClick={() => {
-                            updateEventInfo('description');
-                          }}
-                        >
-                          {t('button.save')}
-                        </Button>
-                      </SpaceBetween>
+                        />
+                      </FormField>
+                      <div className="mt-5">
+                        <SpaceBetween direction="horizontal" size="xs">
+                          <Button
+                            onClick={() => {
+                              setEventDetails((prev) => {
+                                return {
+                                  ...prev,
+                                  description: prevDesc,
+                                };
+                              });
+                              setIsEditingDesc(false);
+                            }}
+                          >
+                            {t('button.cancel')}
+                          </Button>
+                          <Button
+                            loading={loadingUpdateDesc}
+                            variant="primary"
+                            onClick={() => {
+                              updateEventInfo('description');
+                            }}
+                          >
+                            {t('button.save')}
+                          </Button>
+                        </SpaceBetween>
+                      </div>
                     </div>
-                  </div>
-                )}
+                  )}
               </div>
             </div>
             <div>

--- a/frontend/src/pages/analytics/metadata/user-attributes/MetadataUserAttributeSplitPanel.tsx
+++ b/frontend/src/pages/analytics/metadata/user-attributes/MetadataUserAttributeSplitPanel.tsx
@@ -24,9 +24,11 @@ import {
 } from '@cloudscape-design/components';
 import { updateMetadataDisplay } from 'apis/analytics';
 import Loading from 'components/common/Loading';
-import React, { useEffect, useState } from 'react';
+import { UserContext } from 'context/UserContext';
+import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { USER_ATTRIBUTE_DISPLAY_PREFIX } from 'ts/const';
+import { IUserRole, USER_ATTRIBUTE_DISPLAY_PREFIX } from 'ts/const';
+import { getUserInfoFromLocalStorage } from 'ts/utils';
 import MetadataSourceFC from '../comps/MetadataSource';
 
 interface MetadataUserAttributeSplitPanelProps {
@@ -38,6 +40,7 @@ const MetadataUserAttributeSplitPanel: React.FC<
 > = (props: MetadataUserAttributeSplitPanelProps) => {
   const { t } = useTranslation();
   const { attribute } = props;
+  const currentUser = useContext(UserContext) ?? getUserInfoFromLocalStorage();
   const SPLIT_PANEL_I18NSTRINGS = {
     preferencesTitle: t('splitPanel.preferencesTitle'),
     preferencesPositionLabel: t('splitPanel.preferencesPositionLabel'),
@@ -126,62 +129,69 @@ const MetadataUserAttributeSplitPanel: React.FC<
                 {t('analytics:metadata.userAttribute.tableColumnDisplayName')}
               </Box>
               <div>
-                {!isEditingDisplayName && (
+                {currentUser.role === IUserRole.ANALYST_READER && (
                   <div className="flex align-center">
                     <div>{attributeDetails.displayName}</div>
-                    <Button
-                      onClick={() => {
-                        setIsEditingDisplayName(true);
-                      }}
-                      variant="icon"
-                      iconName="edit"
-                    />
                   </div>
                 )}
-                {isEditingDisplayName && (
-                  <div>
-                    <FormField>
-                      <Textarea
-                        rows={3}
-                        value={attributeDetails.displayName}
-                        onChange={(e) => {
-                          setAttributeDetails((prev) => {
-                            return {
-                              ...prev,
-                              displayName: e.detail.value,
-                            };
-                          });
+                {currentUser.role !== IUserRole.ANALYST_READER &&
+                  !isEditingDisplayName && (
+                    <div className="flex align-center">
+                      <div>{attributeDetails.displayName}</div>
+                      <Button
+                        onClick={() => {
+                          setIsEditingDisplayName(true);
                         }}
+                        variant="icon"
+                        iconName="edit"
                       />
-                    </FormField>
-                    <div className="mt-5">
-                      <SpaceBetween direction="horizontal" size="xs">
-                        <Button
-                          onClick={() => {
+                    </div>
+                  )}
+                {currentUser.role !== IUserRole.ANALYST_READER &&
+                  isEditingDisplayName && (
+                    <div>
+                      <FormField>
+                        <Textarea
+                          rows={3}
+                          value={attributeDetails.displayName}
+                          onChange={(e) => {
                             setAttributeDetails((prev) => {
                               return {
                                 ...prev,
-                                displayName: prevDisplayName,
+                                displayName: e.detail.value,
                               };
                             });
-                            setIsEditingDisplayName(false);
                           }}
-                        >
-                          {t('button.cancel')}
-                        </Button>
-                        <Button
-                          loading={loadingUpdateDisplayName}
-                          variant="primary"
-                          onClick={() => {
-                            updateEventInfo('displayName');
-                          }}
-                        >
-                          {t('button.save')}
-                        </Button>
-                      </SpaceBetween>
+                        />
+                      </FormField>
+                      <div className="mt-5">
+                        <SpaceBetween direction="horizontal" size="xs">
+                          <Button
+                            onClick={() => {
+                              setAttributeDetails((prev) => {
+                                return {
+                                  ...prev,
+                                  displayName: prevDisplayName,
+                                };
+                              });
+                              setIsEditingDisplayName(false);
+                            }}
+                          >
+                            {t('button.cancel')}
+                          </Button>
+                          <Button
+                            loading={loadingUpdateDisplayName}
+                            variant="primary"
+                            onClick={() => {
+                              updateEventInfo('displayName');
+                            }}
+                          >
+                            {t('button.save')}
+                          </Button>
+                        </SpaceBetween>
+                      </div>
                     </div>
-                  </div>
-                )}
+                  )}
               </div>
             </div>
             <div>

--- a/frontend/src/pages/analytics/metadata/user-attributes/MetadataUserAttributesTable.tsx
+++ b/frontend/src/pages/analytics/metadata/user-attributes/MetadataUserAttributesTable.tsx
@@ -16,12 +16,13 @@ import {
   getMetadataUserAttributesList,
   updateMetadataDisplay,
 } from 'apis/analytics';
+import { UserContext } from 'context/UserContext';
 import { t } from 'i18next';
-import React from 'react';
+import React, { useContext } from 'react';
 import { useParams } from 'react-router-dom';
-import { USER_ATTRIBUTE_DISPLAY_PREFIX } from 'ts/const';
+import { IUserRole, USER_ATTRIBUTE_DISPLAY_PREFIX } from 'ts/const';
 import { MetadataSource } from 'ts/explore-types';
-import { defaultStr } from 'ts/utils';
+import { defaultStr, getUserInfoFromLocalStorage } from 'ts/utils';
 import MetadataSourceFC from '../comps/MetadataSource';
 import MetadataTable from '../table/MetadataTable';
 import { displayNameRegex, descriptionRegex } from '../table/table-config';
@@ -43,6 +44,7 @@ const MetadataUserAttributesTable: React.FC<
   MetadataUserAttributesTableProps
 > = (props: MetadataUserAttributesTableProps) => {
   const { projectId, appId } = useParams();
+  const currentUser = useContext(UserContext) ?? getUserInfoFromLocalStorage();
   const { setShowDetails } = props;
 
   const renderEditNameCell = (
@@ -83,6 +85,38 @@ const MetadataUserAttributesTable: React.FC<
     return <MetadataSourceFC source={e.metadataSource} />;
   };
 
+  const getDisplayNameEditConfig = () => {
+    if (currentUser.role !== IUserRole.ANALYST_READER) {
+      return {
+        validation(item: IAttributeTableItem, value: any) {
+          return !displayNameRegex.test(value)
+            ? undefined
+            : t('tag.invalidInput');
+        },
+        editingCell: (
+          item: IAttributeTableItem,
+          { setValue, currentValue }: any
+        ) => renderEditNameCell(item, setValue, currentValue),
+      };
+    }
+  };
+
+  const getDescriptionEditConfig = () => {
+    if (currentUser.role !== IUserRole.ANALYST_READER) {
+      return {
+        validation(item: IAttributeTableItem, value: any) {
+          return !descriptionRegex.test(value)
+            ? undefined
+            : t('tag.invalidInput');
+        },
+        editingCell: (
+          item: IAttributeTableItem,
+          { setValue, currentValue }: any
+        ) => renderEditDescCell(item, setValue, currentValue),
+      };
+    }
+  };
+
   const COLUMN_DEFINITIONS = [
     {
       id: 'name',
@@ -99,17 +133,7 @@ const MetadataUserAttributesTable: React.FC<
         return e.displayName;
       },
       minWidth: 180,
-      editConfig: {
-        validation(item: IAttributeTableItem, value: any) {
-          return !displayNameRegex.test(value)
-            ? undefined
-            : t('tag.invalidInput');
-        },
-        editingCell: (
-          item: IAttributeTableItem,
-          { setValue, currentValue }: any
-        ) => renderEditNameCell(item, setValue, currentValue),
-      },
+      editConfig: getDisplayNameEditConfig(),
     },
     {
       id: 'description',
@@ -118,17 +142,7 @@ const MetadataUserAttributesTable: React.FC<
         return e.description;
       },
       minWidth: 180,
-      editConfig: {
-        validation(item: IAttributeTableItem, value: any) {
-          return !descriptionRegex.test(value)
-            ? undefined
-            : t('tag.invalidInput');
-        },
-        editingCell: (
-          item: IAttributeTableItem,
-          { setValue, currentValue }: any
-        ) => renderEditDescCell(item, setValue, currentValue),
-      },
+      editConfig: getDescriptionEditConfig(),
     },
     {
       id: 'metadataSource',

--- a/frontend/src/pages/analytics/path/AnalyticsPath.tsx
+++ b/frontend/src/pages/analytics/path/AnalyticsPath.tsx
@@ -40,11 +40,12 @@ import {
 } from 'components/eventselect/AnalyticsType';
 import EventsSelect from 'components/eventselect/EventSelect';
 import SegmentationFilter from 'components/eventselect/SegmentationFilter';
+import { UserContext } from 'context/UserContext';
 import { cloneDeep } from 'lodash';
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import { COMMON_ALERT_TYPE } from 'ts/const';
+import { COMMON_ALERT_TYPE, IUserRole } from 'ts/const';
 import {
   QUICKSIGHT_ANALYSIS_INFIX,
   QUICKSIGHT_DASHBOARD_INFIX,
@@ -63,6 +64,7 @@ import {
   defaultStr,
   generateStr,
   getEventParameters,
+  getUserInfoFromLocalStorage,
 } from 'ts/utils';
 import {
   getDashboardCreateParameters,
@@ -117,6 +119,7 @@ const AnalyticsPath: React.FC<AnalyticsPathProps> = (
     loadingEvents,
   } = props;
   const { appId } = useParams();
+  const currentUser = useContext(UserContext) ?? getUserInfoFromLocalStorage();
   const [loadingData, setLoadingData] = useState(loading);
   const [loadingChart, setLoadingChart] = useState(false);
   const [selectDashboardModalVisible, setSelectDashboardModalVisible] =
@@ -560,15 +563,17 @@ const AnalyticsPath: React.FC<AnalyticsPathProps> = (
                   >
                     {t('button.reset')}
                   </Button>
-                  <Button
-                    variant="primary"
-                    loading={loadingData}
-                    onClick={() => {
-                      setSelectDashboardModalVisible(true);
-                    }}
-                  >
-                    {t('button.saveToDashboard')}
-                  </Button>
+                  {currentUser.role !== IUserRole.ANALYST_READER && (
+                    <Button
+                      variant="primary"
+                      loading={loadingData}
+                      onClick={() => {
+                        setSelectDashboardModalVisible(true);
+                      }}
+                    >
+                      {t('button.saveToDashboard')}
+                    </Button>
+                  )}
                 </SpaceBetween>
               }
             >

--- a/frontend/src/pages/analytics/retention/AnalyticsRetention.tsx
+++ b/frontend/src/pages/analytics/retention/AnalyticsRetention.tsx
@@ -39,11 +39,12 @@ import {
 } from 'components/eventselect/AnalyticsType';
 import RetentionSelect from 'components/eventselect/RetentionSelect';
 import SegmentationFilter from 'components/eventselect/SegmentationFilter';
+import { UserContext } from 'context/UserContext';
 import { cloneDeep } from 'lodash';
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import { COMMON_ALERT_TYPE } from 'ts/const';
+import { COMMON_ALERT_TYPE, IUserRole } from 'ts/const';
 import {
   QUICKSIGHT_ANALYSIS_INFIX,
   QUICKSIGHT_DASHBOARD_INFIX,
@@ -59,6 +60,7 @@ import {
   alertMsg,
   defaultStr,
   getEventParameters,
+  getUserInfoFromLocalStorage,
 } from 'ts/utils';
 import {
   getDashboardCreateParameters,
@@ -104,6 +106,7 @@ const AnalyticsRetention: React.FC<AnalyticsRetentionProps> = (
     groupParameters,
   } = props;
   const { appId } = useParams();
+  const currentUser = useContext(UserContext) ?? getUserInfoFromLocalStorage();
   const [loadingData, setLoadingData] = useState(loading);
   const [loadingChart, setLoadingChart] = useState(false);
   const [selectDashboardModalVisible, setSelectDashboardModalVisible] =
@@ -334,15 +337,17 @@ const AnalyticsRetention: React.FC<AnalyticsRetentionProps> = (
                   >
                     {t('button.reset')}
                   </Button>
-                  <Button
-                    variant="primary"
-                    loading={loadingData}
-                    onClick={() => {
-                      setSelectDashboardModalVisible(true);
-                    }}
-                  >
-                    {t('button.saveToDashboard')}
-                  </Button>
+                  {currentUser.role !== IUserRole.ANALYST_READER && (
+                    <Button
+                      variant="primary"
+                      loading={loadingData}
+                      onClick={() => {
+                        setSelectDashboardModalVisible(true);
+                      }}
+                    >
+                      {t('button.saveToDashboard')}
+                    </Button>
+                  )}
                 </SpaceBetween>
               }
             >

--- a/frontend/src/pages/user/CreateUser.tsx
+++ b/frontend/src/pages/user/CreateUser.tsx
@@ -64,6 +64,7 @@ const CreateUser: React.FC<CreateUserProps> = (props: CreateUserProps) => {
       label: defaultStr(t('user:options.operator')),
     },
     { value: IUserRole.ANALYST, label: defaultStr(t('user:options.analyst')) },
+    { value: IUserRole.ANALYST_READER, label: defaultStr(t('user:options.analystReader')) },
     {
       value: IUserRole.NO_IDENTITY,
       label: defaultStr(t('user:options.noIdentity')),

--- a/frontend/src/pages/user/CreateUser.tsx
+++ b/frontend/src/pages/user/CreateUser.tsx
@@ -64,7 +64,10 @@ const CreateUser: React.FC<CreateUserProps> = (props: CreateUserProps) => {
       label: defaultStr(t('user:options.operator')),
     },
     { value: IUserRole.ANALYST, label: defaultStr(t('user:options.analyst')) },
-    { value: IUserRole.ANALYST_READER, label: defaultStr(t('user:options.analystReader')) },
+    {
+      value: IUserRole.ANALYST_READER,
+      label: defaultStr(t('user:options.analystReader')),
+    },
     {
       value: IUserRole.NO_IDENTITY,
       label: defaultStr(t('user:options.noIdentity')),

--- a/frontend/src/pages/user/SettingUser.tsx
+++ b/frontend/src/pages/user/SettingUser.tsx
@@ -37,6 +37,7 @@ const SettingUser: React.FC<SettingUserProps> = (props: SettingUserProps) => {
     roleJsonPath: '',
     operatorRoleNames: '',
     analystRoleNames: '',
+    analystReaderRoleNames: '',
   } as IUserSettings;
   const [curUserSetting, setCurUserSetting] =
     useState<IUserSettings>(defaultUserSetting);
@@ -148,6 +149,22 @@ const SettingUser: React.FC<SettingUserProps> = (props: SettingUserProps) => {
               return {
                 ...prev,
                 analystRoleNames: e.detail.value,
+              };
+            });
+          }}
+        />
+      </FormField>
+      <FormField
+        label={t('user:labels.settingUserAnalystReaderRoleNames')}
+        description={t('user:labels.settingUserAnalystReaderRoleNamesDesc')}
+      >
+        <Input
+          value={defaultStr(curUserSetting.analystReaderRoleNames)}
+          onChange={(e) => {
+            setCurUserSetting((prev) => {
+              return {
+                ...prev,
+                analystReaderRoleNames: e.detail.value,
               };
             });
           }}

--- a/frontend/src/pages/user/UserList.tsx
+++ b/frontend/src/pages/user/UserList.tsx
@@ -46,6 +46,10 @@ const UserList: React.FC = () => {
     },
     { value: IUserRole.ANALYST, label: defaultStr(t('user:options.analyst')) },
     {
+      value: IUserRole.ANALYST_READER,
+      label: defaultStr(t('user:options.analystReader')),
+    },
+    {
       value: IUserRole.NO_IDENTITY,
       label: defaultStr(t('user:options.noIdentity')),
     },
@@ -59,6 +63,8 @@ const UserList: React.FC = () => {
         return t('user:options.operator');
       case IUserRole.ANALYST:
         return t('user:options.analyst');
+      case IUserRole.ANALYST_READER:
+        return t('user:options.analystReader');
       default:
         return t('user:options.noIdentity');
     }

--- a/frontend/src/ts/const.ts
+++ b/frontend/src/ts/const.ts
@@ -414,6 +414,7 @@ export enum IUserRole {
   ADMIN = 'Admin',
   OPERATOR = 'Operator',
   ANALYST = 'Analyst',
+  ANALYST_READER = 'AnalystReader',
   NO_IDENTITY = 'NoIdentity',
 }
 

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -32,5 +32,6 @@ declare global {
     readonly roleJsonPath: string;
     readonly operatorRoleNames: string;
     readonly analystRoleNames: string;
+    readonly analystReaderRoleNames: string;
   }
 }

--- a/src/control-plane/backend/lambda/api/common/constants.ts
+++ b/src/control-plane/backend/lambda/api/common/constants.ts
@@ -65,6 +65,7 @@ const PIPELINE_SUPPORTED_REGIONS = [
 const DEFAULT_ROLE_JSON_PATH = '$.payload.cognito:groups';
 const DEFAULT_OPERATOR_ROLE_NAMES = 'ClickstreamOperator';
 const DEFAULT_ANALYST_ROLE_NAMES = 'ClickstreamAnalyst';
+const DEFAULT_ANALYST_READER_ROLE_NAMES = 'ClickstreamAnalystReader';
 const PIPELINE_STACKS = 'PipelineStacks';
 
 export {
@@ -93,5 +94,6 @@ export {
   DEFAULT_ROLE_JSON_PATH,
   DEFAULT_OPERATOR_ROLE_NAMES,
   DEFAULT_ANALYST_ROLE_NAMES,
+  DEFAULT_ANALYST_READER_ROLE_NAMES,
   PIPELINE_STACKS,
 };

--- a/src/control-plane/backend/lambda/api/common/types.ts
+++ b/src/control-plane/backend/lambda/api/common/types.ts
@@ -416,5 +416,6 @@ export enum IUserRole {
   ADMIN = 'Admin',
   OPERATOR = 'Operator',
   ANALYST = 'Analyst',
+  ANALYST_READER = 'AnalystReader',
   NO_IDENTITY = 'NoIdentity',
 }

--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -168,7 +168,10 @@ async function getRoleFromToken(decodedToken: any) {
   let oidcRoles: string[] = [];
 
   const userSettings = await userService.getUserSettingsFromDDB();
-  if (isEmpty(userSettings.roleJsonPath) || isEmpty(userSettings.operatorRoleNames) || isEmpty(userSettings.analystRoleNames)) {
+  if (isEmpty(userSettings.roleJsonPath) ||
+    isEmpty(userSettings.operatorRoleNames) ||
+    isEmpty(userSettings.analystRoleNames ||
+    isEmpty(userSettings.analystReaderRoleNames))) {
     return role;
   }
 
@@ -188,6 +191,7 @@ function mapToRole(userSettings: IUserSettings, oidcRoles: string[]) {
   }
   const operatorRoleNames = userSettings.operatorRoleNames.split(',').map(role => role.trim());
   const analystRoleNames = userSettings.analystRoleNames.split(',').map(role => role.trim());
+  const analystReaderRoleNames = userSettings.analystReaderRoleNames.split(',').map(role => role.trim());
 
   if (oidcRoles.some(role => operatorRoleNames.includes(role)) && oidcRoles.some(role => analystRoleNames.includes(role))) {
     return IUserRole.ADMIN;
@@ -197,6 +201,9 @@ function mapToRole(userSettings: IUserSettings, oidcRoles: string[]) {
   }
   if (oidcRoles.some(role => analystRoleNames.includes(role))) {
     return IUserRole.ANALYST;
+  }
+  if (oidcRoles.some(role => analystReaderRoleNames.includes(role))) {
+    return IUserRole.ANALYST_READER;
   }
   return IUserRole.NO_IDENTITY;
 }

--- a/src/control-plane/backend/lambda/api/middle-ware/auth-role.ts
+++ b/src/control-plane/backend/lambda/api/middle-ware/auth-role.ts
@@ -22,20 +22,26 @@ import { DynamoDbStore } from '../store/dynamodb/dynamodb-store';
 const store: ClickStreamStore = new DynamoDbStore();
 
 const routerRoles: Map<string, IUserRole[]> = new Map();
-routerRoles.set('GET /api/user/details', [IUserRole.ADMIN, IUserRole.OPERATOR, IUserRole.ANALYST, IUserRole.NO_IDENTITY]);
-routerRoles.set('GET /api/pipeline/:id', [IUserRole.ADMIN, IUserRole.OPERATOR, IUserRole.ANALYST]);
-routerRoles.set('GET /api/app', [IUserRole.ADMIN, IUserRole.OPERATOR, IUserRole.ANALYST]);
-routerRoles.set('GET /api/project', [IUserRole.ADMIN, IUserRole.OPERATOR, IUserRole.ANALYST]);
-routerRoles.set('ALL /api/project/:pid/:aid/dashboard/*', [IUserRole.ADMIN, IUserRole.ANALYST]);
-routerRoles.set('GET /api/project/:pid/analyzes', [IUserRole.ADMIN, IUserRole.ANALYST]);
+routerRoles.set('GET /api/user/details', [IUserRole.ADMIN, IUserRole.OPERATOR, IUserRole.ANALYST, IUserRole.ANALYST_READER, IUserRole.NO_IDENTITY]);
+routerRoles.set('GET /api/pipeline/:id', [IUserRole.ADMIN, IUserRole.OPERATOR, IUserRole.ANALYST, IUserRole.ANALYST_READER]);
+routerRoles.set('GET /api/app', [IUserRole.ADMIN, IUserRole.OPERATOR, IUserRole.ANALYST, IUserRole.ANALYST_READER]);
+routerRoles.set('GET /api/project', [IUserRole.ADMIN, IUserRole.OPERATOR, IUserRole.ANALYST, IUserRole.ANALYST_READER]);
+routerRoles.set('GET /api/project/:pid/:aid/dashboard/*', [IUserRole.ADMIN, IUserRole.ANALYST, IUserRole.ANALYST_READER]);
+routerRoles.set('POST /api/project/:pid/:aid/dashboard/*', [IUserRole.ADMIN, IUserRole.ANALYST]);
+routerRoles.set('PUT /api/project/:pid/:aid/dashboard/*', [IUserRole.ADMIN, IUserRole.ANALYST]);
+routerRoles.set('DELETE /api/project/:pid/:aid/dashboard/*', [IUserRole.ADMIN, IUserRole.ANALYST]);
+routerRoles.set('GET /api/project/:pid/analyzes', [IUserRole.ADMIN, IUserRole.ANALYST, IUserRole.ANALYST_READER]);
 
 routerRoles.set('ALL /api/env/*', [IUserRole.ADMIN, IUserRole.OPERATOR]);
 routerRoles.set('ALL /api/app/*', [IUserRole.ADMIN, IUserRole.OPERATOR]);
 routerRoles.set('ALL /api/pipeline/*', [IUserRole.ADMIN, IUserRole.OPERATOR]);
 routerRoles.set('ALL /api/plugin/*', [IUserRole.ADMIN, IUserRole.OPERATOR]);
 routerRoles.set('ALL /api/project/*', [IUserRole.ADMIN, IUserRole.OPERATOR]);
-routerRoles.set('ALL /api/metadata/*', [IUserRole.ADMIN, IUserRole.ANALYST]);
-routerRoles.set('ALL /api/reporting/*', [IUserRole.ADMIN, IUserRole.ANALYST]);
+routerRoles.set('GET /api/metadata/*', [IUserRole.ADMIN, IUserRole.ANALYST, IUserRole.ANALYST_READER]);
+routerRoles.set('POST /api/metadata/*', [IUserRole.ADMIN, IUserRole.ANALYST]);
+routerRoles.set('PUT /api/metadata/*', [IUserRole.ADMIN, IUserRole.ANALYST]);
+routerRoles.set('DELETE /api/metadata/*', [IUserRole.ADMIN, IUserRole.ANALYST]);
+routerRoles.set('ALL /api/reporting/*', [IUserRole.ADMIN, IUserRole.ANALYST, IUserRole.ANALYST_READER]);
 routerRoles.set('ALL /api/user/*', [IUserRole.ADMIN]);
 
 

--- a/src/control-plane/backend/lambda/api/model/user.ts
+++ b/src/control-plane/backend/lambda/api/model/user.ts
@@ -31,4 +31,5 @@ export interface IUserSettings {
   readonly roleJsonPath: string;
   readonly operatorRoleNames: string;
   readonly analystRoleNames: string;
+  readonly analystReaderRoleNames: string;
 }

--- a/src/control-plane/backend/lambda/api/service/user.ts
+++ b/src/control-plane/backend/lambda/api/service/user.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-import { DEFAULT_ANALYST_ROLE_NAMES, DEFAULT_OPERATOR_ROLE_NAMES, DEFAULT_ROLE_JSON_PATH } from '../common/constants';
+import { DEFAULT_ANALYST_READER_ROLE_NAMES, DEFAULT_ANALYST_ROLE_NAMES, DEFAULT_OPERATOR_ROLE_NAMES, DEFAULT_ROLE_JSON_PATH } from '../common/constants';
 import { ApiFail, ApiSuccess } from '../common/types';
 import { getRoleFromToken, getTokenFromRequest } from '../common/utils';
 import { IUser, IUserSettings } from '../model/user';
@@ -107,6 +107,7 @@ export class UserService {
         roleJsonPath: DEFAULT_ROLE_JSON_PATH,
         operatorRoleNames: DEFAULT_OPERATOR_ROLE_NAMES,
         analystRoleNames: DEFAULT_ANALYST_ROLE_NAMES,
+        analystReaderRoleNames: DEFAULT_ANALYST_READER_ROLE_NAMES,
       } as IUserSettings;
       return defaultSettings;
     }

--- a/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-store.ts
+++ b/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-store.ts
@@ -1195,11 +1195,12 @@ export class DynamoDbStore implements ClickStreamStore {
         type: 'USER_SETTINGS',
       },
       // Define expressions for the new or updated attributes
-      UpdateExpression: 'SET roleJsonPath= :roleJsonPath, operatorRoleNames= :operatorRoleNames, analystRoleNames= :analystRoleNames',
+      UpdateExpression: 'SET roleJsonPath= :roleJsonPath, operatorRoleNames= :operatorRoleNames, analystRoleNames= :analystRoleNames, analystReaderRoleNames= :analystReaderRoleNames',
       ExpressionAttributeValues: {
         ':roleJsonPath': userSettings.roleJsonPath,
         ':operatorRoleNames': userSettings.operatorRoleNames,
         ':analystRoleNames': userSettings.analystRoleNames,
+        ':analystReaderRoleNames': userSettings.analystReaderRoleNames,
       },
       ReturnValues: 'ALL_NEW',
     });

--- a/src/control-plane/backend/lambda/api/test/api/auth.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/auth.test.ts
@@ -172,6 +172,7 @@ describe('Validate role middleware test', () => {
       .set(amznRequestContextHeader, context_error_group);
     expect(res.statusCode).toBe(200);
     expect(res.body.data).toEqual({
+      analystReaderRoleNames: 'ClickstreamAnalystReader',
       analystRoleNames: 'ClickstreamAnalyst',
       operatorRoleNames: 'ClickstreamOperator',
       roleJsonPath: '$.payload.cognito:groups',
@@ -313,6 +314,7 @@ describe('Route role test', () => {
     expect((await request(app).get('/api/env/regions').set(amznRequestContextHeader, context)).statusCode).toBe(200);
     expect((await request(app).get('/api/metadata/events').set(amznRequestContextHeader, context)).statusCode).toBe(403);
     expect((await request(app).get('/api/metadata/event/1').set(amznRequestContextHeader, context)).statusCode).toBe(403);
+    expect((await request(app).put('/api/metadata/display').set(amznRequestContextHeader, context)).statusCode).toBe(403);
     expect((await request(app).get('/api/user').set(amznRequestContextHeader, context)).statusCode).toBe(403);
     expect((await request(app).post('/api/user').set(amznRequestContextHeader, context)).statusCode).toBe(403);
     expect((await request(app).get('/api/user/details').set(amznRequestContextHeader, context)).statusCode).toBe(400);
@@ -358,6 +360,53 @@ describe('Route role test', () => {
     expect((await request(app).get('/api/env/regions').set(amznRequestContextHeader, context)).statusCode).toBe(403);
     expect((await request(app).get('/api/metadata/events').set(amznRequestContextHeader, context)).statusCode).toBe(400);
     expect((await request(app).get('/api/metadata/event/1').set(amznRequestContextHeader, context)).statusCode).toBe(400);
+    expect((await request(app).put('/api/metadata/display').set(amznRequestContextHeader, context)).statusCode).toBe(400);
+    expect((await request(app).get('/api/user').set(amznRequestContextHeader, context)).statusCode).toBe(403);
+    expect((await request(app).post('/api/user').set(amznRequestContextHeader, context)).statusCode).toBe(403);
+    expect((await request(app).get('/api/user/details').set(amznRequestContextHeader, context)).statusCode).toBe(400);
+    expect((await request(app).put('/api/user/1').set(amznRequestContextHeader, context)).statusCode).toBe(403);
+    expect((await request(app).delete('/api/user/1').set(amznRequestContextHeader, context)).statusCode).toBe(403);
+    expect((await request(app).post('/api/reporting/funnel').set(amznRequestContextHeader, context)).statusCode).toBe(400);
+    expect((await request(app).post('/api/reporting/event').set(amznRequestContextHeader, context)).statusCode).toBe(400);
+    expect((await request(app).post('/api/reporting/path').set(amznRequestContextHeader, context)).statusCode).toBe(400);
+    expect((await request(app).post('/api/reporting/retention').set(amznRequestContextHeader, context)).statusCode).toBe(400);
+  });
+
+  it('Validate all routers for Analyst Reader.', async () => {
+    userMock(ddbMock, 'fake@example.com', IUserRole.ANALYST_READER, true);
+    ec2ClientMock.on(DescribeRegionsCommand).resolves({
+      Regions: [
+        { RegionName: 'us-east-1' },
+        { RegionName: 'ap-northeast-4' },
+      ],
+    });
+    quickSightClient.on(ListUsersCommand).resolves({
+      UserList: [
+        { Arn: 'arn:aws:quicksight:us-east-1:555555555555:user/default/4a05631e-cbe6-477c-915d-1704aec9f101' },
+      ],
+    });
+    quickSightClient.on(GenerateEmbedUrlForRegisteredUserCommand).resolves({
+      EmbedUrl: 'https://quicksight.aws.amazon.com/embed/4ui7xyvq73/studies/4a05631e-cbe6-477c-915d-1704aec9f101?isauthcode=true&identityprovider=quicksight&code=4a05631e-cbe6-477c-915d-1704aec9f101',
+    });
+    expect((await request(app).get('/api/project').set(amznRequestContextHeader, context)).statusCode).toBe(400);
+    expect((await request(app).post('/api/project').set(amznRequestContextHeader, context)).statusCode).toBe(403);
+    expect((await request(app).put('/api/project/1').set(amznRequestContextHeader, context)).statusCode).toBe(403);
+    expect((await request(app).get('/api/project/1').set(amznRequestContextHeader, context)).statusCode).toBe(403);
+    expect((await request(app).delete('/api/project/1').set(amznRequestContextHeader, context)).statusCode).toBe(403);
+    expect((await request(app).get('/api/project/1/2/dashboard').set(amznRequestContextHeader, context)).statusCode).toBe(400);
+    expect((await request(app).get('/api/project/1/2/dashboard/3').set(amznRequestContextHeader, context)).statusCode).toBe(400);
+    expect((await request(app).post('/api/project/1/2/dashboard').set(amznRequestContextHeader, context)).statusCode).toBe(403);
+    expect((await request(app).delete('/api/project/1/2/dashboard/3').set(amznRequestContextHeader, context)).statusCode).toBe(403);
+    expect((await request(app).get('/api/pipeline').set(amznRequestContextHeader, context)).statusCode).toBe(403);
+    expect((await request(app).post('/api/pipeline').set(amznRequestContextHeader, context)).statusCode).toBe(403);
+    expect((await request(app).put('/api/pipeline/1').set(amznRequestContextHeader, context)).statusCode).toBe(403);
+    expect((await request(app).get('/api/pipeline/1').set(amznRequestContextHeader, context)).statusCode).toBe(400);
+    expect((await request(app).delete('/api/pipeline/1').set(amznRequestContextHeader, context)).statusCode).toBe(403);
+    expect((await request(app).get('/api/project/1/analyzes').set(amznRequestContextHeader, context)).statusCode).toBe(400);
+    expect((await request(app).get('/api/env/regions').set(amznRequestContextHeader, context)).statusCode).toBe(403);
+    expect((await request(app).get('/api/metadata/events').set(amznRequestContextHeader, context)).statusCode).toBe(400);
+    expect((await request(app).get('/api/metadata/event/1').set(amznRequestContextHeader, context)).statusCode).toBe(400);
+    expect((await request(app).put('/api/metadata/display').set(amznRequestContextHeader, context)).statusCode).toBe(403);
     expect((await request(app).get('/api/user').set(amznRequestContextHeader, context)).statusCode).toBe(403);
     expect((await request(app).post('/api/user').set(amznRequestContextHeader, context)).statusCode).toBe(403);
     expect((await request(app).get('/api/user/details').set(amznRequestContextHeader, context)).statusCode).toBe(400);
@@ -403,6 +452,7 @@ describe('Route role test', () => {
     expect((await request(app).get('/api/env/regions').set(amznRequestContextHeader, context)).statusCode).toBe(403);
     expect((await request(app).get('/api/metadata/events').set(amznRequestContextHeader, context)).statusCode).toBe(403);
     expect((await request(app).get('/api/metadata/event/1').set(amznRequestContextHeader, context)).statusCode).toBe(403);
+    expect((await request(app).put('/api/metadata/display').set(amznRequestContextHeader, context)).statusCode).toBe(403);
     expect((await request(app).get('/api/user').set(amznRequestContextHeader, context)).statusCode).toBe(403);
     expect((await request(app).post('/api/user').set(amznRequestContextHeader, context)).statusCode).toBe(403);
     expect((await request(app).get('/api/user/details').set(amznRequestContextHeader, context)).statusCode).toBe(400);


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. Backend api auth add analyst reader role
2. User settings support set analyst reader group in cognito
3. Frontend hide Analyse menu if current user is analyst reader
4. Disable edit metadata display name and description if current user is analyst reader

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend