### PR TITLE
fix: custom display overwrite preset display

### DIFF
--- a/src/control-plane/backend/lambda/api/service/display.ts
+++ b/src/control-plane/backend/lambda/api/service/display.ts
@@ -75,7 +75,9 @@ export class CMetadataDisplay {
     }
     const presetEvent = this.builtList.PresetEvents.find((e: any) => e.name === event.name);
     event.metadataSource = presetEvent ? MetadataSource.PRESET : MetadataSource.CUSTOM;
-    event.description = presetEvent ? presetEvent.description : event.description;
+    if (!metadataDisplay && presetEvent) {
+      event.description = presetEvent ? presetEvent.description : event.description;
+    }
   }
 
   private patchEventParameterInfo(parameter: IMetadataEventParameter) {
@@ -94,8 +96,10 @@ export class CMetadataDisplay {
       (e: any) => e.name === parameter.name && e.dataType === parameter.valueType);
     const publicEventParameter = this.builtList.PublicEventParameters.find(
       (e: any) => e.name === parameter.name && e.dataType === parameter.valueType);
+    if (!metadataDisplay && presetEventParameter) {
+      parameter.description = presetEventParameter ? presetEventParameter.description : parameter.description;
+    }
     parameter.metadataSource = presetEventParameter ? MetadataSource.PRESET : MetadataSource.CUSTOM;
-    parameter.description = presetEventParameter ? presetEventParameter.description : parameter.description;
     parameter.parameterType = publicEventParameter ? MetadataParameterType.PUBLIC : MetadataParameterType.PRIVATE;
   }
 
@@ -114,7 +118,9 @@ export class CMetadataDisplay {
     const presetUserAttribute = this.builtList.PresetUserAttributes.find(
       (e: any) => e.name === attribute.name && e.dataType === attribute.valueType);
     attribute.metadataSource = presetUserAttribute ? MetadataSource.PRESET : MetadataSource.CUSTOM;
-    attribute.description = presetUserAttribute ? presetUserAttribute.description : attribute.description;
+    if (!metadataDisplay && presetUserAttribute) {
+      attribute.description = presetUserAttribute ? presetUserAttribute.description : attribute.description;
+    }
   }
 
   public async patch(projectId: string, appId: string,

--- a/src/control-plane/backend/lambda/api/test/api/metadata.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/metadata.test.ts
@@ -445,8 +445,8 @@ describe('Metadata Event test', () => {
         dataVolumeLastDay: 1,
         displayName: `display name of event ${MOCK_EVENT_NAME}`,
         description: {
-          'en-US': 'mock event description in built-in',
-          'zh-CN': '内置事件的描述',
+          'en-US': 'Description of event event-mock',
+          'zh-CN': 'event-mock说明',
         },
       },
     });
@@ -534,8 +534,8 @@ describe('Metadata Event test', () => {
         dataVolumeLastDay: 0,
         displayName: `display name of event ${MOCK_EVENT_NAME}`,
         description: {
-          'en-US': 'mock event description in built-in',
-          'zh-CN': '内置事件的描述',
+          'en-US': 'Description of event event-mock',
+          'zh-CN': 'event-mock说明',
         },
       },
     });
@@ -968,8 +968,8 @@ describe('Metadata Event test', () => {
             name: `${MOCK_EVENT_NAME}`,
             displayName: `display name of event ${MOCK_EVENT_NAME}`,
             description: {
-              'en-US': 'mock event description in built-in',
-              'zh-CN': '内置事件的描述',
+              'en-US': 'Description of event event-mock',
+              'zh-CN': 'event-mock说明',
             },
             metadataSource: MetadataSource.PRESET,
             hasData: false,
@@ -1130,8 +1130,8 @@ describe('Metadata Event Attribute test', () => {
             metadataSource: MetadataSource.PRESET,
             displayName: `display name of event ${MOCK_EVENT_NAME}`,
             description: {
-              'en-US': 'mock event description in built-in',
-              'zh-CN': '内置事件的描述',
+              'en-US': 'Description of event event-mock',
+              'zh-CN': 'event-mock说明',
             },
           },
           {
@@ -1209,8 +1209,8 @@ describe('Metadata Event Attribute test', () => {
             metadataSource: MetadataSource.PRESET,
             displayName: `display name of event ${MOCK_EVENT_NAME}`,
             description: {
-              'en-US': 'mock event description in built-in',
-              'zh-CN': '内置事件的描述',
+              'en-US': 'Description of event event-mock',
+              'zh-CN': 'event-mock说明',
             },
           },
         ],
@@ -1591,8 +1591,8 @@ describe('Metadata User Attribute test', () => {
             appId: MOCK_APP_ID,
             name: MOCK_USER_ATTRIBUTE_NAME,
             description: {
-              'en-US': 'mock preset user attribute description in built-in',
-              'zh-CN': '内置用户属性的描述',
+              'en-US': 'Description of user parameter user-attribute-mock',
+              'zh-CN': 'user-attribute-mock参数说明',
             },
             displayName: 'display name of user parameter user-attribute-mock',
             category: ConditionCategory.USER_OUTER,
@@ -1678,8 +1678,8 @@ describe('Metadata User Attribute test', () => {
             appId: MOCK_APP_ID,
             name: MOCK_USER_ATTRIBUTE_NAME,
             description: {
-              'en-US': 'mock preset user attribute description in built-in',
-              'zh-CN': '内置用户属性的描述',
+              'en-US': 'Description of user parameter user-attribute-mock',
+              'zh-CN': 'user-attribute-mock参数说明',
             },
             displayName: 'display name of user parameter user-attribute-mock',
             category: ConditionCategory.USER_OUTER,


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend