### PR TITLE
fix: limit time filter hint text to max length 100

### DIFF
--- a/src/control-plane/backend/lambda/api/locales/en-US.json
+++ b/src/control-plane/backend/lambda/api/locales/en-US.json
@@ -8,7 +8,7 @@
       "tableChart": "Detail information"
     },
     "filter": {
-      "scope": "The scope of this time filter is based on the selection made at the time of saving this analysis. For example, if the time range selected at the time of saving this analysis is the past 7 days, then it is not possible to choose data from more than 7 days ago."
+      "scope": "Time filter scope is based on saved settings. Data out of scope can not be fetched."
     }
   }
 }


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend