### PR TITLE
chore: remove data source ARN and owner principal in create dashboard api

### DIFF
--- a/frontend/src/pages/analytics/dashboard/create/CreateDashboard.tsx
+++ b/frontend/src/pages/analytics/dashboard/create/CreateDashboard.tsx
@@ -30,11 +30,8 @@ import Loading from 'components/common/Loading';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MAX_USER_INPUT_LENGTH } from 'ts/const';
-import {
-  OUTPUT_REPORTING_QUICKSIGHT_DATA_SOURCE_ARN,
-  XSS_PATTERN,
-} from 'ts/constant-ln';
-import { defaultStr, getValueFromStackOutputs } from 'ts/utils';
+import { XSS_PATTERN } from 'ts/constant-ln';
+import { defaultStr } from 'ts/utils';
 import { v4 as uuidv4 } from 'uuid';
 
 interface CreateDashboardProps {
@@ -74,17 +71,11 @@ const CreateDashboard: React.FC<CreateDashboardProps> = (
   const confirmCreateDashboard = async () => {
     setLoadingCreate(true);
     try {
-      const reportingOutputs = getValueFromStackOutputs(pipeline, 'Reporting', [
-        OUTPUT_REPORTING_QUICKSIGHT_DATA_SOURCE_ARN,
-      ]);
       const params: IAnalyticsDashboard = {
         ...curDashboard,
         projectId: projectId,
         appId: appId,
         region: pipeline.region,
-        defaultDataSourceArn:
-          reportingOutputs.get(OUTPUT_REPORTING_QUICKSIGHT_DATA_SOURCE_ARN) ??
-          '',
         sheets: sheetNames.map((item) => {
           return { id: uuidv4().replace(/-/g, ''), name: item.label };
         }),

--- a/frontend/src/types/analytics.d.ts
+++ b/frontend/src/types/analytics.d.ts
@@ -187,7 +187,6 @@ declare global {
     readonly description: string;
     readonly region: string;
     readonly sheets: IAnalyticsDashboardSheet[];
-    readonly defaultDataSourceArn: string;
     readonly embedUrl?: string;
 
     readonly createAt: number;

--- a/src/control-plane/backend/lambda/api/model/project.ts
+++ b/src/control-plane/backend/lambda/api/model/project.ts
@@ -52,8 +52,6 @@ export interface IDashboard {
   readonly description: string;
   readonly region: string;
   readonly sheets: IDashboardSheet[];
-  readonly ownerPrincipal: string;
-  readonly defaultDataSourceArn: string;
   embedUrl?: string;
 
   readonly createAt: number;

--- a/src/control-plane/backend/lambda/api/router/project.ts
+++ b/src/control-plane/backend/lambda/api/router/project.ts
@@ -47,7 +47,6 @@ router_project.post(
   '/:projectId/:appId/dashboard',
   validate([
     body().custom(isValidEmpty).custom(isXSSRequest),
-    body('defaultDataSourceArn').custom(isValidEmpty),
     param('projectId').custom(isProjectExisted),
     header('X-Click-Stream-Request-Id').custom(isRequestIdExisted),
   ]),

--- a/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
@@ -373,6 +373,7 @@ export const describeDashboard = async (
 
 export const createPublishDashboard = async (
   dashboard: IDashboard,
+  defaultDataSourceArn: string,
 ): Promise<any> => {
   try {
     const principals = await getClickstreamUserArn();
@@ -390,7 +391,7 @@ export const createPublishDashboard = async (
       PhysicalTableMap: {
         PhyTable0: {
           CustomSql: {
-            DataSourceArn: dashboard.defaultDataSourceArn,
+            DataSourceArn: defaultDataSourceArn,
             Name: 'event',
             SqlQuery: `select * from ${dashboard.appId}.event`,
             Columns: [

--- a/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-store.ts
+++ b/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-store.ts
@@ -48,8 +48,6 @@ export class DynamoDbStore implements ClickStreamStore {
         description: dashboard.description ?? '',
         region: dashboard.region ?? '',
         sheets: dashboard.sheets ?? [],
-        ownerPrincipal: dashboard.ownerPrincipal ?? '',
-        defaultDataSourceArn: dashboard.defaultDataSourceArn ?? '',
         createAt: Date.now(),
         updateAt: Date.now(),
         operator: dashboard.operator?? '',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend