### PR TITLE
fix: control plane deploy fail in CN regions

### DIFF
--- a/src/cloudfront-control-plane-stack.ts
+++ b/src/cloudfront-control-plane-stack.ts
@@ -105,7 +105,7 @@ export class CloudFrontControlPlaneStack extends Stack {
         iamCertificateId: iamCertificateId.valueAsString,
       };
 
-      Aspects.of(this).add(new InjectCustomResourceConfig('true'));
+      Aspects.of(this).add(new InjectCustomResourceConfig('false'));
 
       this.addToParamGroups(
         'Domain Information',

--- a/test/control-plane/cloudfront-control-plane-stack.test.ts
+++ b/test/control-plane/cloudfront-control-plane-stack.test.ts
@@ -962,6 +962,15 @@ describe('CloudFrontS3PortalStack - China region', () => {
       },
     }, 1);
   });
+
+  test('Switch off InstallLatestAwsSdk in China regions', () => {
+    const template = Template.fromStack(portalStack);
+
+    template.resourceCountIs('Custom::AWS', 1);
+    template.resourcePropertiesCountIs('Custom::AWS', {
+      InstallLatestAwsSdk: 'false',
+    }, 1);
+  });
 });
 
 describe('CloudFrontS3PortalStack - existing OIDC provider', () => {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

set InstallLatestAwsSdk to false in china regions

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [x] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend