### PR TITLE
chore: parse the IamRole of redshift serverless namespace with different outputs

### DIFF
--- a/src/analytics/lambdas/custom-resource/redshift-associate-iam-role.ts
+++ b/src/analytics/lambdas/custom-resource/redshift-associate-iam-role.ts
@@ -35,12 +35,12 @@ function strToIamRole(str: string): ClusterIamRole {
 
   const statusMatches = str.match(/applyStatus=([^,]+)[,|\)]/);
   if (!statusMatches || statusMatches.length < 2) {
-    throw new Error(`Invalid IamRole String ($str), can not extract status.`);
+    throw new Error('Invalid IamRole String ($str), can not extract status.');
   }
 
   const roleMatches = str.match(/iamRoleArn=([^,]+)[,|\)]/);
   if (!roleMatches || roleMatches.length < 2) {
-    throw new Error(`Invalid IamRole String ($str), can not extract role arn.`);
+    throw new Error('Invalid IamRole String ($str), can not extract role arn.');
   }
 
   return {

--- a/src/analytics/lambdas/custom-resource/redshift-associate-iam-role.ts
+++ b/src/analytics/lambdas/custom-resource/redshift-associate-iam-role.ts
@@ -31,15 +31,21 @@ type ResourcePropertiesType = CustomProperties & {
 }
 
 function strToIamRole(str: string): ClusterIamRole {
-  const matches = str.match(/IamRole\(applyStatus=(.*), iamRoleArn=(.*)\)/);
+  logger.debug('Parsing IAM role string: ', { str });
 
-  if (!matches || matches.length < 3) {
-    throw new Error('Invalid IamRole string');
+  const statusMatches = str.match(/applyStatus=([^,]+)[,|\)]/);
+  if (!statusMatches || statusMatches.length < 2) {
+    throw new Error(`Invalid IamRole String ($str), can not extract status.`);
+  }
+
+  const roleMatches = str.match(/iamRoleArn=([^,]+)[,|\)]/);
+  if (!roleMatches || roleMatches.length < 2) {
+    throw new Error(`Invalid IamRole String ($str), can not extract role arn.`);
   }
 
   return {
-    ApplyStatus: matches[1] as 'in-sync' | 'removing' | 'adding',
-    IamRoleArn: matches[2],
+    ApplyStatus: statusMatches[1] as 'in-sync' | 'removing' | 'adding',
+    IamRoleArn: roleMatches[1],
   };
 }
 

--- a/test/analytics/analytics-on-redshift/lambda/custom-resources/redshift-associate-iam-role.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/custom-resources/redshift-associate-iam-role.test.ts
@@ -98,7 +98,7 @@ describe('Custom resource - Associate IAM role to redshift cluster', () => {
     }).resolvesOnce({
       namespace: {
         namespaceName,
-        iamRoles: [`IamRole(applyStatus=in-sync, iamRoleArn=${copyRole})`],
+        iamRoles: [`IamRole(iamRoleArn=${copyRole}, applyStatus=in-sync)`],
       },
     });
     redshiftServerlessMock.on(UpdateNamespaceCommand).resolvesOnce({});
@@ -131,7 +131,7 @@ describe('Custom resource - Associate IAM role to redshift cluster', () => {
       namespaceName,
     }).resolvesOnce({
       namespace: {
-        iamRoles: existingIAMRoles.map(role => `IamRole(applyStatus=in-sync, iamRoleArn=${role})`),
+        iamRoles: existingIAMRoles.map(role => `IamRole(iamRoleArn=${role}, applyStatus=in-sync)`),
         defaultIamRoleArn: existingIAMRoles[1],
       },
     }).resolvesOnce({


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Can parse the IamRole string of Redshift Serverless namespace in different outputs in recent changes,

1. IamRole(applyStatus=in-sync, iamRoleArn=arn:aws:iam::123456789:role/Clickstream-DataModelingR-CopyDataFromS3Role8483EDC-2EpRGwygJTu3)
2. IamRole(iamRoleArn=arn:aws:iam::1234567890:role/Clickstream-DataModelingR-CopyDataFromS3Role8483EDC-Phl68sLxbG85, applyStatus=in-sync)

closes #504

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend