### PR TITLE
chore: check previous scan metadata workflow job is running

### DIFF
--- a/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/check-workflow-start.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/check-workflow-start.test.ts
@@ -63,7 +63,7 @@ describe('Lambda - check workflow start', () => {
           executionArn: 'arn:aws:states:us-east-1:xxxxxxxxx:execution:stateMachineNameTest:exec_id_1',
         },
       ],
-    });    
+    });
 
     const resp = await handler(checkMetadataWorkflowEvent);
     expect(resp).toEqual({
@@ -113,7 +113,7 @@ describe('Lambda - check workflow start', () => {
           executionArn: 'arn:aws:states:us-east-1:xxxxxxxxx:execution:stateMachineNameTest:exec_id_1',
         },
       ],
-    });        
+    });
 
     const resp = await handler(checkMetadataWorkflowEvent);
     expect(resp).toEqual({
@@ -160,7 +160,7 @@ describe('Lambda - check workflow start', () => {
           executionArn: 'arn:aws:states:us-east-1:xxxxxxxxx:execution:stateMachineNameTest:exec_id_1',
         },
       ],
-    });       
+    });
 
     const resp = await handler(checkMetadataWorkflowEvent);
     expect(resp).toEqual({
@@ -181,7 +181,7 @@ describe('Lambda - check workflow start', () => {
           executionArn: 'arn:aws:states:us-east-1:xxxxxxxxx:execution:stateMachineNameTest:exec_id_1',
         },
       ],
-    });  
+    });
 
     const resp = await handler(checkMetadataWorkflowEvent);
     expect(resp).toEqual({
@@ -204,7 +204,7 @@ describe('Lambda - check workflow start', () => {
           executionArn: 'arn:aws:states:us-east-1:xxxxxxxxx:execution:stateMachineNameTest:exec_id_1',
         },
       ],
-    });    
+    });
     const resp = await handler(checkMetadataWorkflowEvent);
     expect(resp).toEqual({
       status: WorkflowStatus.CONTINUE,
@@ -226,7 +226,7 @@ describe('Lambda - check workflow start', () => {
           executionArn: 'arn:aws:states:us-east-1:xxxxxxxxx:execution:stateMachineNameTest:exec_id_1',
         },
       ],
-    });     
+    });
     await expect(handler(checkMetadataWorkflowEvent)).rejects.toThrow('input scan date format is not yyyy-mm-dd');
   });
 
@@ -241,12 +241,12 @@ describe('Lambda - check workflow start', () => {
         //@ts-ignore
         {
           executionArn: 'arn:aws:states:us-east-1:xxxxxxxxx:execution:stateMachineNameTest:exec_id_2',
-        },        
+        },
       ],
-    });     
+    });
     const resp = await handler(checkMetadataWorkflowEvent);
     expect(resp).toEqual({
       status: WorkflowStatus.SKIP,
-    });   
-  });  
+    });
+  });
 });


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [x] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend