### PR TITLE
chore: delete QuickSight user when delete last one project

### DIFF
--- a/src/control-plane/backend/click-stream-api.ts
+++ b/src/control-plane/backend/click-stream-api.ts
@@ -326,6 +326,7 @@ export class ClickStreamApiConstruct extends Construct {
           actions: [
             'quicksight:GenerateEmbedUrlForRegisteredUser',
             'quicksight:RegisterUser',
+            'quicksight:DeleteUser',
             'quicksight:ListUsers',
             'quicksight:ListDataSets',
             'quicksight:ListDashboards',

--- a/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
@@ -104,15 +104,16 @@ export const registerUserByRegion = async (
 
 export const deleteClickstreamUser = async () => {
   const identityRegion = await sdkClient.QuickSightIdentityRegion();
+  const quickSightEmbedRoleName = QuickSightEmbedRoleArn?.split(':role/')[1];
   await deleteUserByRegion(identityRegion, {
     AwsAccountId: awsAccountId,
     Namespace: QUICKSIGHT_NAMESPACE,
-    UserName: QUICKSIGHT_PUBLISH_USER_NAME,
+    UserName: `${quickSightEmbedRoleName}/${QUICKSIGHT_PUBLISH_USER_NAME}`,
   });
   await deleteUserByRegion(identityRegion, {
     AwsAccountId: awsAccountId,
     Namespace: QUICKSIGHT_NAMESPACE,
-    UserName: QUICKSIGHT_EXPLORE_USER_NAME,
+    UserName: `${quickSightEmbedRoleName}/${QUICKSIGHT_EXPLORE_USER_NAME}`,
   });
 };
 

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -885,6 +885,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
             Action: [
               'quicksight:GenerateEmbedUrlForRegisteredUser',
               'quicksight:RegisterUser',
+              'quicksight:DeleteUser',
               'quicksight:ListUsers',
               'quicksight:ListDataSets',
               'quicksight:ListDashboards',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend