### PR TITLE
fix: properly handle with the timeout while waiting for redshift data execution result

### DIFF
--- a/src/analytics/lambdas/custom-resource/create-schemas.ts
+++ b/src/analytics/lambdas/custom-resource/create-schemas.ts
@@ -47,7 +47,6 @@ const secretManagerClient = new SecretsManagerClient({
 
 export const physicalIdPrefix = 'create-redshift-db-schemas-custom-resource-';
 export const handler: CdkCustomResourceHandler = async (event: CloudFormationCustomResourceEvent, context: Context) => {
-  logger.info('event', { event });
   const physicalId = ('PhysicalResourceId' in event) ? event.PhysicalResourceId :
     `${physicalIdPrefix}${generateRandomStr(8, 'abcdefghijklmnopqrstuvwxyz0123456789')}`;
   const biUsername = `${(event.ResourceProperties as ResourcePropertiesType).redshiftBIUsernamePrefix}${physicalId.substring(physicalIdPrefix.length)}`;

--- a/test/jestEnv.js
+++ b/test/jestEnv.js
@@ -12,9 +12,9 @@
  */
 
 // solution
-SOLUTION_VERSION='v1.0.0_dev'
+const SOLUTION_VERSION='v1.0.0_dev'
 
-// controlpalne backend API
+// web console backend API
 process.env.AWS_REGION = 'us-east-1'
 process.env.AWS_ACCOUNT_ID = '555555555555'
 process.env.AWS_URL_SUFFIX = 'amazonaws.com'
@@ -30,7 +30,7 @@ process.env.DICTIONARY_TABLE_NAME = 'dictionary-table-name'
 process.env.QUICKSIGHT_EMBED_ROLE_ARN = 'arn:aws:iam::555555555555:role/QuickSightEmbeddingRole'
 process.env.FULL_SOLUTION_VERSION = 'v1.0.0-202311200542_dev'
 
-// controlplane bundling
+// web console bundling
 process.env.IS_SKIP_ASSET_BUNDLE = 'true'
 
 // env variables for analytics stack
@@ -50,3 +50,4 @@ process.env.WORKFLOW_INFO_DDB_TABLE_ARN = 'arn:aws:dynamodb:us-east-1:1111222233
 process.env.PIPELINE_S3_BUCKET_NAME = 'test-pipe-line-bucket';
 process.env.PIPELINE_S3_PREFIX = 'pipeline-prefix/';
 process.env.REDSHIFT_DATABASE = 'project1'
+process.env.REDSHIFT_DATA_WAIT_TIMEOUT = '4'


### PR DESCRIPTION

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend