### PR TITLE
fix: Cannot access data for this visual in dashboard

### DIFF
--- a/src/analytics/private/sqls/redshift/dashboard/clickstream_user_dim_view_v1.sql
+++ b/src/analytics/private/sqls/redshift/dashboard/clickstream_user_dim_view_v1.sql
@@ -11,8 +11,7 @@ WITH user_base AS (
       ELSE _first_traffic_source
     END AS first_traffic_source_source,
     _first_traffic_medium AS first_traffic_source_medium,
-    _first_traffic_source_type AS first_traffic_source_name,
-    _channel AS first_visit_channel,
+    _first_traffic_source_type AS first_traffic_source_name
     CASE
       WHEN user_id IS NOT NULL THEN 'Registered'
       ELSE 'Non-registered'

--- a/src/data-reporting-quicksight-stack.ts
+++ b/src/data-reporting-quicksight-stack.ts
@@ -160,6 +160,7 @@ export class DataReportingQuickSightStack extends Stack {
 
     const cr = createQuicksightCustomResource(this, {
       templateArn: template.attrArn,
+      templateId: template.templateId,
       dataSourceArn: dataSource.attrArn,
       databaseName: stackParams.redshiftDBParam.valueAsString,
       quickSightProps: {

--- a/src/reporting/private/dataset-col-def.ts
+++ b/src/reporting/private/dataset-col-def.ts
@@ -559,10 +559,6 @@ export const clickstream_user_dim_view_columns: InputColumn[] = [
     Type: 'STRING',
   },
   {
-    Name: 'first_visit_channel',
-    Type: 'STRING',
-  },
-  {
     Name: 'device_id',
     Type: 'STRING',
   },

--- a/src/reporting/private/iam.ts
+++ b/src/reporting/private/iam.ts
@@ -54,6 +54,7 @@ export function createRoleForQuicksightCustomResourceLambda(
       ],
       actions: [
         'quicksight:DescribeTemplate',
+        'quicksight:ListTemplateVersions',
       ],
     }),
 
@@ -98,6 +99,7 @@ export function createRoleForQuicksightCustomResourceLambda(
         'quicksight:CreateDashboard',
         'quicksight:UpdateDashboard',
         'quicksight:UpdateDashboardPermissions',
+        'quicksight:UpdateDashboardPublishedVersion',
       ],
     }),
 

--- a/src/reporting/private/template-def.json
+++ b/src/reporting/private/template-def.json
@@ -591,10 +591,6 @@
                         "DataType": "STRING"
                     },
                     {
-                        "Name": "first_visit_channel",
-                        "DataType": "STRING"
-                    },
-                    {
                         "Name": "device_id",
                         "DataType": "STRING"
                     },

--- a/src/reporting/quicksight-custom-resource.ts
+++ b/src/reporting/quicksight-custom-resource.ts
@@ -73,6 +73,7 @@ export function createQuicksightCustomResource(
     analysisName: 'Clickstream Analysis',
     dashboardName: 'Clickstream Dashboard',
     templateArn: props.templateArn,
+    templateId: props.templateId,
     dataSourceArn: props.dataSourceArn,
     databaseName: databaseName,
     dataSets: [
@@ -103,7 +104,6 @@ export function createQuicksightCustomResource(
           'first_traffic_source_medium',
           'first_traffic_source_name',
           'first_referer',
-          'first_visit_channel',
           'registration_status',
           'device_id',
         ],

--- a/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
+++ b/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
@@ -382,7 +382,10 @@ describe('DataReportingQuickSightStack resource test', () => {
             },
           },
           {
-            Action: 'quicksight:DescribeTemplate',
+            Action: [
+              'quicksight:DescribeTemplate',
+              'quicksight:ListTemplateVersions',
+            ],
             Effect: 'Allow',
             Resource: [
               {
@@ -482,6 +485,7 @@ describe('DataReportingQuickSightStack resource test', () => {
               'quicksight:CreateDashboard',
               'quicksight:UpdateDashboard',
               'quicksight:UpdateDashboardPermissions',
+              'quicksight:UpdateDashboardPublishedVersion',
             ],
             Effect: 'Allow',
             Resource: {
@@ -945,10 +949,6 @@ describe('DataReportingQuickSightStack resource test', () => {
                 Type: 'STRING',
               },
               {
-                Name: 'first_visit_channel',
-                Type: 'STRING',
-              },
-              {
                 Name: 'device_id',
                 Type: 'STRING',
               },
@@ -980,7 +980,6 @@ describe('DataReportingQuickSightStack resource test', () => {
               'first_traffic_source_medium',
               'first_traffic_source_name',
               'first_referer',
-              'first_visit_channel',
               'registration_status',
               'device_id',
             ],


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

append latest template version to template Arn when update dashboard

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [x] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend