### PR TITLE
fix: duplicated subscription emails in metrics when upgrade pipeline

### DIFF
--- a/src/metrics/add-sns-subscription.ts
+++ b/src/metrics/add-sns-subscription.ts
@@ -33,7 +33,7 @@ export function addSubscriptionCustomResource(
   scope: Construct,
   props: AddSubscriptionCustomResourceProps,
 ) {
-  const fn = createaddSubscriptionLambda(scope, props);
+  const fn = createAddSubscriptionLambda(scope, props);
   const provider = new Provider(
     scope,
     'addSubscriptionCustomResourceProvider',
@@ -54,11 +54,12 @@ export function addSubscriptionCustomResource(
 }
 
 
-function createaddSubscriptionLambda(scope: Construct, props: AddSubscriptionCustomResourceProps): SolutionNodejsFunction {
+function createAddSubscriptionLambda(scope: Construct, props: AddSubscriptionCustomResourceProps): SolutionNodejsFunction {
   const role = createLambdaRole(scope, 'addSubscriptionLambdaRole', false, [
     new PolicyStatement({
       actions: [
         'sns:Subscribe',
+        'sns:ListSubscriptionsByTopic',
       ],
       resources: [props.snsTopic.topicArn],
     }),


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend