### PR TITLE
fix: example data generator live count

### DIFF
--- a/examples/standalone-data-generator/application/shopping/ScreenEvent.py
+++ b/examples/standalone-data-generator/application/shopping/ScreenEvent.py
@@ -346,7 +346,7 @@ def get_sign_up_page_events(event, user):
 def get_live_page_events(event, user):
     global current_feature, clicked_product
     events = []
-    live_id = random.randint(1, 5)
+    live_id = random.randint(1, 4)
     view_duration = live_id * random.randint(1, 60)
     user.current_timestamp += view_duration * 1000
     next_page = ShoppingScreen.get_next_page(Page.LIVE)

--- a/examples/standalone-data-generator/application/shopping/ShoppingScreen.py
+++ b/examples/standalone-data-generator/application/shopping/ShoppingScreen.py
@@ -182,6 +182,8 @@ class iOSScreen:
             return iOSScreen.BUY_RESULT
         elif screen_name == Page.PROFILE:
             return iOSScreen.PROFILE
+        elif screen_name == Page.LIVE:
+            return iOSScreen.LIVE
         else:
             return iOSScreen.EXIT
 
@@ -222,5 +224,7 @@ class WebScreen:
             return WebScreen.RESULT
         elif screen_name == Page.PROFILE:
             return WebScreen.PROFILE
+        elif screen_name == Page.LIVE:
+            return WebScreen.LIVE
         else:
             return iOSScreen.EXIT


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary
1. change example data generator live max count to 4

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend