### PR TITLE
fix: set warm pool default value to 0 when pipeline update

### DIFF
--- a/frontend/src/pages/pipelines/create/CreatePipeline.tsx
+++ b/frontend/src/pages/pipelines/create/CreatePipeline.tsx
@@ -2553,7 +2553,7 @@ const CreatePipeline: React.FC<CreatePipelineProps> = (
           ),
           warmPoolSize: defaultGenericsValue(
             data.ingestionServer.size.warmPoolSize,
-            0
+            1
           ),
           scaleOnCpuUtilizationPercent: defaultGenericsValue(
             data.ingestionServer.size.scaleOnCpuUtilizationPercent,

--- a/frontend/src/pages/pipelines/create/CreatePipeline.tsx
+++ b/frontend/src/pages/pipelines/create/CreatePipeline.tsx
@@ -2553,7 +2553,7 @@ const CreatePipeline: React.FC<CreatePipelineProps> = (
           ),
           warmPoolSize: defaultGenericsValue(
             data.ingestionServer.size.warmPoolSize,
-            1
+            0
           ),
           scaleOnCpuUtilizationPercent: defaultGenericsValue(
             data.ingestionServer.size.scaleOnCpuUtilizationPercent,

--- a/frontend/src/ts/utils.ts
+++ b/frontend/src/ts/utils.ts
@@ -368,7 +368,7 @@ export const checkDisable = (condOne?: boolean, condTwo?: boolean) => {
 };
 
 export const defaultGenericsValue = <T>(expectValue: T, defaultValue: T) => {
-  if (expectValue) {
+  if (expectValue || expectValue === 0) {
     return expectValue;
   } else {
     return defaultValue;


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary



## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend