### PR TITLE
fix: change GTMTransformer to builtIn plugin

### DIFF
--- a/src/control-plane/backend/config/dictionary.json
+++ b/src/control-plane/backend/config/dictionary.json
@@ -88,15 +88,15 @@
         "updateAt": 1667355960000
       },
       {
-        "id": "THIRD-PARTY-1",
-        "type": "PLUGIN#THIRD-PARTY-1",
+        "id": "BUILT-IN-4",
+        "type": "PLUGIN#BUILT-IN-4",
         "prefix": "PLUGIN",
         "name": "GTMTransformer",
         "description": {
           "en-US": "Convert the GTM server data format into the data format in the data warehouse",
           "zh-CN": "把GTM服务的数据格式，转换成数据仓库中的数据格式"
         },
-        "builtIn": false,
+        "builtIn": true,
         "mainFunction": "software.aws.solution.clickstream.gtm.GTMServerDataTransformer",
         "jarFile": "",
         "bindCount": 0,


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Set **GTMTransformer** to builtIn plugin

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend