### PR TITLE
fix: data source update fail when upgrade from v1.0.3

### DIFF
--- a/src/data-reporting-quicksight-stack.ts
+++ b/src/data-reporting-quicksight-stack.ts
@@ -138,19 +138,6 @@ export class DataReportingQuickSightStack extends Stack {
           port: stackParams.redshiftPortParam.valueAsNumber,
         },
       },
-      permissions: [
-        {
-          principal: stackParams.quickSightOwnerPrincipalParam.valueAsString,
-          actions: [
-            'quicksight:UpdateDataSourcePermissions',
-            'quicksight:DescribeDataSourcePermissions',
-            'quicksight:PassDataSource',
-            'quicksight:DescribeDataSource',
-            'quicksight:DeleteDataSource',
-            'quicksight:UpdateDataSource',
-          ],
-        },
-      ],
       vpcConnectionProperties: {
         vpcConnectionArn,
       },

--- a/src/reporting/private/dashboard.ts
+++ b/src/reporting/private/dashboard.ts
@@ -143,6 +143,34 @@ export async function waitForDataSetCreateCompleted(quickSight: QuickSight, acco
   }
 };
 
+export async function waitForDataSourceChangeCompleted(quickSight: QuickSight, accountId: string, dataSourceId: string) {
+  for (const _i of Array(60).keys()) {
+    try {
+      const dataSource = await quickSight.describeDataSource({
+        AwsAccountId: accountId,
+        DataSourceId: dataSourceId,
+      });
+
+      if ( dataSource.DataSource?.Status === ResourceStatus.UPDATE_SUCCESSFUL
+        || dataSource.DataSource?.Status === ResourceStatus.CREATION_SUCCESSFUL) {
+        return;
+      } else if ( dataSource.DataSource?.Status === ResourceStatus.UPDATE_FAILED ) {
+        throw new Error('Data source update failed.');
+      } else if ( dataSource.DataSource?.Status === ResourceStatus.CREATION_FAILED ) {
+        throw new Error('Data source create failed.');
+      }
+
+      logger.info('waitForDataSourceChangeCompleted: sleep 1 second');
+      await sleep(1000);
+
+
+    } catch (err: any) {
+      logger.error(`Data source create/update failed due to ${(err as Error).message}`);
+      throw err;
+    }
+  }
+};
+
 export async function waitForAnalysisChangeCompleted(quickSight: QuickSight, accountId: string, analysisId: string) {
   for (const _i of Array(60).keys()) {
     try {

--- a/src/reporting/private/iam.ts
+++ b/src/reporting/private/iam.ts
@@ -43,6 +43,8 @@ export function createRoleForQuicksightCustomResourceLambda(
       actions: [
         'quicksight:DescribeDataSource',
         'quicksight:PassDataSource',
+        'quicksight:DescribeDataSourcePermissions',
+        'quicksight:UpdateDataSourcePermissions',
       ],
     }),
 

--- a/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
+++ b/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
@@ -358,6 +358,8 @@ describe('DataReportingQuickSightStack resource test', () => {
             Action: [
               'quicksight:DescribeDataSource',
               'quicksight:PassDataSource',
+              'quicksight:DescribeDataSourcePermissions',
+              'quicksight:UpdateDataSourcePermissions',
             ],
             Effect: 'Allow',
             Resource: {
@@ -819,21 +821,6 @@ describe('DataReportingQuickSightStack resource test', () => {
         ],
       ],
     },
-    Permissions: [
-      {
-        Actions: [
-          'quicksight:UpdateDataSourcePermissions',
-          'quicksight:DescribeDataSourcePermissions',
-          'quicksight:PassDataSource',
-          'quicksight:DescribeDataSource',
-          'quicksight:DeleteDataSource',
-          'quicksight:UpdateDataSource',
-        ],
-        Principal: {
-          Ref: 'QuickSightOwnerPrincipalParam',
-        },
-      },
-    ],
     Type: 'REDSHIFT',
     VpcConnectionProperties: {
       VpcConnectionArn: {

--- a/test/reporting/quicksight/lambda/quicksight-resource.test.ts
+++ b/test/reporting/quicksight/lambda/quicksight-resource.test.ts
@@ -23,6 +23,7 @@ import {
   DescribeDashboardCommand,
   DescribeDashboardDefinitionCommand,
   DescribeDataSetCommand,
+  DescribeDataSourceCommand,
   DescribeTemplateDefinitionCommand,
   ListAnalysesCommand,
   ListDashboardsCommand,
@@ -39,6 +40,7 @@ import {
   UpdateDashboardPublishedVersionCommand,
   UpdateDataSetCommand,
   UpdateDataSetPermissionsCommand,
+  UpdateDataSourcePermissionsCommand,
 } from '@aws-sdk/client-quicksight';
 import { CdkCustomResourceResponse } from 'aws-lambda';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -517,6 +519,13 @@ describe('QuickSight Lambda function', () => {
 
   test('Create QuickSight dashboard - One app id', async () => {
 
+    quickSightClientMock.on(DescribeDataSourceCommand).resolves({
+      DataSource: {
+        Status: ResourceStatus.CREATION_SUCCESSFUL,
+      },
+    });
+    quickSightClientMock.on(UpdateDataSourcePermissionsCommand).resolves({});
+
     quickSightClientMock.on(DescribeDataSetCommand).resolvesOnce({
       DataSet: {
         DataSetId: 'dataset_0',
@@ -572,6 +581,13 @@ describe('QuickSight Lambda function', () => {
   });
 
   test('Create QuickSight dashboard - Multiple app id', async () => {
+
+    quickSightClientMock.on(DescribeDataSourceCommand).resolves({
+      DataSource: {
+        Status: ResourceStatus.CREATION_SUCCESSFUL,
+      },
+    });
+    quickSightClientMock.on(UpdateDataSourcePermissionsCommand).resolves({});
 
     quickSightClientMock.on(DescribeDataSetCommand).resolvesOnce({
       DataSet: {
@@ -652,6 +668,12 @@ describe('QuickSight Lambda function', () => {
   });
 
   test('Create QuickSight dashboard - dataset already exist', async () => {
+    quickSightClientMock.on(DescribeDataSourceCommand).resolves({
+      DataSource: {
+        Status: ResourceStatus.CREATION_SUCCESSFUL,
+      },
+    });
+    quickSightClientMock.on(UpdateDataSourcePermissionsCommand).resolves({});
     quickSightClientMock.on(CreateDataSetCommand).rejectsOnce(existError);
     try {
       await handler(basicEvent, context);
@@ -666,6 +688,13 @@ describe('QuickSight Lambda function', () => {
   });
 
   test('Create QuickSight dashboard - analysis already exist', async () => {
+
+    quickSightClientMock.on(DescribeDataSourceCommand).resolves({
+      DataSource: {
+        Status: ResourceStatus.CREATION_SUCCESSFUL,
+      },
+    });
+    quickSightClientMock.on(UpdateDataSourcePermissionsCommand).resolves({});
     quickSightClientMock.on(DescribeDataSetCommand).resolvesOnce({
       DataSet: {
         DataSetId: 'dataset_0',
@@ -700,6 +729,12 @@ describe('QuickSight Lambda function', () => {
   });
 
   test('Create QuickSight dashboard - dashboard already exist', async () => {
+    quickSightClientMock.on(DescribeDataSourceCommand).resolves({
+      DataSource: {
+        Status: ResourceStatus.CREATION_SUCCESSFUL,
+      },
+    });
+    quickSightClientMock.on(UpdateDataSourcePermissionsCommand).resolves({});
     quickSightClientMock.on(DescribeDataSetCommand).resolvesOnce({
       DataSet: {
         DataSetId: 'dataset_0',
@@ -773,6 +808,13 @@ describe('QuickSight Lambda function', () => {
   });
 
   test('Update QuickSight dashboard - One app id', async () => {
+
+    quickSightClientMock.on(DescribeDataSourceCommand).resolves({
+      DataSource: {
+        Status: ResourceStatus.UPDATE_SUCCESSFUL,
+      },
+    });
+    quickSightClientMock.on(UpdateDataSourcePermissionsCommand).resolves({});
 
     quickSightClientMock.on(UpdateDataSetCommand).resolvesOnce({
       Arn: 'arn:aws:quicksight:us-east-1:xxxxxxxxxx:dataset/dataset_0',
@@ -852,6 +894,13 @@ describe('QuickSight Lambda function', () => {
   });
 
   test('Update QuickSight dashboard - template change', async () => {
+
+    quickSightClientMock.on(DescribeDataSourceCommand).resolves({
+      DataSource: {
+        Status: ResourceStatus.UPDATE_SUCCESSFUL,
+      },
+    });
+    quickSightClientMock.on(UpdateDataSourcePermissionsCommand).resolves({});
 
     quickSightClientMock.on(UpdateDataSetCommand).resolvesOnce({
       Arn: 'arn:aws:quicksight:us-east-1:xxxxxxxxxx:dataset/dataset_0',
@@ -936,6 +985,13 @@ describe('QuickSight Lambda function', () => {
   });
 
   test('Update QuickSight dashboard - permission update', async () => {
+
+    quickSightClientMock.on(DescribeDataSourceCommand).resolves({
+      DataSource: {
+        Status: ResourceStatus.UPDATE_SUCCESSFUL,
+      },
+    });
+    quickSightClientMock.on(UpdateDataSourcePermissionsCommand).resolves({});
 
     quickSightClientMock.on(UpdateDataSetCommand).resolvesOnce({
       Arn: 'arn:aws:quicksight:us-east-1:xxxxxxxxxx:dataset/dataset_0',
@@ -1025,6 +1081,13 @@ describe('QuickSight Lambda function', () => {
 
   test('Update QuickSight dashboard - dataset not exist.', async () => {
 
+    quickSightClientMock.on(DescribeDataSourceCommand).resolves({
+      DataSource: {
+        Status: ResourceStatus.UPDATE_SUCCESSFUL,
+      },
+    });
+    quickSightClientMock.on(UpdateDataSourcePermissionsCommand).resolves({});
+
     quickSightClientMock.on(UpdateDataSetCommand).rejectsOnce(existError);
 
     try {
@@ -1053,6 +1116,13 @@ describe('QuickSight Lambda function', () => {
   });
 
   test('Update QuickSight dashboard - analysis not exist.', async () => {
+
+    quickSightClientMock.on(DescribeDataSourceCommand).resolves({
+      DataSource: {
+        Status: ResourceStatus.UPDATE_SUCCESSFUL,
+      },
+    });
+    quickSightClientMock.on(UpdateDataSourcePermissionsCommand).resolves({});
 
     quickSightClientMock.on(UpdateDataSetCommand).resolvesOnce({
       Arn: 'arn:aws:quicksight:us-east-1:xxxxxxxxxx:dataset/dataset_0',
@@ -1116,6 +1186,13 @@ describe('QuickSight Lambda function', () => {
   });
 
   test('Update QuickSight dashboard - dashboard not exist.', async () => {
+
+    quickSightClientMock.on(DescribeDataSourceCommand).resolves({
+      DataSource: {
+        Status: ResourceStatus.UPDATE_SUCCESSFUL,
+      },
+    });
+    quickSightClientMock.on(UpdateDataSourcePermissionsCommand).resolves({});
 
     quickSightClientMock.on(UpdateDataSetCommand).resolvesOnce({
       Arn: 'arn:aws:quicksight:us-east-1:xxxxxxxxxx:dataset/dataset_0',
@@ -1189,6 +1266,13 @@ describe('QuickSight Lambda function', () => {
 
   test('Update QuickSight dashboard - One app id from empty app id', async () => {
 
+    quickSightClientMock.on(DescribeDataSourceCommand).resolves({
+      DataSource: {
+        Status: ResourceStatus.UPDATE_SUCCESSFUL,
+      },
+    });
+    quickSightClientMock.on(UpdateDataSourcePermissionsCommand).resolves({});
+
     quickSightClientMock.on(CreateDataSetCommand).resolvesOnce({
       Arn: 'arn:aws:quicksight:us-east-1:xxxxxxxxxx:dataset/dataset_0',
       Status: 200,
@@ -1246,6 +1330,13 @@ describe('QuickSight Lambda function', () => {
   });
 
   test('Update QuickSight dashboard - Multiple app id', async () => {
+
+    quickSightClientMock.on(DescribeDataSourceCommand).resolves({
+      DataSource: {
+        Status: ResourceStatus.UPDATE_SUCCESSFUL,
+      },
+    });
+    quickSightClientMock.on(UpdateDataSourcePermissionsCommand).resolves({});
 
     quickSightClientMock.on(UpdateDataSetCommand).resolvesOnce({
       Arn: 'arn:aws:quicksight:us-east-1:xxxxxxxxxx:dataset/dataset_0',
@@ -1344,6 +1435,13 @@ describe('QuickSight Lambda function', () => {
 
   test('Update QuickSight dashboard - Multiple app id with delete app', async () => {
 
+    quickSightClientMock.on(DescribeDataSourceCommand).resolves({
+      DataSource: {
+        Status: ResourceStatus.UPDATE_SUCCESSFUL,
+      },
+    });
+    quickSightClientMock.on(UpdateDataSourcePermissionsCommand).resolves({});
+
     quickSightClientMock.on(UpdateDataSetCommand).resolvesOnce({
       Arn: 'arn:aws:quicksight:us-east-1:xxxxxxxxxx:dataset/dataset_0',
       Status: 200,
@@ -1427,6 +1525,13 @@ describe('QuickSight Lambda function', () => {
   });
 
   test('Update QuickSight dashboard - Multiple app id with delete and create app', async () => {
+
+    quickSightClientMock.on(DescribeDataSourceCommand).resolves({
+      DataSource: {
+        Status: ResourceStatus.UPDATE_SUCCESSFUL,
+      },
+    });
+    quickSightClientMock.on(UpdateDataSourcePermissionsCommand).resolves({});
 
     quickSightClientMock.on(UpdateDataSetCommand).resolvesOnce({
       Arn: 'arn:aws:quicksight:us-east-1:xxxxxxxxxx:dataset/dataset_0',
@@ -1556,6 +1661,13 @@ describe('QuickSight Lambda function', () => {
 
   test('Update QuickSight dashboard - with new dateset or upgrade from older version', async () => {
 
+    quickSightClientMock.on(DescribeDataSourceCommand).resolves({
+      DataSource: {
+        Status: ResourceStatus.UPDATE_SUCCESSFUL,
+      },
+    });
+    quickSightClientMock.on(UpdateDataSourcePermissionsCommand).resolves({});
+
     quickSightClientMock.on(UpdateDataSetCommand).callsFakeOnce(input => {
       if (input.DataSetId !== 'clickstream_dataset_test-database-n_test1_Lifecycle_Daily_View_c0f9155d') {
         throw new Error('update data set id is not the expected one.');
@@ -1671,6 +1783,13 @@ describe('QuickSight Lambda function', () => {
   });
 
   test('Update QuickSight dashboard - with analysis id and dashboard id changed', async () => {
+
+    quickSightClientMock.on(DescribeDataSourceCommand).resolves({
+      DataSource: {
+        Status: ResourceStatus.UPDATE_SUCCESSFUL,
+      },
+    });
+    quickSightClientMock.on(UpdateDataSourcePermissionsCommand).resolves({});
 
     quickSightClientMock.on(UpdateDataSetCommand).callsFakeOnce(input => {
       if (input.DataSetId !== 'clickstream_dataset_test-database-n_test1_Lifecycle_Daily_View_c0f9155d') {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [x] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend