### PR TITLE
fix: miss permission for ec2 DescribeNatGateways

### DIFF
--- a/src/control-plane/backend/click-stream-api.ts
+++ b/src/control-plane/backend/click-stream-api.ts
@@ -249,6 +249,7 @@ export class ClickStreamApiConstruct extends Construct {
             'ec2:DescribeVpcEndpoints',
             'ec2:DescribeSecurityGroupRules',
             'ec2:DescribeAvailabilityZones',
+            'ec2:DescribeNatGateways',
             'kafka:ListClustersV2',
             'kafka:ListClusters',
             'kafka:ListNodes',

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -709,6 +709,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
               'ec2:DescribeVpcEndpoints',
               'ec2:DescribeSecurityGroupRules',
               'ec2:DescribeAvailabilityZones',
+              'ec2:DescribeNatGateways',
               'kafka:ListClustersV2',
               'kafka:ListClusters',
               'kafka:ListNodes',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend