### PR TITLE
fix: reporting stack miss parameter

### DIFF
--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -1101,6 +1101,9 @@ export class CReportingStack extends JSONObject {
     QuickSightPrincipalParam?: string;
 
   @JSONObject.required
+    QuickSightOwnerPrincipalParam?: string;
+
+  @JSONObject.required
     RedshiftDBParam?: string;
 
   @JSONObject.required
@@ -1175,6 +1178,7 @@ export class CReportingStack extends JSONObject {
       QuickSightUserParam: resources.quickSightUser?.publishUserName,
       QuickSightNamespaceParam: pipeline.reporting?.quickSight?.namespace,
       QuickSightPrincipalParam: resources.quickSightUser?.publishUserArn,
+      QuickSightOwnerPrincipalParam: resources.quickSightUser?.exploreUserArn,
       RedshiftDBParam: pipeline.projectId,
       RedShiftDBSchemaParam: resources.appIds?.join(','),
       QuickSightVpcConnectionSubnetParam: resources.quickSightSubnetIds?.join(','),

--- a/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
@@ -842,6 +842,10 @@ const BASE_REPORTING_PARAMETERS = [
     ParameterValue: 'arn:aws:quicksight:us-east-1:555555555555:user/default/QuickSightEmbeddingRole/ClickstreamPublishUser',
   },
   {
+    ParameterKey: 'QuickSightOwnerPrincipalParam',
+    ParameterValue: 'arn:aws:quicksight:us-east-1:555555555555:user/default/QuickSightEmbeddingRole/ClickstreamExploreUser',
+  },
+  {
     ParameterKey: 'RedshiftDBParam',
     ParameterValue: 'project_8888_8888',
   },
@@ -868,7 +872,7 @@ const BASE_REPORTING_PARAMETERS = [
 ];
 
 export const REPORTING_WITH_PROVISIONED_REDSHIFT_PARAMETERS = [
-  ...BASE_REPORTING_PARAMETERS.slice(0, 6),
+  ...BASE_REPORTING_PARAMETERS.slice(0, 7),
   {
     ParameterKey: 'RedshiftEndpointParam',
     ParameterValue: 'https://redshift/xxx/yyy',
@@ -877,7 +881,7 @@ export const REPORTING_WITH_PROVISIONED_REDSHIFT_PARAMETERS = [
     ParameterKey: 'RedshiftPortParam',
     ParameterValue: '5002',
   },
-  ...BASE_REPORTING_PARAMETERS.slice(6, BASE_REPORTING_PARAMETERS.length),
+  ...BASE_REPORTING_PARAMETERS.slice(7, BASE_REPORTING_PARAMETERS.length),
 ];
 
 export const REPORTING_WITH_NEW_REDSHIFT_PARAMETERS = [
@@ -892,6 +896,10 @@ export const REPORTING_WITH_NEW_REDSHIFT_PARAMETERS = [
   {
     ParameterKey: 'QuickSightPrincipalParam',
     ParameterValue: 'arn:aws:quicksight:us-east-1:555555555555:user/default/QuickSightEmbeddingRole/ClickstreamPublishUser',
+  },
+  {
+    ParameterKey: 'QuickSightOwnerPrincipalParam',
+    ParameterValue: 'arn:aws:quicksight:us-east-1:555555555555:user/default/QuickSightEmbeddingRole/ClickstreamExploreUser',
   },
   {
     ParameterKey: 'RedshiftDBParam',

--- a/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
+++ b/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
@@ -59,6 +59,12 @@ describe('DataReportingQuickSightStack parameter test', () => {
     });
   });
 
+  test('Should has Parameter QuickSightOwnerPrincipalParam', () => {
+    template.hasParameter('QuickSightOwnerPrincipalParam', {
+      Type: 'String',
+    });
+  });
+
   test('Should has Parameter redshiftEndpointParam', () => {
     template.hasParameter('RedshiftEndpointParam', {
       Type: 'String',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

#468 

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend