### PR TITLE
fix: user api encode uid

### DIFF
--- a/frontend/src/apis/user.ts
+++ b/frontend/src/apis/user.ts
@@ -24,17 +24,27 @@ export const addUser = async (user: IUser) => {
 };
 
 export const updateUser = async (user: IUser) => {
-  const result: any = await apiRequest('put', `/user/${user.id}`, user);
+  const result: any = await apiRequest(
+    'put',
+    `/user/${encodeURIComponent(user.id)}`,
+    user
+  );
   return result;
 };
 
 export const deleteUser = async (uid: string) => {
-  const result: any = await apiRequest('delete', `/user/${uid}`);
+  const result: any = await apiRequest(
+    'delete',
+    `/user/${encodeURIComponent(uid)}`
+  );
   return result;
 };
 
 export const getUserDetails = async (uid: string) => {
-  const result: any = await apiRequest('get', `/user/details?id=${uid}`);
+  const result: any = await apiRequest(
+    'get',
+    `/user/details?id=${encodeURIComponent(uid)}`
+  );
   return result;
 };
 

--- a/src/control-plane/backend/lambda/api/test/api/user.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/user.test.ts
@@ -178,6 +178,23 @@ describe('User test', () => {
     expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
   });
 
+  it('Get details of user that url encode', async () => {
+    tokenMock(ddbMock, false);
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        id: 'fake+test@example.com',
+        role: IUserRole.OPERATOR,
+        deleted: false,
+      },
+    });
+    const res = await request(app)
+      .get('/api/user/details?id=fake%2Btest@example.com');
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ data: { deleted: false, role: 'Operator', id: 'fake+test@example.com' }, message: '', success: true });
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
+  });
+
   it('Get details of user that is not exist', async () => {
     tokenMock(ddbMock, false);
     ddbMock.on(GetCommand).resolves({});


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

closes #472 

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend