### PR TITLE
fix: user settings miss attributes in ddb

### DIFF
--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -183,13 +183,6 @@ async function getRoleFromToken(decodedToken: any) {
   let oidcRoles: string[] = [];
 
   const userSettings = await userService.getUserSettingsFromDDB();
-  if (isEmpty(userSettings.roleJsonPath) ||
-    isEmpty(userSettings.operatorRoleNames) ||
-    isEmpty(userSettings.analystRoleNames ||
-    isEmpty(userSettings.analystReaderRoleNames))) {
-    return role;
-  }
-
   const values = JSONPath({ path: userSettings.roleJsonPath, json: decodedToken });
   if (Array.prototype.isPrototypeOf(values) && values.length > 0) {
     oidcRoles = values[0] as string[];

--- a/src/control-plane/backend/lambda/api/service/user.ts
+++ b/src/control-plane/backend/lambda/api/service/user.ts
@@ -115,16 +115,13 @@ export class UserService {
   };
 
   public async getUserSettingsFromDDB() {
-    const userSettings = await store.getUserSettings();
-    if (!userSettings) {
-      const defaultSettings = {
-        roleJsonPath: DEFAULT_ROLE_JSON_PATH,
-        operatorRoleNames: DEFAULT_OPERATOR_ROLE_NAMES,
-        analystRoleNames: DEFAULT_ANALYST_ROLE_NAMES,
-        analystReaderRoleNames: DEFAULT_ANALYST_READER_ROLE_NAMES,
-      } as IUserSettings;
-      return defaultSettings;
-    }
+    const ddbData = await store.getUserSettings();
+    const userSettings = {
+      roleJsonPath: ddbData?.roleJsonPath || DEFAULT_ROLE_JSON_PATH,
+      operatorRoleNames: ddbData?.operatorRoleNames || DEFAULT_OPERATOR_ROLE_NAMES,
+      analystRoleNames: ddbData?.analystRoleNames || DEFAULT_ANALYST_ROLE_NAMES,
+      analystReaderRoleNames: ddbData?.analystReaderRoleNames || DEFAULT_ANALYST_READER_ROLE_NAMES,
+    };
     return userSettings;
   }
 

--- a/src/control-plane/backend/lambda/api/test/api/user.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/user.test.ts
@@ -473,6 +473,41 @@ describe('User test', () => {
     expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
   });
 
+  it('Get user settings miss some attributes', async () => {
+    ddbMock.on(GetCommand, {
+      TableName: clickStreamTableName,
+      Key: {
+        id: 'USER_SETTINGS',
+        type: 'USER_SETTINGS',
+      },
+    }).resolves({
+      Item: {
+        id: 'USER_SETTINGS',
+        type: 'USER_SETTINGS',
+        roleJsonPath: '$.payload.any_keys.roles',
+        operatorRoleNames: `${DEFAULT_OPERATOR_ROLE_NAMES} , Operator1 , Operator2 `,
+        analystRoleNames: `${DEFAULT_ANALYST_ROLE_NAMES} , Analyst1 , Analyst2 `,
+      },
+    });
+    const res = await request(app)
+      .get('/api/user/settings');
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(
+      {
+        data: {
+          roleJsonPath: '$.payload.any_keys.roles',
+          operatorRoleNames: `${DEFAULT_OPERATOR_ROLE_NAMES} , Operator1 , Operator2 `,
+          analystRoleNames: `${DEFAULT_ANALYST_ROLE_NAMES} , Analyst1 , Analyst2 `,
+          analystReaderRoleNames: DEFAULT_ANALYST_READER_ROLE_NAMES,
+        },
+        message: '',
+        success: true,
+      },
+    );
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
+  });
+
   it('Get user settings', async () => {
     ddbMock.on(GetCommand, {
       TableName: clickStreamTableName,
@@ -497,8 +532,6 @@ describe('User test', () => {
     expect(res.body).toEqual(
       {
         data: {
-          id: 'USER_SETTINGS',
-          type: 'USER_SETTINGS',
           roleJsonPath: '$.payload.any_keys.roles',
           operatorRoleNames: `${DEFAULT_OPERATOR_ROLE_NAMES} , Operator1 , Operator2 `,
           analystRoleNames: `${DEFAULT_ANALYST_ROLE_NAMES} , Analyst1 , Analyst2 `,


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend