### PR TITLE
docs: add self-hosted kafka cluster

### DIFF
--- a/docs/en/pipeline-mgmt/ingestion/create-data-sink-w-kafka.md
+++ b/docs/en/pipeline-mgmt/ingestion/create-data-sink-w-kafka.md
@@ -1,6 +1,6 @@
 # Apache Kafka
 This data sink will stream the clickstream data collected by the ingestion endpoint into an topic in a Kafka cluster.
-Currently, solution support Amazon Managed Streaming for Apache Kafka (Amazon MSK).
+Currently, solution support Amazon Managed Streaming for Apache Kafka (Amazon MSK) and Self-hosted Kafka cluster.
 
 ## Amazon MSK
 * **Select an existing Amazon MSK cluster.** Select an MSK cluster from the drop-down list, the MSK cluster needs to meet the following requirements:
@@ -14,12 +14,15 @@ Currently, solution support Amazon Managed Streaming for Apache Kafka (Amazon MS
 
 * **Topic**: The user can specify a topic name. By default, the solution will create a topic with "project-id".
 
-<!-- ## Self-hosted:
+## Self-hosted:
 Users can also use self-hosted Kafka clusters. In order to integrate the solution with Kafka clusters, provide the following configurations:
 
-* **Broker link**: Enter the  brokers link of Kafka cluster that you wish to connect to.
-* **Topic**: User can specify the topic for storing the data
-* **Security Group**: This VPC security group defines which subnets and IP ranges can access the Kafka cluster. -->
+* **Broker link**: Enter the brokers link of Kafka cluster that you wish to connect to, the Kafka cluster needs to meet the following requirements:
+  * The Kafka cluster and this solution need to be in the same VPC
+  * The number of Kafka cluster brokers cannot be less than two
+
+* **Topic**: User can specify the topic for storing the data. 
+* **Security Group**: This VPC security group defines which subnets and IP ranges can access the Kafka cluster.
 
 ## Connector
 Enable solution to create Kafka connector and a custom plugin for this connector. This connector will sink the data from Kafka cluster to S3 bucket.

--- a/docs/zh/pipeline-mgmt/ingestion/create-data-sink-w-kafka.md
+++ b/docs/zh/pipeline-mgmt/ingestion/create-data-sink-w-kafka.md
@@ -1,6 +1,6 @@
 # Apache Kafka
 该数据宿将从摄取端点收集的点击流数据流式传输到 Kafka 集群中的一个主题。
-目前，该解决方案支持 Amazon Managed Streaming for Apache Kafka (Amazon MSK)。
+目前，该解决方案支持 Amazon Managed Streaming for Apache Kafka (Amazon MSK)和自托管 Kafka 集群。
 
 ## Amazon MSK
 * **选择现有的 Amazon MSK 集群。** 从下拉列表中选择一个 MSK 集群，该 MSK 集群需要满足以下要求：
@@ -13,6 +13,16 @@
     **注意**：如果没有 MSK 集群，用户需要按照以上要求创建一个 MSK 集群。
 
 * **主题：** 用户可以指定主题名称。默认情况下，该解决方案将创建一个名为“project-id”的主题。
+
+## 自托管集群:
+用户还可以使用自托管的Kafka集群。为了将解决方案与Kafka集群集成，请提供以下配置:
+
+* **Broker 链接**: 输入您要连接的Kafka集群的brokers链接，Kafka集群需要满足以下要求：
+  * Kafka集群和本方案需要在同一个VPC
+  * Kafka集群broker数量不能少于2个
+
+* **主题**: 用户可以指定存储数据的主题。
+* **Security Group**: 该VPC安全组定义了哪些子网和IP范围可以访问Kafka集群。
 
 ## 连接器
 启用解决方案创建 Kafka 连接器和自定义插件。此连接器将从 Kafka 集群中的数据汇入 S3 存储桶中。


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

add self-hosted kafka cluster part

## Implementation highlights

add self-hosted kafka cluster part

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend