### PR TITLE
fix: using same request id when sending concurrent requests

### DIFF
--- a/.viperlightignore
+++ b/.viperlightignore
@@ -90,7 +90,6 @@ frontend/src/ts/constant-ln.ts:80
 frontend/src/ts/constant-ln.ts:83
 frontend/src/ts/constant-ln.ts:86
 frontend/src/ts/constant-ln.ts:89
-src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:54
 src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:55
 src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:56
 src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:57
@@ -100,6 +99,7 @@ src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:60
 src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:61
 src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:62
 src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:63
+src/control-plane/backend/lambda/api/test/api/ddb-mock.ts:64
 src/control-plane/backend/lambda/api/common/constants.ts:14
 
 [node-yarnoutdated]

--- a/frontend/src/ts/request.ts
+++ b/frontend/src/ts/request.ts
@@ -54,7 +54,7 @@ axios.interceptors.request.use(
     } as any;
     // set x-click-stream-request-id
     if (!config.headers[REQUEST_ID_KEY]) {
-      config.headers[REQUEST_ID_KEY] = requestId || generateStr(18);
+      config.headers[REQUEST_ID_KEY] = generateStr(18);
       requestId = config.headers[REQUEST_ID_KEY];
     }
     return config;

--- a/frontend/src/ts/test/utils.test.ts
+++ b/frontend/src/ts/test/utils.test.ts
@@ -22,7 +22,57 @@ import {
   validateProjectId,
 } from '../utils';
 
+global.crypto = {
+  getRandomValues: <T extends ArrayBufferView | null>(buffer: T): T => {
+    if (buffer === null) {
+      return buffer;
+    }
+    const bytes = new Uint8Array(
+      buffer.buffer,
+      buffer.byteOffset,
+      buffer.byteLength
+    );
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = Math.floor(Math.random() * 256);
+    }
+    return buffer;
+  },
+} as any;
+
 describe('generateStr', () => {
+  const validCharacters =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+  test('generates string of correct length', () => {
+    const length = 10;
+    const randomString = generateStr(length);
+    expect(randomString).toHaveLength(length);
+  });
+
+  test('contains only valid characters', () => {
+    const randomString = generateStr(20);
+    for (const char of randomString) {
+      expect(validCharacters.includes(char)).toBe(true);
+    }
+  });
+
+  test('generates different strings on subsequent calls', () => {
+    const string1 = generateStr(15);
+    const string2 = generateStr(15);
+    expect(string1).not.toEqual(string2);
+  });
+
+  test('handles zero length', () => {
+    const randomString = generateStr(0);
+    expect(randomString).toBe('');
+  });
+
+  test('handles very large length', () => {
+    const length = 1000;
+    const randomString = generateStr(length);
+    expect(randomString).toHaveLength(length);
+  });
+
   it('generate 8 characters string', () => {
     const result = generateStr(8);
     expect(result.length).toBe(8);

--- a/frontend/src/ts/utils.ts
+++ b/frontend/src/ts/utils.ts
@@ -35,15 +35,14 @@ export const defaultStr = (
 };
 
 export const generateStr = (length: number) => {
-  const characters = 'abcdefghijklmnopqrstuvwxyz';
+  const validCharacters =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const array = new Uint8Array(length);
+  window.crypto.getRandomValues(array);
   let randomString = '';
-  let seed = new Date().getTime();
-
-  while (randomString.length < length) {
-    seed = (seed * 9301 + 49297) % 233280;
-    const randomIndex = Math.floor((seed / 233280) * characters.length);
-    randomString += characters.charAt(randomIndex);
-  }
+  array.forEach((value) => {
+    randomString += validCharacters.charAt(value % validCharacters.length);
+  });
   return randomString;
 };
 

--- a/src/control-plane/backend/lambda/api/middle-ware/response-time.ts
+++ b/src/control-plane/backend/lambda/api/middle-ware/response-time.ts
@@ -24,8 +24,8 @@ export async function responseTime(req: express.Request, res: express.Response, 
   // @ts-ignore
   res.end = async (chunk: any, encoding: BufferEncoding, cb?: () => void) => {
     const requestId = req.get('X-Click-Stream-Request-Id');
-    if (requestId && res.statusCode >= 200 && res.statusCode <= 299) {
-      await projectServ.saveRequestId(requestId);
+    if (requestId && res.statusCode >= 500) {
+      await projectServ.deleteRequestId(requestId);
     }
     duration = Date.now() - start;
     res.setHeader('X-Click-Stream-Response-Time', duration);

--- a/src/control-plane/backend/lambda/api/router/user.ts
+++ b/src/control-plane/backend/lambda/api/router/user.ts
@@ -46,6 +46,7 @@ router_user.put(
   '/:id',
   validate([
     body('id').custom(isUserValid),
+    header('X-Click-Stream-Request-Id').custom(isRequestIdExisted),
   ]),
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     return userServ.update(req, res, next);
@@ -55,6 +56,7 @@ router_user.delete(
   '/:id',
   validate([
     param('id').custom(isUserValid),
+    header('X-Click-Stream-Request-Id').custom(isRequestIdExisted),
   ]),
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     return userServ.delete(req, res, next);

--- a/src/control-plane/backend/lambda/api/service/project.ts
+++ b/src/control-plane/backend/lambda/api/service/project.ts
@@ -286,4 +286,8 @@ export class ProjectServ {
     await store.saveRequestId(id);
   };
 
+  public async deleteRequestId(id: string) {
+    await store.deleteRequestId(id);
+  };
+
 }

--- a/src/control-plane/backend/lambda/api/store/click-stream-store.ts
+++ b/src/control-plane/backend/lambda/api/store/click-stream-store.ts
@@ -69,5 +69,5 @@ export interface ClickStreamStore {
 
   isRequestIdExisted: (id: string) => Promise<boolean>;
   saveRequestId: (id: string) => Promise<void>;
-
+  deleteRequestId: (id: string) => Promise<void>;
 }

--- a/src/control-plane/backend/lambda/api/test/api/analytics-dashboard.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/analytics-dashboard.test.ts
@@ -67,7 +67,7 @@ describe('Analytics dashboard test', () => {
     expect(quickSightMock).toHaveReceivedCommandTimes(CreateDataSetCommand, 1);
     expect(quickSightMock).toHaveReceivedCommandTimes(CreateDashboardCommand, 1);
     expect(quickSightMock).toHaveReceivedCommandTimes(CreateAnalysisCommand, 1);
-    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 2);
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
     expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 2);
   });
 
@@ -107,8 +107,8 @@ describe('Analytics dashboard test', () => {
     expect(quickSightMock).toHaveReceivedCommandTimes(CreateDataSetCommand, 0);
     expect(quickSightMock).toHaveReceivedCommandTimes(CreateDashboardCommand, 0);
     expect(quickSightMock).toHaveReceivedCommandTimes(CreateAnalysisCommand, 0);
-    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 2);
-    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
   });
 
   it('List dashboards of project', async () => {

--- a/src/control-plane/backend/lambda/api/test/api/application.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/application.test.ts
@@ -114,7 +114,7 @@ describe('Application test', () => {
     expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 2);
   });
   it('Create application with mock ddb error', async () => {
-    tokenMock(ddbMock, false);
+    tokenMock(ddbMock, false).rejectsOnce(new Error('Mock DynamoDB error'));;
     projectExistedMock(ddbMock, true);
 
     ddbMock.on(QueryCommand)
@@ -141,8 +141,6 @@ describe('Application test', () => {
           },
         ],
       });
-    // Mock DynamoDB error
-    ddbMock.on(PutCommand).rejects(new Error('Mock DynamoDB error'));
     const res = await request(app)
       .post('/api/app')
       .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
@@ -161,7 +159,7 @@ describe('Application test', () => {
       message: 'Unexpected error occurred at server.',
       error: 'Error',
     });
-    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 2);
   });
   it('Create application with mock stack status error', async () => {
     tokenMock(ddbMock, false);
@@ -211,7 +209,7 @@ describe('Application test', () => {
       success: false,
       message: 'The pipeline current status does not allow update.',
     });
-    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
   });
   it('Create application with mock pipeline error', async () => {
     tokenMock(ddbMock, false);
@@ -236,7 +234,7 @@ describe('Application test', () => {
       success: false,
       message: 'The latest pipeline not found.',
     });
-    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
   });
   it('Create application 400', async () => {
     tokenMock(ddbMock, false);
@@ -303,7 +301,7 @@ describe('Application test', () => {
         },
       ],
     });
-    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
   });
   it('Create application with non-existent project', async () => {
     tokenMock(ddbMock, false);
@@ -334,7 +332,7 @@ describe('Application test', () => {
         },
       ],
     });
-    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
   });
   it('Create application with error id', async () => {
     tokenMock(ddbMock, false);

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -945,7 +945,7 @@ describe('Pipeline test', () => {
       message: 'Template: AppRegistry not found in dictionary.',
       success: false,
     });
-    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
   });
   it('Create pipeline with mock error', async () => {
     tokenMock(ddbMock, false);
@@ -971,7 +971,7 @@ describe('Pipeline test', () => {
       message: 'Unexpected error occurred at server.',
       error: 'Error',
     });
-    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
   });
   it('Create pipeline 400', async () => {
     tokenMock(ddbMock, false);
@@ -1027,7 +1027,7 @@ describe('Pipeline test', () => {
         },
       ],
     });
-    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
   });
   it('Create pipeline with non-existent project', async () => {
     tokenMock(ddbMock, false);
@@ -1052,7 +1052,7 @@ describe('Pipeline test', () => {
         },
       ],
     });
-    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
   });
   it('Get pipeline by ID', async () => {
     projectExistedMock(ddbMock, true);

--- a/src/control-plane/backend/lambda/api/test/api/plugin.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/plugin.test.ts
@@ -12,6 +12,7 @@
  */
 
 import {
+  DeleteCommand,
   DynamoDBDocumentClient,
   PutCommand,
   QueryCommand,
@@ -121,9 +122,7 @@ describe('Plugin test', () => {
     });
   });
   it('Create plugin with mock error', async () => {
-    tokenMock(ddbMock, false);
-    // Mock DynamoDB error
-    ddbMock.on(PutCommand).rejects(new Error('Mock DynamoDB error'));;
+    tokenMock(ddbMock, false).rejectsOnce(new Error('Mock DynamoDB error'));
     const res = await request(app)
       .post('/api/plugin')
       .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
@@ -142,7 +141,8 @@ describe('Plugin test', () => {
       message: 'Unexpected error occurred at server.',
       error: 'Error',
     });
-    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 2);
+    expect(ddbMock).toHaveReceivedCommandTimes(DeleteCommand, 1);
   });
   it('Create plugin 400', async () => {
     tokenMock(ddbMock, false);
@@ -206,7 +206,7 @@ describe('Plugin test', () => {
         },
       ],
     });
-    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
   });
   it('Create plugin without jar or main function', async () => {
     tokenMock(ddbMock, false);

--- a/src/control-plane/backend/lambda/api/test/api/project.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/project.test.ts
@@ -58,9 +58,8 @@ describe('Project test', () => {
     expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 2);
   });
   it('Create project with id exist', async () => {
-    tokenMock(ddbMock, false);
+    tokenMock(ddbMock, false).resolvesOnce({});
     projectExistedMock(ddbMock, true);
-    ddbMock.on(PutCommand).resolvesOnce({});
     const res = await request(app)
       .post('/api/project')
       .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
@@ -76,13 +75,11 @@ describe('Project test', () => {
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(400);
     expect(res.body).toEqual({ error: [{ location: 'body', msg: 'Project resource existed.', param: 'id', value: MOCK_PROJECT_ID }], message: 'Parameter verification failed.', success: false });
-    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
   });
   it('Create project with mock error', async () => {
-    tokenMock(ddbMock, false);
+    tokenMock(ddbMock, false).rejectsOnce(new Error('Mock DynamoDB error'));
     projectExistedMock(ddbMock, false);
-    // Mock DynamoDB error
-    ddbMock.on(PutCommand).rejects(new Error('Mock DynamoDB error'));
     const res = await request(app)
       .post('/api/project')
       .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
@@ -102,7 +99,7 @@ describe('Project test', () => {
       message: 'Unexpected error occurred at server.',
       error: 'Error',
     });
-    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 2);
   });
   it('Create project 400', async () => {
     tokenMock(ddbMock, false);
@@ -169,7 +166,7 @@ describe('Project test', () => {
         },
       ],
     });
-    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
   });
   it('Get project by ID', async () => {
     ddbMock.on(GetCommand).resolves({

--- a/src/control-plane/backend/lambda/api/test/api/user.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/user.test.ts
@@ -86,14 +86,13 @@ describe('User test', () => {
   });
 
   it('Update user', async () => {
-    tokenMock(ddbMock, false);
+    tokenMock(ddbMock, false).resolvesOnce({});
     ddbMock.on(GetCommand).resolvesOnce({
       Item: {
         id: MOCK_USER_ID,
         deleted: false,
       },
     });
-    ddbMock.on(PutCommand).resolvesOnce({});
     const res = await request(app)
       .put(`/api/user/${MOCK_USER_ID}`)
       .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
@@ -114,14 +113,13 @@ describe('User test', () => {
   });
 
   it('Update user no allow', async () => {
-    tokenMock(ddbMock, false);
+    tokenMock(ddbMock, false).resolvesOnce({});
     ddbMock.on(GetCommand).resolvesOnce({
       Item: {
         id: MOCK_USER_ID,
         deleted: false,
       },
     });
-    ddbMock.on(PutCommand).resolvesOnce({});
     const res = await request(app)
       .put(`/api/user/${MOCK_USER_ID}`)
       .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
@@ -137,7 +135,7 @@ describe('User test', () => {
     expect(res.body.message).toEqual('This user not allow to be modified.');
     expect(res.body.success).toEqual(false);
     expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
-    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
   });
 
   it('Delete user', async () => {
@@ -562,7 +560,8 @@ describe('User test', () => {
     expect(res.statusCode).toBe(200);
     expect(res.body.message).toEqual('User settings updated.');
     expect(res.body.success).toEqual(true);
-    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
     expect(ddbMock).toHaveReceivedCommandTimes(UpdateCommand, 1);
   });
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend