### PR TITLE
fix: QuickSight subscription check error when creating/updating reporting

### DIFF
--- a/src/control-plane/backend/click-stream-api.ts
+++ b/src/control-plane/backend/click-stream-api.ts
@@ -301,7 +301,6 @@ export class ClickStreamApiConstruct extends Construct {
             `arn:${Aws.PARTITION}:quicksight:*:${Aws.ACCOUNT_ID}:dataset/${QUICKSIGHT_TEMP_RESOURCE_NAME_PREFIX}*`,
           ],
           actions: [
-            'quicksight:DescribeAccountSubscription',
             'quicksight:UpdateDashboardPermissions',
             'quicksight:CreateDataSet',
             'quicksight:DeleteDataSet',
@@ -332,6 +331,15 @@ export class ClickStreamApiConstruct extends Construct {
             'quicksight:ListDataSets',
             'quicksight:ListDashboards',
             'quicksight:ListAnalyses',
+          ],
+        }),
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          resources: [
+            `arn:${Aws.PARTITION}:quicksight:*:${Aws.ACCOUNT_ID}:*`,
+          ],
+          actions: [
+            'quicksight:DescribeAccountSubscription',
           ],
         }),
         new iam.PolicyStatement({

--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -1073,6 +1073,8 @@ export class CReportingStack extends JSONObject {
       'RedShiftDBSchemaParam',
       'QuickSightVpcConnectionSubnetParam',
       'RedshiftParameterKeyParam',
+      'QuickSightPrincipalParam',
+      'QuickSightOwnerPrincipalParam',
     ];
     return allowedList;
   }

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -960,28 +960,24 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
             ],
           },
           {
-            Action: [
-              'quicksight:DescribeAccountSubscription',
-            ],
+            Action: 'quicksight:DescribeAccountSubscription',
             Effect: 'Allow',
-            Resource: [
-              {
-                'Fn::Join': [
-                  '',
-                  [
-                    'arn:',
-                    {
-                      Ref: 'AWS::Partition',
-                    },
-                    ':quicksight:*:',
-                    {
-                      Ref: 'AWS::AccountId',
-                    },
-                    ':*',
-                  ],
+            Resource: {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:',
+                  {
+                    Ref: 'AWS::Partition',
+                  },
+                  ':quicksight:*:',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':*',
                 ],
-              },
-            ],
+              ],
+            },
           },
           {
             Action: 'sts:AssumeRole',

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -752,7 +752,6 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
           },
           {
             Action: [
-              'quicksight:DescribeAccountSubscription',
               'quicksight:UpdateDashboardPermissions',
               'quicksight:CreateDataSet',
               'quicksight:DeleteDataSet',
@@ -955,6 +954,30 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
                       Ref: 'AWS::AccountId',
                     },
                     ':user/*',
+                  ],
+                ],
+              },
+            ],
+          },
+          {
+            Action: [
+              'quicksight:DescribeAccountSubscription',
+            ],
+            Effect: 'Allow',
+            Resource: [
+              {
+                'Fn::Join': [
+                  '',
+                  [
+                    'arn:',
+                    {
+                      Ref: 'AWS::Partition',
+                    },
+                    ':quicksight:*:',
+                    {
+                      Ref: 'AWS::AccountId',
+                    },
+                    ':*',
                   ],
                 ],
               },


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend