### PR TITLE
chore: validate the ingress rules of security groups of vpc endpoints

### DIFF
--- a/src/control-plane/backend/lambda/api/common/request-valid.ts
+++ b/src/control-plane/backend/lambda/api/common/request-valid.ts
@@ -255,7 +255,6 @@ export const isAppId: CustomValidator = value => {
   }
   const regexp = new RegExp(APP_ID_PATTERN);
   const match = value.match(regexp);
-  console.log(match);
   if (!match || value !== match[0]) {
     return Promise.reject(`Validation error: appId: ${value} not match ${APP_ID_PATTERN}. Please check and try again.`);
   }

--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -429,9 +429,6 @@ function _checkInterfaceEndpoint(allSubnets: ClickStreamSubnet[], isolatedSubnet
     ToPort: 443,
     CidrIpv4: subnet.cidr,
   };
-  if (service.endsWith('.ecs')) {
-    console.log(subnet);
-  }
   if (!containRule([], vpcEndpointSGRules, vpcEndpointRule)) {
     invalidServices.push({
       service: service,
@@ -531,17 +528,6 @@ function _isAllowSecurityGroup(securityGroupsRule: SecurityGroupRule, rule: Secu
   }
   return false;
 }
-
-// function _isAllowAllIngressTrafficFromSubnets(securityGroupsRules: SecurityGroupRule[], subnet: ClickStreamSubnet) {
-//   const subnetCidrRule: SecurityGroupRule = {
-//     IsEgress: false,
-//     IpProtocol: 'tcp',
-//     FromPort: 443,
-//     ToPort: 443,
-//     CidrIpv4: subnet.cidr,
-//   };
-//   return containRule([], securityGroupsRules, subnetCidrRule);
-// }
 
 function getSubnetsAZ(subnets: ClickStreamSubnet[]) {
   const azArray = new Array<string>();

--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -435,7 +435,7 @@ function _checkInterfaceEndpoint(allSubnets: ClickStreamSubnet[], isolatedSubnet
       reason: 'The traffic is not allowed by security group rules',
     });
   }
-  if (service.includes('glue') && !_isAllowAllIngressTrafficFromSubnets(vpcEndpointSGRules, subnet)) {
+  if (!_isAllowAllIngressTrafficFromSubnets(vpcEndpointSGRules, subnet)) {
     invalidServices.push({
       service: service,
       reason: `The ingress traffic from subnet(${subnet.id}) is not allowed by security group rules`,

--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -429,16 +429,13 @@ function _checkInterfaceEndpoint(allSubnets: ClickStreamSubnet[], isolatedSubnet
     ToPort: 443,
     CidrIpv4: subnet.cidr,
   };
-  if (!containRule(vpcEndpointSGIds ?? [], vpcEndpointSGRules, vpcEndpointRule)) {
+  if (service.endsWith('.ecs')) {
+    console.log(subnet);
+  }
+  if (!containRule([], vpcEndpointSGRules, vpcEndpointRule)) {
     invalidServices.push({
       service: service,
       reason: 'The traffic is not allowed by security group rules',
-    });
-  }
-  if (!_isAllowAllIngressTrafficFromSubnets(vpcEndpointSGRules, subnet)) {
-    invalidServices.push({
-      service: service,
-      reason: `The ingress traffic from subnet(${subnet.id}) is not allowed by security group rules`,
     });
   }
   return invalidServices;
@@ -467,46 +464,15 @@ function checkRoutesGatewayId(routes: Route[], gatewayId: string) {
 
 function containRule(securityGroups: string[], securityGroupsRules: SecurityGroupRule[], rule: SecurityGroupRule) {
   for (let securityGroupsRule of securityGroupsRules) {
-    if (allowAllTraffic(securityGroupsRule, rule.IsEgress ?? false)) {
-      return true;
+    if (!_isAllowCidr(securityGroupsRule, rule) && !_isAllowSecurityGroup(securityGroupsRule, rule, securityGroups)) {
+      continue;
     }
-    if (!_isRuleMatch(securityGroupsRule, rule, securityGroups)) {continue;}
     return true;
   }
   return false;
 }
 
-function allowAllTraffic(securityGroupsRule: SecurityGroupRule, isEgress: boolean) {
-  if (securityGroupsRule.IsEgress === isEgress
-    && securityGroupsRule.IpProtocol === '-1'
-    && securityGroupsRule.FromPort === -1
-    && securityGroupsRule.ToPort === -1
-    && securityGroupsRule.CidrIpv4 === '0.0.0.0/0') {
-    return true;
-  }
-  return false;
-}
-
-function _isRuleMatch(securityGroupsRule: SecurityGroupRule, rule: SecurityGroupRule, securityGroups?: string[]) {
-  if (!_isRulesMatch2(securityGroupsRule, rule)) {return false;}
-
-  if (securityGroupsRule.CidrIpv4 !== '0.0.0.0/0') {
-    if (securityGroupsRule.CidrIpv4 && rule.CidrIpv4) {
-      const securityGroupsRuleCidr = ip.cidr(securityGroupsRule.CidrIpv4);
-      const ruleCidr = ip.cidr(rule.CidrIpv4);
-      if (!securityGroupsRuleCidr.includes(ruleCidr.firstUsableIp) || !securityGroupsRuleCidr.includes(ruleCidr.lastUsableIp)) {
-        return false;
-      }
-    } else if (securityGroupsRule.ReferencedGroupInfo?.GroupId) {
-      if (!securityGroups?.includes(securityGroupsRule.ReferencedGroupInfo.GroupId)) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
-function _isRulesMatch2(securityGroupsRule: SecurityGroupRule, rule: SecurityGroupRule) {
+function _checkRulesMatchBaseInfo(securityGroupsRule: SecurityGroupRule, rule: SecurityGroupRule) {
   if (securityGroupsRule.IsEgress !== rule.IsEgress) {
     return false;
   }
@@ -521,16 +487,61 @@ function _isRulesMatch2(securityGroupsRule: SecurityGroupRule, rule: SecurityGro
   return true;
 }
 
-function _isAllowAllIngressTrafficFromSubnets(securityGroupsRules: SecurityGroupRule[], subnet: ClickStreamSubnet) {
-  const subnetCidrRule: SecurityGroupRule = {
-    IsEgress: false,
-    IpProtocol: 'tcp',
-    FromPort: 443,
-    ToPort: 443,
-    CidrIpv4: subnet.cidr,
-  };
-  return containRule([], securityGroupsRules, subnetCidrRule);
+function _isAllowAllTraffic(securityGroupsRule: SecurityGroupRule, isEgress: boolean) {
+  if (securityGroupsRule.IsEgress === isEgress
+    && securityGroupsRule.IpProtocol === '-1'
+    && securityGroupsRule.FromPort === -1
+    && securityGroupsRule.ToPort === -1
+    && securityGroupsRule.CidrIpv4 === '0.0.0.0/0') {
+    return true;
+  }
+  return false;
 }
+
+function _isAllowCidr(securityGroupsRule: SecurityGroupRule, rule: SecurityGroupRule) {
+  if (_isAllowAllTraffic(securityGroupsRule, rule.IsEgress ?? false)) {
+    return true;
+  }
+  if (!_checkRulesMatchBaseInfo(securityGroupsRule, rule)) {
+    return false;
+  }
+  if (securityGroupsRule.CidrIpv4 && rule.CidrIpv4) {
+    if (securityGroupsRule.CidrIpv4 === '0.0.0.0/0') {
+      return true;
+    }
+    const securityGroupsRuleCidr = ip.cidr(securityGroupsRule.CidrIpv4);
+    const ruleCidr = ip.cidr(rule.CidrIpv4);
+    if (securityGroupsRuleCidr.includes(ruleCidr.firstUsableIp) && securityGroupsRuleCidr.includes(ruleCidr.lastUsableIp)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function _isAllowSecurityGroup(securityGroupsRule: SecurityGroupRule, rule: SecurityGroupRule, securityGroups?: string[]) {
+  if (_isAllowAllTraffic(securityGroupsRule, rule.IsEgress ?? false)) {
+    return true;
+  }
+  if (!_checkRulesMatchBaseInfo(securityGroupsRule, rule)) {
+    return false;
+  }
+  if (securityGroupsRule.ReferencedGroupInfo?.GroupId &&
+    securityGroups?.includes(securityGroupsRule.ReferencedGroupInfo.GroupId)) {
+    return true;
+  }
+  return false;
+}
+
+// function _isAllowAllIngressTrafficFromSubnets(securityGroupsRules: SecurityGroupRule[], subnet: ClickStreamSubnet) {
+//   const subnetCidrRule: SecurityGroupRule = {
+//     IsEgress: false,
+//     IpProtocol: 'tcp',
+//     FromPort: 443,
+//     ToPort: 443,
+//     CidrIpv4: subnet.cidr,
+//   };
+//   return containRule([], securityGroupsRules, subnetCidrRule);
+// }
 
 function getSubnetsAZ(subnets: ClickStreamSubnet[]) {
   const azArray = new Array<string>();

--- a/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
@@ -630,7 +630,7 @@ function createPipelineMock(
           IpProtocol: '-1',
           FromPort: -1,
           ToPort: -1,
-          CidrIpv4: props?.sgError ? '11.11.11.11/32' : '0.0.0.0/0',
+          CidrIpv4: props?.sgError ? '11.11.11.11/32' : '10.0.0.0/16',
         },
         {
           GroupId: 'sg-00000000000000031',
@@ -638,7 +638,7 @@ function createPipelineMock(
           IpProtocol: '-1',
           FromPort: -1,
           ToPort: -1,
-          CidrIpv4: props?.glueEndpointSGError || props?.sgError ? '11.11.11.11/32' : '0.0.0.0/0',
+          CidrIpv4: props?.glueEndpointSGError || props?.sgError ? '11.11.11.11/32' : '10.0.0.0/16',
         },
       ],
     });

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -675,7 +675,7 @@ describe('Pipeline test', () => {
       });
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(400);
-    expect(res.body.message).toEqual('Validation error: vpc endpoint error in subnet: subnet-00000000000000011, detail: [{\"service\":\"com.amazonaws.ap-southeast-1.logs\",\"reason\":\"The traffic is not allowed by security group rules\"}].');
+    expect(res.body.message).toEqual('Validation error: vpc endpoint error in subnet: subnet-00000000000000011, detail: [{\"service\":\"com.amazonaws.ap-southeast-1.logs\",\"reason\":\"The traffic is not allowed by security group rules\"},{\"service\":\"com.amazonaws.ap-southeast-1.logs\",\"reason\":\"The ingress traffic from subnet(subnet-00000000000000011) is not allowed by security group rules\"}].');
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeVpcEndpointsCommand, 1);
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeSecurityGroupRulesCommand, 1);
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeSubnetsCommand, 1);

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -835,7 +835,7 @@ describe('Pipeline test', () => {
       });
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(400);
-    expect(res.body.message).toEqual('Validation error: vpc endpoint error in subnet: subnet-00000000000000011, detail: [{\"service\":\"com.amazonaws.ap-southeast-1.glue\",\"reason\":\"The traffic is not allowed by security group rules\"}].');
+    expect(res.body.message).toEqual('Validation error: vpc endpoint error in subnet: subnet-00000000000000011, detail: [{\"service\":\"com.amazonaws.ap-southeast-1.glue\",\"reason\":\"The traffic is not allowed by security group rules\"},{\"service\":\"com.amazonaws.ap-southeast-1.glue\",\"reason\":\"The ingress traffic from subnet(subnet-00000000000000011) is not allowed by security group rules\"}].');
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeVpcEndpointsCommand, 1);
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeSecurityGroupRulesCommand, 1);
     expect(ec2Mock).toHaveReceivedCommandTimes(DescribeSubnetsCommand, 1);


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend