### PR TITLE
chore: service ping in China region

### DIFF
--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -181,12 +181,12 @@ export const ServerlessRedshiftRPUByRegionMapping = {
     max: 0,
   },
   'cn-north-1': {
-    min: 0,
-    max: 0,
+    min: 8,
+    max: 512,
   },
   'cn-northwest-1': {
-    min: 0,
-    max: 0,
+    min: 8,
+    max: 512,
   },
 };
 

--- a/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
@@ -196,6 +196,9 @@ export const quickSightIsSubscribed = async (): Promise<boolean> => {
 
 export const quickSightPing = async (region: string): Promise<boolean> => {
   try {
+    if (region.startsWith('cn')) {
+      return false;
+    }
     const quickSightClient = sdkClient.QuickSightClient({
       maxAttempts: 1,
       region: region,

--- a/src/control-plane/backend/lambda/api/store/aws/redshift.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/redshift.ts
@@ -185,7 +185,7 @@ export const getSubnetsByClusterSubnetGroup = async (region: string, clusterSubn
 
 export const redshiftServerlessPing = async (region: string): Promise<boolean> => {
   try {
-    if (region.startsWith('cn')) {
+    if (region === 'cn-northwest-1') {
       return false;
     }
     const redshiftServerlessClient = new RedshiftServerlessClient({

--- a/src/control-plane/backend/lambda/api/test/api/env.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/env.test.ts
@@ -1304,36 +1304,12 @@ describe('Account Env test', () => {
       '/api/env/ping?region=cn-north-1&services=emr-serverless,msk,quicksight,redshift-serverless,global-accelerator,athena');
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual({
-      success: true,
-      message: '',
-      data: [
-        {
-          service: 'global-accelerator',
-          available: false,
-        },
-        {
-          service: 'quicksight',
-          available: false,
-        },
-        {
-          service: 'emr-serverless',
-          available: true,
-        },
-        {
-          service: 'redshift-serverless',
-          available: true,
-        },
-        {
-          service: 'athena',
-          available: true,
-        },
-        {
-          service: 'msk',
-          available: true,
-        },
-      ],
-    });
+    expect(res.body.data).toContainEqual({ service: 'global-accelerator', available: false });
+    expect(res.body.data).toContainEqual({ service: 'quicksight', available: false });
+    expect(res.body.data).toContainEqual({ service: 'emr-serverless', available: true });
+    expect(res.body.data).toContainEqual({ service: 'redshift-serverless', available: true });
+    expect(res.body.data).toContainEqual({ service: 'athena', available: true });
+    expect(res.body.data).toContainEqual({ service: 'msk', available: true });
   });
   it('Ping Services in cn-northwest-1', async () => {
     emrServerlessClient.on(ListApplicationsCommand).resolves({
@@ -1360,36 +1336,12 @@ describe('Account Env test', () => {
       '/api/env/ping?region=cn-northwest-1&services=emr-serverless,msk,quicksight,redshift-serverless,global-accelerator,athena');
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual({
-      success: true,
-      message: '',
-      data: [
-        {
-          service: 'global-accelerator',
-          available: false,
-        },
-        {
-          service: 'quicksight',
-          available: false,
-        },
-        {
-          service: 'redshift-serverless',
-          available: false,
-        },
-        {
-          service: 'emr-serverless',
-          available: true,
-        },
-        {
-          service: 'athena',
-          available: true,
-        },
-        {
-          service: 'msk',
-          available: true,
-        },
-      ],
-    });
+    expect(res.body.data).toContainEqual({ service: 'global-accelerator', available: false });
+    expect(res.body.data).toContainEqual({ service: 'quicksight', available: false });
+    expect(res.body.data).toContainEqual({ service: 'emr-serverless', available: true });
+    expect(res.body.data).toContainEqual({ service: 'redshift-serverless', available: false });
+    expect(res.body.data).toContainEqual({ service: 'athena', available: true });
+    expect(res.body.data).toContainEqual({ service: 'msk', available: true });
   });
   it('Ping Services with ENOTFOUND', async () => {
     const mockError = new Error('Mock ENOTFOUND error');
@@ -1407,36 +1359,12 @@ describe('Account Env test', () => {
       '/api/env/ping?region=cn-north-1&services=emr-serverless,msk,quicksight,redshift-serverless,global-accelerator,athena');
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual({
-      success: true,
-      message: '',
-      data: [
-        {
-          service: 'global-accelerator',
-          available: false,
-        },
-        {
-          service: 'quicksight',
-          available: false,
-        },
-        {
-          service: 'emr-serverless',
-          available: false,
-        },
-        {
-          service: 'msk',
-          available: false,
-        },
-        {
-          service: 'redshift-serverless',
-          available: false,
-        },
-        {
-          service: 'athena',
-          available: false,
-        },
-      ],
-    });
+    expect(res.body.data).toContainEqual({ service: 'global-accelerator', available: false });
+    expect(res.body.data).toContainEqual({ service: 'quicksight', available: false });
+    expect(res.body.data).toContainEqual({ service: 'emr-serverless', available: false });
+    expect(res.body.data).toContainEqual({ service: 'redshift-serverless', available: false });
+    expect(res.body.data).toContainEqual({ service: 'athena', available: false });
+    expect(res.body.data).toContainEqual({ service: 'msk', available: false });
   });
   it('Get Host Zones', async () => {
     route53Client.on(ListHostedZonesCommand).resolves({

--- a/src/control-plane/backend/lambda/api/test/api/env.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/env.test.ts
@@ -1313,11 +1313,11 @@ describe('Account Env test', () => {
           available: false,
         },
         {
-          service: 'emr-serverless',
-          available: true,
+          service: 'quicksight',
+          available: false,
         },
         {
-          service: 'quicksight',
+          service: 'emr-serverless',
           available: true,
         },
         {
@@ -1369,15 +1369,15 @@ describe('Account Env test', () => {
           available: false,
         },
         {
+          service: 'quicksight',
+          available: false,
+        },
+        {
           service: 'redshift-serverless',
           available: false,
         },
         {
           service: 'emr-serverless',
-          available: true,
-        },
-        {
-          service: 'quicksight',
           available: true,
         },
         {
@@ -1416,15 +1416,15 @@ describe('Account Env test', () => {
           available: false,
         },
         {
+          service: 'quicksight',
+          available: false,
+        },
+        {
           service: 'emr-serverless',
           available: false,
         },
         {
           service: 'msk',
-          available: false,
-        },
-        {
-          service: 'quicksight',
           available: false,
         },
         {

--- a/src/control-plane/backend/lambda/api/test/api/env.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/env.test.ts
@@ -1313,6 +1313,62 @@ describe('Account Env test', () => {
           available: false,
         },
         {
+          service: 'emr-serverless',
+          available: true,
+        },
+        {
+          service: 'quicksight',
+          available: true,
+        },
+        {
+          service: 'redshift-serverless',
+          available: true,
+        },
+        {
+          service: 'athena',
+          available: true,
+        },
+        {
+          service: 'msk',
+          available: true,
+        },
+      ],
+    });
+  });
+  it('Ping Services in cn-northwest-1', async () => {
+    emrServerlessClient.on(ListApplicationsCommand).resolves({
+      applications: [],
+    });
+    kafkaClient.on(ListClustersV2Command).resolves({
+      ClusterInfoList: [],
+    });
+    kafkaConnectClient.on(ListConnectorsCommand).resolves({
+      connectors: [],
+    });
+    redshiftServerlessClient.on(ListWorkgroupsCommand).resolves({
+      workgroups: [],
+    });
+    athenaClient.on(ListWorkGroupsCommand).resolves({
+      WorkGroups: [],
+    });
+    quickSightClient.on(DescribeAccountSubscriptionCommand).resolves({
+      AccountInfo: {
+        AccountName: '',
+      },
+    });
+    const res = await request(app).get(
+      '/api/env/ping?region=cn-northwest-1&services=emr-serverless,msk,quicksight,redshift-serverless,global-accelerator,athena');
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      message: '',
+      data: [
+        {
+          service: 'global-accelerator',
+          available: false,
+        },
+        {
           service: 'redshift-serverless',
           available: false,
         },
@@ -1360,10 +1416,6 @@ describe('Account Env test', () => {
           available: false,
         },
         {
-          service: 'redshift-serverless',
-          available: false,
-        },
-        {
           service: 'emr-serverless',
           available: false,
         },
@@ -1373,6 +1425,10 @@ describe('Account Env test', () => {
         },
         {
           service: 'quicksight',
+          available: false,
+        },
+        {
+          service: 'redshift-serverless',
           available: false,
         },
         {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. Enable Redshift Serverless in cn-north-1
2. Disable QuickSight in China region

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend