### PR TITLE
chore: Correlate API Gateway request ID with Lambda request ID

### DIFF
--- a/src/control-plane/backend/lambda/api/common/constants.ts
+++ b/src/control-plane/backend/lambda/api/common/constants.ts
@@ -29,6 +29,7 @@ const STSUploadRole = process.env.STS_UPLOAD_ROLE_ARN;
 const APIRoleName = process.env.API_ROLE_NAME;
 const QuickSightEmbedRoleArn = process.env.QUICKSIGHT_EMBED_ROLE_ARN;
 const amznRequestContextHeader = 'x-amzn-request-context';
+const amznLambdaContextHeader = 'x-amzn-lambda-context';
 const ALLOW_UPLOADED_FILE_TYPES = process.env.ALLOW_UPLOADED_FILE_TYPES ?? 'jar,mmdb';
 const QUICKSIGHT_CONTROL_PLANE_REGION = process.env.QUICKSIGHT_CONTROL_PLANE_REGION ?? 'us-east-1';
 const SDK_MAVEN_VERSION_API_LINK =
@@ -97,6 +98,7 @@ export {
   APIRoleName,
   QuickSightEmbedRoleArn,
   amznRequestContextHeader,
+  amznLambdaContextHeader,
   QUICKSIGHT_CONTROL_PLANE_REGION,
   SDK_MAVEN_VERSION_API_LINK,
   PIPELINE_SUPPORTED_REGIONS,

--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -97,6 +97,21 @@ function getServerlessRedshiftRPU(region: string): RPURange {
   return { min: 0, max: 0 } as RPURange;
 }
 
+function deserializeContext(contextStr: string | undefined) {
+  let context;
+  try {
+    if (contextStr) {
+      context = JSON.parse(contextStr);
+    }
+  } catch (err) {
+    logger.warn('Invalid context', {
+      contextStr,
+      err,
+    });
+  }
+  return context;
+}
+
 function getEmailFromRequestContext(requestContext: string | undefined) {
   let email = '';
   try {
@@ -899,4 +914,5 @@ export {
   getCurMonthStr,
   getVersionFromTags,
   getAppRegistryApplicationArn,
+  deserializeContext,
 };

--- a/src/control-plane/backend/lambda/api/index.ts
+++ b/src/control-plane/backend/lambda/api/index.ts
@@ -16,6 +16,7 @@ import { accessLog } from './middle-ware/access-log';
 import { authOIDC } from './middle-ware/auth-oidc';
 import { authRole } from './middle-ware/auth-role';
 import { errorHandler } from './middle-ware/error-handler';
+import { injectContext } from './middle-ware/inject-context';
 import { responseTime } from './middle-ware/response-time';
 import { router_app } from './router/application';
 import { router_env } from './router/environment';
@@ -31,6 +32,8 @@ app.disable('x-powered-by');
 const port = process.env.PORT || 8080;
 
 app.use(express.json({ limit: '384kb' }));
+
+app.use(injectContext);
 
 app.use(accessLog);
 

--- a/src/control-plane/backend/lambda/api/middle-ware/inject-context.ts
+++ b/src/control-plane/backend/lambda/api/middle-ware/inject-context.ts
@@ -1,0 +1,30 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import express from 'express';
+import { amznLambdaContextHeader, amznRequestContextHeader } from '../common/constants';
+import { logger } from '../common/powertools';
+import { deserializeContext } from '../common/utils';
+
+// Implement inject context middleware function
+export function injectContext(req: express.Request, res: express.Response, next: express.NextFunction) {
+  const requestContext = deserializeContext(req.get(amznRequestContextHeader)) ?? undefined;
+  const lambdaContext = deserializeContext(req.get(amznLambdaContextHeader)) ?? undefined;
+  logger.addPersistentLogAttributes({
+    apiGatewayRequestId: requestContext?.requestId ?? '',
+    lambdaRequestId: lambdaContext?.request_id ?? '',
+  });
+
+  res.set('X-Click-Stream-Lambda-Request-Id', lambdaContext?.request_id ?? '');
+  next();
+}

--- a/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
+++ b/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
@@ -23,7 +23,7 @@ export interface LambdaAdapterLayerProps {
 
 export class LambdaAdapterLayer extends LayerVersion {
   constructor(scope: Construct, id: string, props?: LambdaAdapterLayerProps) {
-    const defaultVersion = props?.arch ?? '0.7.0';
+    const defaultVersion = props?.arch ?? '0.7.1';
     const defaultPlatform = props?.platform ?? 'linux/amd64';
     const defaultArch = props?.arch ?? 'x86_64';
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. Upgrade LambdaAdapter default version to 0.7.1 for support lambda context.
2. Inject context IDs to log attribute.
3. Add new response header `X-Click-Stream-Lambda-Request-Id`

<img width="775" alt="截屏2023-11-19 19 34 53" src="https://github.com/awslabs/clickstream-analytics-on-aws/assets/18416040/44defec8-a7e6-457d-8d03-0991efad8104">
<img width="1091" alt="截屏2023-11-19 19 35 26" src="https://github.com/awslabs/clickstream-analytics-on-aws/assets/18416040/4a52b834-9ed2-47a8-9527-5df60994e71c">


## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend