### PR TITLE
fix: add servicecatalog:UpdateApplication for api role

### DIFF
--- a/src/common/solution-info.ts
+++ b/src/common/solution-info.ts
@@ -46,5 +46,7 @@ function parseVersion(version: string): VersionProps {
 
 export function versionDetail(version: string): string {
   const { short, buildId } = parseVersion(version);
-  return `(Version ${short})${buildId ? `(Build ${buildId})` : ''}`;
+  const buildInfo = buildId ? `(Build ${buildId})` : '';
+
+  return `(Version ${short})${buildInfo}`;
 }

--- a/src/control-plane/backend/stack-action-state-machine-construct.ts
+++ b/src/control-plane/backend/stack-action-state-machine-construct.ts
@@ -167,6 +167,7 @@ export class StackActionStateMachine extends Construct {
             'kms:*',
             'athena:*',
             'servicecatalog:CreateApplication',
+            'servicecatalog:UpdateApplication',
             'servicecatalog:DeleteApplication',
             'servicecatalog:GetApplication',
             'servicecatalog:GetAssociatedResource',

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -1033,6 +1033,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
               'kms:*',
               'athena:*',
               'servicecatalog:CreateApplication',
+              'servicecatalog:UpdateApplication',
               'servicecatalog:DeleteApplication',
               'servicecatalog:GetApplication',
               'servicecatalog:GetAssociatedResource',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Add `servicecatalog:UpdateApplication` permission for api role

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend