### PR TITLE
fix: change event_properties_metadata to event_parameter_metadata to align…

### DIFF
--- a/src/analytics/lambdas/scan-metadata-workflow/store-metadata-into-ddb.ts
+++ b/src/analytics/lambdas/scan-metadata-workflow/store-metadata-into-ddb.ts
@@ -144,10 +144,10 @@ async function handleEventMetadata(appId: string, metadataItems: any[]) {
 }
 
 async function handlePropertiesMetadata(appId: string, metadataItems: any[]) {
-  const itemsMap = await getExistingItemsFromDDB(appId, 'event_properties_metadata');
+  const itemsMap = await getExistingItemsFromDDB(appId, 'event_parameter_metadata');
 
   const inputSql =
-    `SELECT id, month, prefix, project_id, app_id, day_number, category, event_name, property_name, value_type, value_enum, platform FROM ${appId}.event_properties_metadata;`;
+    `SELECT id, month, prefix, project_id, app_id, day_number, category, event_name, property_name, value_type, value_enum, platform FROM ${appId}.event_parameter_metadata;`;
 
   const response = await queryMetadata(inputSql);
 

--- a/src/analytics/private/sqls/redshift/sp-scan-metadata.sql
+++ b/src/analytics/private/sqls/redshift/sp-scan-metadata.sql
@@ -7,12 +7,12 @@ DECLARE
 	log_name varchar(50) := 'sp_scan_metadata';
 BEGIN
 
-	-- Drop event_properties_metadata and event_metadata table, the data should be moved into DDB
-	DROP TABLE IF EXISTS {{schema}}.event_properties_metadata;
+	-- Drop event_parameter_metadata and event_metadata table, the data should be moved into DDB
+	DROP TABLE IF EXISTS {{schema}}.event_parameter_metadata;
 	DROP TABLE IF EXISTS {{schema}}.event_metadata;
 	DROP TABLE IF EXISTS {{schema}}.user_attribute_metadata;
 
-  CREATE TABLE IF NOT EXISTS {{schema}}.event_properties_metadata (
+  CREATE TABLE IF NOT EXISTS {{schema}}.event_parameter_metadata (
     id VARCHAR(255),
 		month VARCHAR(255),
     prefix VARCHAR(255),
@@ -240,7 +240,7 @@ BEGIN
 
 	CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'info', 'Insert data into properties_temp_table table successfully.');
 
-	INSERT INTO {{schema}}.event_properties_metadata (id, month, prefix, project_id, app_id, day_number, category, event_name, property_name, value_type, value_enum, platform) 
+	INSERT INTO {{schema}}.event_parameter_metadata (id, month, prefix, project_id, app_id, day_number, category, event_name, property_name, value_type, value_enum, platform) 
 	SELECT
 		project_id || '#' || app_info_app_id || '#' || event_name || '#' || property_category || '#' || property_name || '#' || value_type AS id,
 		month,
@@ -321,7 +321,7 @@ BEGIN
 		GROUP BY event_name, project_id, app_info_app_id, property_category, month, day_number, property_name, value_type, platform
 	);
 
-	CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'info', 'Insert all parameters data into event_properties_metadata table successfully.');	
+	CALL {{schema}}.{{sp_clickstream_log}}(log_name, 'info', 'Insert all parameters data into event_parameter_metadata table successfully.');	
 
 	query := 'SELECT column_name FROM user_column_temp_table';
 	FOR rec IN EXECUTE query LOOP

--- a/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/store-metadata-into-ddb.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/store-metadata-into-ddb.test.ts
@@ -528,7 +528,7 @@ describe('Lambda - store the metadata into DDB from Redshift', () => {
       ClusterIdentifier: undefined,
       Database: 'project1',
       DbUser: undefined,
-      Sql: 'SELECT distinct id, month FROM app1.event_properties_metadata;',
+      Sql: 'SELECT distinct id, month FROM app1.event_parameter_metadata;',
       WithEvent: true,
       WorkgroupName: 'demo',
     });
@@ -536,7 +536,7 @@ describe('Lambda - store the metadata into DDB from Redshift', () => {
       ClusterIdentifier: undefined,
       Database: 'project1',
       DbUser: undefined,
-      Sql: 'SELECT id, month, prefix, project_id, app_id, day_number, category, event_name, property_name, value_type, value_enum, platform FROM app1.event_properties_metadata;',
+      Sql: 'SELECT id, month, prefix, project_id, app_id, day_number, category, event_name, property_name, value_type, value_enum, platform FROM app1.event_parameter_metadata;',
       WithEvent: true,
       WorkgroupName: 'demo',
     });


### PR DESCRIPTION
… with the event_parameter table


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

change event_properties_metadata to event_parameter_metadata to align with the event_parameter table

## Implementation highlights

change event_properties_metadata to event_parameter_metadata to align with the event_parameter table

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend