### PR TITLE
chore: change default app type to shopping in example data generator

### DIFF
--- a/examples/standalone-data-generator/configure.py
+++ b/examples/standalone-data-generator/configure.py
@@ -14,7 +14,7 @@ import json
 import enums
 
 # application type, you can switch to `enums.Application.Shopping` to send shopping events.
-APP_TYPE = enums.Application.NotePad
+APP_TYPE = enums.Application.Shopping
 
 # for history event consts
 DURATION_OF_DAYS = 30

--- a/examples/standalone-data-generator/create_event.py
+++ b/examples/standalone-data-generator/create_event.py
@@ -44,6 +44,7 @@ if __name__ == '__main__':
     if configure.APP_ID == "" or configure.ENDPOINT == "":
         print("Error: please config your appId and endpoint")
     else:
+        print("Your configuration is:\nappId: " + configure.APP_ID + "\nendpoint: " + configure.ENDPOINT)
         start_time = utils.current_timestamp()
         # init all user
         all_user_count = app_provider.get_all_user_count()
@@ -80,4 +81,5 @@ if __name__ == '__main__':
                 utils.current_timestamp() - start_gen_day_user_event_time) + "\n")
 
         print("job finished, upload " + str(total_events_count) + " events, cost: " +
-              str(utils.current_timestamp() - start_time) + "ms")
+              str(utils.current_timestamp() - start_time) + "ms\n")
+        print("Your configuration is:\nappId: " + configure.APP_ID + "\nendpoint: " + configure.ENDPOINT)


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary
1. change default app type to shopping in example data generator

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend