### PR TITLE
chore: improve UX for Analytics Studio when pipeline not support

### DIFF
--- a/frontend/public/locales/en-US/analytics.json
+++ b/frontend/public/locales/en-US/analytics.json
@@ -185,7 +185,7 @@
     "projectSelectError": "Must select a project",
     "appSelectError": "Must select an application",
     "dashboardNameEmptyError": "Please input dashboard name.",
-    "dashboardSheetNumError": "Dashboard sheet can't be more than 10 and can't be empty.",
+    "dashboardSheetNumError": "The dashboard sheet can't be more than ten and can't be empty.",
     "funnelPipelineVersionError": "Missing parameters, please upgrade the pipeline corresponding to the current project.",
     "dashboardSelectError": "Must select a dashboard",
     "sheetSelectError": "Must select a sheet",
@@ -195,7 +195,7 @@
     "selectTwoEvent": "Query metrics error: Please select at least two steps",
     "retentionJoinColumnDatatype": "Query metrics error: The data type for each set of associated parameter in retention analysis must be the same",
     "errorProjectOrApp": "Non-existent projects or applications: ",
-    "notSupportProjectOrApp": "This project or application not support Analytics Studio: "
+    "notSupportProjectOrApp": "This project or application does not support Analytics Studio: "
   },
   "operators": {
     "null": "is null",
@@ -268,7 +268,7 @@
   "emptyData": "No Data",
   "emptyDataMessage": "Please configure metrics to query",
   "emptyExploreMessage": "There are no explore modules available for the current project",
-  "emptyAnalyzeMessage": "There are no analyzes available for the current project",
+  "emptyAnalyzeMessage": "There are no analyses available for the current project",
   "emptyDashboardMessage": "No dashboard data has been found yet",
   "noDataAvailableTitle": "No clickstream data available for analytics",
   "noDataAvailableMessage": "The solution did not find any project has clickstream data yet, please contact your system admin to start collecting data.",

--- a/frontend/public/locales/en-US/analytics.json
+++ b/frontend/public/locales/en-US/analytics.json
@@ -16,7 +16,7 @@
     "deleteTip1": "Are you sure you want to delete the dashboard ",
     "deleteTip2": " delete dashboard will delete all data in QuickSight.",
     "defaultUserLifecycle": "User life cycle",
-    "defaultUserLifecycleDescription":"Out-of-the-box user lifecycle analysis dashboard created by solution.",
+    "defaultUserLifecycleDescription": "Out-of-the-box user lifecycle analysis dashboard created by solution.",
     "defaultTag": "default"
   },
   "realtime": {
@@ -44,8 +44,8 @@
     "userSegmentation": "User Segmentation"
   },
   "list": {
-    "loading": "Loading dashboards.",
-    "noDashboard": "You don’t have any clickstream analytics dashboard yet.",
+    "loading": "Loading dashboards",
+    "noDashboard": "You don’t have any clickstream analytics dashboard yet",
     "id": "ID",
     "description": "Descriptions",
     "createAt": "Creation time",
@@ -185,7 +185,7 @@
     "projectSelectError": "Must select a project",
     "appSelectError": "Must select an application",
     "dashboardNameEmptyError": "Please input dashboard name.",
-    "dashboardSheetTooMuchError": "Dashboard sheet can't be more than 10.",
+    "dashboardSheetNumError": "Dashboard sheet can't be more than 10 and can't be empty.",
     "funnelPipelineVersionError": "Missing parameters, please upgrade the pipeline corresponding to the current project.",
     "dashboardSelectError": "Must select a dashboard",
     "sheetSelectError": "Must select a sheet",
@@ -193,7 +193,9 @@
     "dateRangeInvalid": "The selected date range is invalid. The start date must be before the end date.",
     "inputVisualNameError": "Please input visualization name.",
     "selectTwoEvent": "Query metrics error: Please select at least two steps",
-    "retentionJoinColumnDatatype": "Query metrics error: The data type for each set of associated parameter in retention analysis must be the same"
+    "retentionJoinColumnDatatype": "Query metrics error: The data type for each set of associated parameter in retention analysis must be the same",
+    "errorProjectOrApp": "Non-existent projects or applications: ",
+    "notSupportProjectOrApp": "This project or application not support Analytics Studio: "
   },
   "operators": {
     "null": "is null",
@@ -256,6 +258,7 @@
     "realtimeStopped": "Realtime streaming is stopped",
     "realtimeStarted": "Realtime streaming is started",
     "reportingNotEnabled": "Reporting module is not enabled",
+    "pipelineVersionNotSupport": "The pipeline version is not supported",
     "setStartNode": "Set start node",
     "participateNodes": "Select nodes to participate in the analysis",
     "includingOtherEvents": "Including other events",
@@ -264,6 +267,8 @@
   },
   "emptyData": "No Data",
   "emptyDataMessage": "Please configure metrics to query",
+  "emptyExploreMessage": "There are no explore modules available for the current project",
+  "emptyAnalyzeMessage": "There are no analyzes available for the current project",
   "noDataAvailableTitle": "No clickstream data available for analytics",
   "noDataAvailableMessage": "The solution did not find any project has clickstream data yet, please contact your system admin to start collecting data.",
   "information": {

--- a/frontend/public/locales/en-US/analytics.json
+++ b/frontend/public/locales/en-US/analytics.json
@@ -269,6 +269,7 @@
   "emptyDataMessage": "Please configure metrics to query",
   "emptyExploreMessage": "There are no explore modules available for the current project",
   "emptyAnalyzeMessage": "There are no analyzes available for the current project",
+  "emptyDashboardMessage": "No dashboard data has been found yet",
   "noDataAvailableTitle": "No clickstream data available for analytics",
   "noDataAvailableMessage": "The solution did not find any project has clickstream data yet, please contact your system admin to start collecting data.",
   "information": {

--- a/frontend/public/locales/zh-CN/analytics.json
+++ b/frontend/public/locales/zh-CN/analytics.json
@@ -44,8 +44,8 @@
     "userSegmentation": "用户分群"
   },
   "list": {
-    "loading": "正在加载仪表板。",
-    "noDashboard": "您还没有任何点击流分析仪表板。",
+    "loading": "正在加载仪表板",
+    "noDashboard": "您还没有任何点击流分析仪表板",
     "id": "ID",
     "description": "描述",
     "createAt": "创建时间",
@@ -185,7 +185,7 @@
     "projectSelectError": "必须选择一个项目",
     "appSelectError": "必须选择一个应用程序",
     "dashboardNameEmptyError": "请输入仪表板名称",
-    "dashboardSheetTooMuchError": "工作表不能超过10个",
+    "dashboardSheetNumError": "工作表不能超过10个，并且不能为空",
     "funnelPipelineVersionError": "缺少参数，请升级当前项目对应的数据管道",
     "dashboardSelectError": "必须选择一个仪表板",
     "sheetSelectError": "必须选择一个工作表",
@@ -193,7 +193,9 @@
     "dateRangeInvalid": "所选日期范围无效。开始日期必须在结束日期之前。",
     "inputVisualNameError": "请输入图表名称",
     "selectTwoEvent": "查询指标错误: 请最少选择 2 个步骤",
-    "retentionJoinColumnDatatype": "查询指标错误: 留存分析每一组关联属性的数据类型必须相同"
+    "retentionJoinColumnDatatype": "查询指标错误: 留存分析每一组关联属性的数据类型必须相同",
+    "errorProjectOrApp": "不存在的的项目或应用程序: ",
+    "notSupportProjectOrApp": "当前项目或应用程序不支持分析工作坊: "
   },
   "operators": {
     "null": "空",
@@ -256,6 +258,7 @@
     "realtimeStopped": "实时流已停止",
     "realtimeStarted": "实时流已启动",
     "reportingNotEnabled": "Reporting模块未启用",
+    "pipelineVersionNotSupport": "数据管道版本不支持",
     "setStartNode": "设置起始节点",
     "participateNodes": "选择参与分析的节点",
     "includingOtherEvents": "包括其他事件",
@@ -264,6 +267,8 @@
   },
   "emptyData": "无数据",
   "emptyDataMessage": "请配置指标进行查询",
+  "emptyExploreMessage": "当前项目没有任何探索模块可用",
+  "emptyAnalyzeMessage": "当前项目尚未找到任何分析数据",
   "noDataAvailableTitle": "没有可用于分析的点击流数据",
   "noDataAvailableMessage": "尚未找到任何具有点击流数据的项目，请与您的系统管理员联系以开始收集数据。",
   "information": {

--- a/frontend/public/locales/zh-CN/analytics.json
+++ b/frontend/public/locales/zh-CN/analytics.json
@@ -269,6 +269,7 @@
   "emptyDataMessage": "请配置指标进行查询",
   "emptyExploreMessage": "当前项目没有任何探索模块可用",
   "emptyAnalyzeMessage": "当前项目尚未找到任何分析数据",
+  "emptyDashboardMessage": "尚未找到对应的仪表板",
   "noDataAvailableTitle": "没有可用于分析的点击流数据",
   "noDataAvailableMessage": "尚未找到任何具有点击流数据的项目，请与您的系统管理员联系以开始收集数据。",
   "information": {

--- a/frontend/src/apis/analytics.ts
+++ b/frontend/src/apis/analytics.ts
@@ -219,7 +219,7 @@ export const previewRetention = async (data: IExploreRequest) => {
 export const getPipelineDetailByProjectId = async (projectId: string) => {
   const result: any = await apiRequest(
     'get',
-    `/pipeline/${projectId}?pid=${projectId}`
+    `/pipeline/${projectId}?pid=${projectId}&cache=true`
   );
   return result;
 };
@@ -245,14 +245,6 @@ export const clean = async (region: string) => {
   const result: any = await apiRequest('post', '/reporting/clean', {
     region: region,
   });
-  return result;
-};
-
-export const analysisEnable = async (projectId: string) => {
-  const result: any = await apiRequest(
-    'get',
-    `/reporting/enable?projectId=${projectId}`
-  );
   return result;
 };
 

--- a/frontend/src/apis/analytics.ts
+++ b/frontend/src/apis/analytics.ts
@@ -248,6 +248,14 @@ export const clean = async (region: string) => {
   return result;
 };
 
+export const analysisEnable = async (projectId: string) => {
+  const result: any = await apiRequest(
+    'get',
+    `/reporting/enable?projectId=${projectId}`
+  );
+  return result;
+};
+
 export const embedAnalyzesUrl = async (
   projectId: string,
   allowedDomain: string

--- a/frontend/src/components/eventselect/AnalyticsType.ts
+++ b/frontend/src/components/eventselect/AnalyticsType.ts
@@ -43,10 +43,23 @@ export interface IAnalyticsItem extends SelectProps.Option {
   values?: IMetadataAttributeValue[];
 }
 
+export interface IProjectSelectItem extends SelectProps.Option {
+  projectId?: string;
+  projectName?: string;
+  appId?: string;
+  appName?: string;
+}
+
 export interface CategoryItemType {
   categoryName: string;
   categoryType: string;
   itemList: IAnalyticsItem[];
+}
+
+export enum AnalyticsProjectAppStatus {
+  NoExist = 'NoExist',
+  Disabled = 'Disabled',
+  Enable = 'Enable',
 }
 
 export enum ERelationShip {

--- a/frontend/src/components/layouts/AnalyticsHeader.tsx
+++ b/frontend/src/components/layouts/AnalyticsHeader.tsx
@@ -20,10 +20,8 @@ import {
 } from '@cloudscape-design/components';
 import { getProjectList } from 'apis/project';
 import { IProjectSelectItem } from 'components/eventselect/AnalyticsType';
-import { DispatchContext } from 'context/StateContext';
-import { StateActionType } from 'context/reducer';
 import { useLocalStorage } from 'pages/common/use-local-storage';
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import {
@@ -47,7 +45,6 @@ const AnalyticsHeader: React.FC<IHeaderProps> = (props: IHeaderProps) => {
   const { t, i18n } = useTranslation();
   const { user, signOut } = props;
   const { projectId, appId } = useParams();
-  const dispatch = useContext(DispatchContext);
   const [displayName, setDisplayName] = useState('');
   const [fullLogoutUrl, setFullLogoutUrl] = useState('');
   const [allProjectOptions, setAllProjectOptions] =
@@ -170,10 +167,6 @@ const AnalyticsHeader: React.FC<IHeaderProps> = (props: IHeaderProps) => {
             ),
           })
         );
-        dispatch?.({
-          type: StateActionType.SET_PROJECT_OPTIONS,
-          payload: projectOptions,
-        });
         setAllProjectOptions(projectOptions);
         setSelectOptionFromParams(projectOptions);
       }

--- a/frontend/src/components/layouts/AnalyticsHeader.tsx
+++ b/frontend/src/components/layouts/AnalyticsHeader.tsx
@@ -104,10 +104,10 @@ const AnalyticsHeader: React.FC<IHeaderProps> = (props: IHeaderProps) => {
     return options;
   };
 
-  const showWarningMessage = (message: string) => {
+  const showWarningMessage = (type: FlashbarProps.Type, message: string) => {
     setItems([
       {
-        type: 'warning',
+        type: type,
         content: message,
         dismissible: true,
         onDismiss: () => setItems([]),
@@ -123,11 +123,13 @@ const AnalyticsHeader: React.FC<IHeaderProps> = (props: IHeaderProps) => {
       const option = getProjectAppFromOptions(projectId, appId, projectOptions);
       if (!option) {
         showWarningMessage(
+          'error',
           `${t('analytics:valid.errorProjectOrApp')}${projectId} / ${appId}`
         );
         setSelectedOption(null);
       } else if (option.disabled) {
         showWarningMessage(
+          'warning',
           `${t(
             'analytics:valid.notSupportProjectOrApp'
           )}${projectId} / ${appId}`

--- a/frontend/src/context/reducer.ts
+++ b/frontend/src/context/reducer.ts
@@ -11,6 +11,7 @@
  *  and limitations under the License.
  */
 
+import { SelectProps } from '@cloudscape-design/components';
 import { IConditionItemType } from 'components/eventselect/AnalyticsType';
 import { validateFilterConditions } from 'pages/analytics/analytics-utils';
 
@@ -37,6 +38,7 @@ export interface IState {
   showAttributeError: boolean;
   showAttributeOperatorError: boolean;
   showAttributeValueError: boolean;
+  projectOptions: SelectProps.Options;
 }
 
 export enum StateActionType {
@@ -46,6 +48,7 @@ export enum StateActionType {
   SHOW_EVENT_VALID_ERROR = 'SHOW_EVENT_VALID_ERROR',
   HIDE_EVENT_VALID_ERROR = 'HIDE_EVENT_VALID_ERROR',
   VALIDATE_FILTER_CONDITIONS = 'VALIDATE_FILTER_CONDITIONS',
+  SET_PROJECT_OPTIONS = 'SET_PROJECT_OPTIONS',
 }
 
 export type Action = { type: StateActionType; payload: any };
@@ -57,10 +60,14 @@ export const initialState: IState = {
   showAttributeError: false,
   showAttributeOperatorError: false,
   showAttributeValueError: false,
+  projectOptions: [],
 };
 
 export const reducer = (state: IState, action: Action): IState => {
   switch (action.type) {
+    case StateActionType.SET_PROJECT_OPTIONS: {
+      return { ...state, projectOptions: action.payload };
+    }
     case StateActionType.SHOW_HELP_PANEL: {
       return { ...state, showHelpPanel: true, helpPanelType: action.payload };
     }

--- a/frontend/src/context/reducer.ts
+++ b/frontend/src/context/reducer.ts
@@ -11,7 +11,6 @@
  *  and limitations under the License.
  */
 
-import { SelectProps } from '@cloudscape-design/components';
 import { IConditionItemType } from 'components/eventselect/AnalyticsType';
 import { validateFilterConditions } from 'pages/analytics/analytics-utils';
 
@@ -38,7 +37,6 @@ export interface IState {
   showAttributeError: boolean;
   showAttributeOperatorError: boolean;
   showAttributeValueError: boolean;
-  projectOptions: SelectProps.Options;
 }
 
 export enum StateActionType {
@@ -48,7 +46,6 @@ export enum StateActionType {
   SHOW_EVENT_VALID_ERROR = 'SHOW_EVENT_VALID_ERROR',
   HIDE_EVENT_VALID_ERROR = 'HIDE_EVENT_VALID_ERROR',
   VALIDATE_FILTER_CONDITIONS = 'VALIDATE_FILTER_CONDITIONS',
-  SET_PROJECT_OPTIONS = 'SET_PROJECT_OPTIONS',
 }
 
 export type Action = { type: StateActionType; payload: any };
@@ -60,14 +57,10 @@ export const initialState: IState = {
   showAttributeError: false,
   showAttributeOperatorError: false,
   showAttributeValueError: false,
-  projectOptions: [],
 };
 
 export const reducer = (state: IState, action: Action): IState => {
   switch (action.type) {
-    case StateActionType.SET_PROJECT_OPTIONS: {
-      return { ...state, projectOptions: action.payload };
-    }
     case StateActionType.SHOW_HELP_PANEL: {
       return { ...state, showHelpPanel: true, helpPanelType: action.payload };
     }

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -54,6 +54,11 @@ code {
   align-items: center;
 }
 
+.center {
+  margin: auto;
+  width: 50%;
+}
+
 .page-loading {
   text-align: center;
   padding: 20px;

--- a/frontend/src/pages/analytics/AnalyticsHome.tsx
+++ b/frontend/src/pages/analytics/AnalyticsHome.tsx
@@ -60,7 +60,7 @@ const AnalyticsHome: React.FC<AnalyticsHomeProps> = (
       )
     ) {
       window.location.href = `/analytics/${analyticsInfo.projectId}/app/${analyticsInfo.appId}/dashboards`;
-    } else {
+    } else if (apps.length > 0) {
       setAnalyticsInfo(apps[0]);
       window.location.href = `/analytics/${apps[0].projectId}/app/${apps[0].appId}/dashboards`;
     }
@@ -77,7 +77,11 @@ const AnalyticsHome: React.FC<AnalyticsHomeProps> = (
         });
       if (success) {
         for (const project of data.items) {
-          if (project.applications && project.reportingEnabled) {
+          if (
+            project.applications &&
+            project.reportingEnabled &&
+            !project.pipelineVersion?.startsWith('v1.0')
+          ) {
             for (const app of project.applications) {
               apps.push({
                 projectId: project.id,

--- a/frontend/src/pages/analytics/analyzes/AnalyticsAnalyzes.tsx
+++ b/frontend/src/pages/analytics/analyzes/AnalyticsAnalyzes.tsx
@@ -69,7 +69,7 @@ const AnalyticsAnalyzes: React.FC = () => {
     setLoadingData(false);
   };
 
-  const checkProjectEnableAndLoadData = async (loadDataFunc: ()=>void) => {
+  const checkProjectEnableAndLoadData = async (loadDataFunc: () => void) => {
     setLoadingData(true);
     try {
       const { success, data }: ApiResponse<{ reportingEnabled: boolean }> =

--- a/frontend/src/pages/analytics/analyzes/AnalyticsAnalyzes.tsx
+++ b/frontend/src/pages/analytics/analyzes/AnalyticsAnalyzes.tsx
@@ -31,7 +31,7 @@ import {
   Header,
   SpaceBetween,
 } from '@cloudscape-design/components';
-import { analysisEnable, embedAnalyzesUrl } from 'apis/analytics';
+import { embedAnalyzesUrl, getPipelineDetailByProjectId } from 'apis/analytics';
 import InfoLink from 'components/common/InfoLink';
 import Loading from 'components/common/Loading';
 import AnalyticsNavigation from 'components/layouts/AnalyticsNavigation';
@@ -42,7 +42,7 @@ import { StateActionType, HelpPanelType } from 'context/reducer';
 import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import { defaultStr } from 'ts/utils';
+import { defaultStr, pipelineAnalysisStudioEnable } from 'ts/utils';
 import ExploreEmbedFrame from '../comps/ExploreEmbedFrame';
 
 const AnalyticsAnalyzes: React.FC = () => {
@@ -69,24 +69,24 @@ const AnalyticsAnalyzes: React.FC = () => {
     setLoadingData(false);
   };
 
-  const checkProjectEnableAndLoadData = async (loadDataFunc: () => void) => {
+  const loadPipeline = async () => {
     setLoadingData(true);
     try {
-      const { success, data }: ApiResponse<{ reportingEnabled: boolean }> =
-        await analysisEnable(defaultStr(projectId));
-      if (success && data?.reportingEnabled) {
-        loadDataFunc();
-      } else {
-        setLoadingData(false);
+      const { success, data }: ApiResponse<IPipeline> =
+        await getPipelineDetailByProjectId(defaultStr(projectId));
+      if (success && pipelineAnalysisStudioEnable(data)) {
+        await getAnalyzes();
       }
+      setLoadingData(false);
     } catch (error) {
       setLoadingData(false);
+      console.log(error);
     }
   };
 
   useEffect(() => {
     if (projectId && appId) {
-      checkProjectEnableAndLoadData(getAnalyzes);
+      loadPipeline();
     }
   }, [projectId]);
 

--- a/frontend/src/pages/analytics/analyzes/AnalyticsAnalyzes.tsx
+++ b/frontend/src/pages/analytics/analyzes/AnalyticsAnalyzes.tsx
@@ -31,7 +31,7 @@ import {
   Header,
   SpaceBetween,
 } from '@cloudscape-design/components';
-import { embedAnalyzesUrl } from 'apis/analytics';
+import { analysisEnable, embedAnalyzesUrl } from 'apis/analytics';
 import InfoLink from 'components/common/InfoLink';
 import Loading from 'components/common/Loading';
 import AnalyticsNavigation from 'components/layouts/AnalyticsNavigation';
@@ -69,9 +69,24 @@ const AnalyticsAnalyzes: React.FC = () => {
     setLoadingData(false);
   };
 
+  const checkProjectEnableAndLoadData = async (loadDataFunc: any) => {
+    setLoadingData(true);
+    try {
+      const { success, data }: ApiResponse<{ reportingEnabled: boolean }> =
+        await analysisEnable(defaultStr(projectId));
+      if (success && data?.reportingEnabled) {
+        loadDataFunc();
+      } else {
+        setLoadingData(false);
+      }
+    } catch (error) {
+      setLoadingData(false);
+    }
+  };
+
   useEffect(() => {
-    if (projectId) {
-      getAnalyzes();
+    if (projectId && appId) {
+      checkProjectEnableAndLoadData(getAnalyzes);
     }
   }, [projectId]);
 

--- a/frontend/src/pages/analytics/analyzes/AnalyticsAnalyzes.tsx
+++ b/frontend/src/pages/analytics/analyzes/AnalyticsAnalyzes.tsx
@@ -42,7 +42,7 @@ import { StateActionType, HelpPanelType } from 'context/reducer';
 import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import { defaultStr, pipelineAnalysisStudioEnable } from 'ts/utils';
+import { defaultStr } from 'ts/utils';
 import ExploreEmbedFrame from '../comps/ExploreEmbedFrame';
 
 const AnalyticsAnalyzes: React.FC = () => {
@@ -74,7 +74,7 @@ const AnalyticsAnalyzes: React.FC = () => {
     try {
       const { success, data }: ApiResponse<IPipeline> =
         await getPipelineDetailByProjectId(defaultStr(projectId));
-      if (success && pipelineAnalysisStudioEnable(data)) {
+      if (success && data.analysisStudioEnabled) {
         await getAnalyzes();
       }
       setLoadingData(false);

--- a/frontend/src/pages/analytics/analyzes/AnalyticsAnalyzes.tsx
+++ b/frontend/src/pages/analytics/analyzes/AnalyticsAnalyzes.tsx
@@ -69,7 +69,7 @@ const AnalyticsAnalyzes: React.FC = () => {
     setLoadingData(false);
   };
 
-  const checkProjectEnableAndLoadData = async (loadDataFunc: any) => {
+  const checkProjectEnableAndLoadData = async (loadDataFunc: ()=>void) => {
     setLoadingData(true);
     try {
       const { success, data }: ApiResponse<{ reportingEnabled: boolean }> =

--- a/frontend/src/pages/analytics/comps/ExploreEmbedFrame.tsx
+++ b/frontend/src/pages/analytics/comps/ExploreEmbedFrame.tsx
@@ -86,12 +86,16 @@ const ExploreEmbedFrame: React.FC<ExploreEmbedFrameProps> = (
             color="text-status-inactive"
           >
             <ExtendIcon icon="ClipboardData" color="#666" />
-            {embedType === 'dashboard' ||
-              (embedType === 'visual' && (
-                <SpaceBetween size="m">
-                  {t('analytics:emptyDataMessage')}
-                </SpaceBetween>
-              ))}
+            {embedType === 'visual' && (
+              <SpaceBetween size="m">
+                {t('analytics:emptyDataMessage')}
+              </SpaceBetween>
+            )}
+            {embedType === 'dashboard' && (
+              <SpaceBetween size="m">
+                {t('analytics:emptyDashboardMessage')}
+              </SpaceBetween>
+            )}
             {embedType === 'console' && (
               <SpaceBetween size="m">
                 {t('analytics:emptyAnalyzeMessage')}

--- a/frontend/src/pages/analytics/comps/ExploreEmbedFrame.tsx
+++ b/frontend/src/pages/analytics/comps/ExploreEmbedFrame.tsx
@@ -86,9 +86,17 @@ const ExploreEmbedFrame: React.FC<ExploreEmbedFrameProps> = (
             color="text-status-inactive"
           >
             <ExtendIcon icon="ClipboardData" color="#666" />
-            <SpaceBetween size="m">
-              {t('analytics:emptyDataMessage')}
-            </SpaceBetween>
+            {embedType === 'dashboard' ||
+              (embedType === 'visual' && (
+                <SpaceBetween size="m">
+                  {t('analytics:emptyDataMessage')}
+                </SpaceBetween>
+              ))}
+            {embedType === 'console' && (
+              <SpaceBetween size="m">
+                {t('analytics:emptyAnalyzeMessage')}
+              </SpaceBetween>
+            )}
           </Box>
         </div>
       )}

--- a/frontend/src/pages/analytics/dashboard/AnalyticsDashboard.tsx
+++ b/frontend/src/pages/analytics/dashboard/AnalyticsDashboard.tsx
@@ -124,7 +124,7 @@ const AnalyticsDashboardCard: React.FC<any> = () => {
     }
   };
 
-  const checkProjectEnableAndLoadData = async (loadDataFunc: any) => {
+  const checkProjectEnableAndLoadData = async (loadDataFunc: ()=>void) => {
     setLoadingData(true);
     try {
       const { success, data }: ApiResponse<{ reportingEnabled: boolean }> =

--- a/frontend/src/pages/analytics/dashboard/AnalyticsDashboard.tsx
+++ b/frontend/src/pages/analytics/dashboard/AnalyticsDashboard.tsx
@@ -17,7 +17,10 @@ import {
   Cards,
   Pagination,
 } from '@cloudscape-design/components';
-import { analysisEnable, getAnalyticsDashboardList } from 'apis/analytics';
+import {
+  getAnalyticsDashboardList,
+  getPipelineDetailByProjectId,
+} from 'apis/analytics';
 import AnalyticsNavigation from 'components/layouts/AnalyticsNavigation';
 import CustomBreadCrumb from 'components/layouts/CustomBreadCrumb';
 import HelpInfo from 'components/layouts/HelpInfo';
@@ -29,7 +32,7 @@ import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router-dom';
 import { TIME_FORMAT } from 'ts/const';
 import { DEFAULT_DASHBOARD_NAME } from 'ts/constant-ln';
-import { defaultStr } from 'ts/utils';
+import { defaultStr, pipelineAnalysisStudioEnable } from 'ts/utils';
 import CreateDashboard from './create/CreateDashboard';
 import DashboardHeader from '../comps/DashboardHeader';
 
@@ -124,24 +127,24 @@ const AnalyticsDashboardCard: React.FC<any> = () => {
     }
   };
 
-  const checkProjectEnableAndLoadData = async (loadDataFunc: () => void) => {
+  const loadPipeline = async () => {
     setLoadingData(true);
     try {
-      const { success, data }: ApiResponse<{ reportingEnabled: boolean }> =
-        await analysisEnable(defaultStr(projectId));
-      if (success && data?.reportingEnabled) {
-        loadDataFunc();
-      } else {
-        setLoadingData(false);
+      const { success, data }: ApiResponse<IPipeline> =
+        await getPipelineDetailByProjectId(defaultStr(projectId));
+      if (success && pipelineAnalysisStudioEnable(data)) {
+        await listAnalyticsDashboards();
       }
+      setLoadingData(false);
     } catch (error) {
       setLoadingData(false);
+      console.log(error);
     }
   };
 
   useEffect(() => {
     if (projectId && appId) {
-      checkProjectEnableAndLoadData(listAnalyticsDashboards);
+      loadPipeline();
     }
   }, [currentPage]);
 

--- a/frontend/src/pages/analytics/dashboard/AnalyticsDashboard.tsx
+++ b/frontend/src/pages/analytics/dashboard/AnalyticsDashboard.tsx
@@ -17,7 +17,7 @@ import {
   Cards,
   Pagination,
 } from '@cloudscape-design/components';
-import { getAnalyticsDashboardList } from 'apis/analytics';
+import { analysisEnable, getAnalyticsDashboardList } from 'apis/analytics';
 import AnalyticsNavigation from 'components/layouts/AnalyticsNavigation';
 import CustomBreadCrumb from 'components/layouts/CustomBreadCrumb';
 import HelpInfo from 'components/layouts/HelpInfo';
@@ -116,6 +116,22 @@ const AnalyticsDashboardCard: React.FC<any> = () => {
       if (success) {
         setAnalyticsDashboardList(data.items);
         setTotalCount(data.totalCount);
+      }
+      setLoadingData(false);
+    } catch (error) {
+      setLoadingData(false);
+      console.log(error);
+    }
+  };
+
+  const checkProjectEnableAndLoadData = async (loadDataFunc: any) => {
+    setLoadingData(true);
+    try {
+      const { success, data }: ApiResponse<{ reportingEnabled: boolean }> =
+        await analysisEnable(defaultStr(projectId));
+      if (success && data?.reportingEnabled) {
+        loadDataFunc();
+      } else {
         setLoadingData(false);
       }
     } catch (error) {
@@ -125,7 +141,7 @@ const AnalyticsDashboardCard: React.FC<any> = () => {
 
   useEffect(() => {
     if (projectId && appId) {
-      listAnalyticsDashboards();
+      checkProjectEnableAndLoadData(listAnalyticsDashboards);
     }
   }, [currentPage]);
 

--- a/frontend/src/pages/analytics/dashboard/AnalyticsDashboard.tsx
+++ b/frontend/src/pages/analytics/dashboard/AnalyticsDashboard.tsx
@@ -32,7 +32,7 @@ import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router-dom';
 import { TIME_FORMAT } from 'ts/const';
 import { DEFAULT_DASHBOARD_NAME } from 'ts/constant-ln';
-import { defaultStr, pipelineAnalysisStudioEnable } from 'ts/utils';
+import { defaultStr } from 'ts/utils';
 import CreateDashboard from './create/CreateDashboard';
 import DashboardHeader from '../comps/DashboardHeader';
 
@@ -132,7 +132,7 @@ const AnalyticsDashboardCard: React.FC<any> = () => {
     try {
       const { success, data }: ApiResponse<IPipeline> =
         await getPipelineDetailByProjectId(defaultStr(projectId));
-      if (success && pipelineAnalysisStudioEnable(data)) {
+      if (success && data.analysisStudioEnabled) {
         await listAnalyticsDashboards();
       }
       setLoadingData(false);

--- a/frontend/src/pages/analytics/dashboard/AnalyticsDashboard.tsx
+++ b/frontend/src/pages/analytics/dashboard/AnalyticsDashboard.tsx
@@ -124,7 +124,7 @@ const AnalyticsDashboardCard: React.FC<any> = () => {
     }
   };
 
-  const checkProjectEnableAndLoadData = async (loadDataFunc: ()=>void) => {
+  const checkProjectEnableAndLoadData = async (loadDataFunc: () => void) => {
     setLoadingData(true);
     try {
       const { success, data }: ApiResponse<{ reportingEnabled: boolean }> =

--- a/frontend/src/pages/analytics/explore/AnalyticsExplore.tsx
+++ b/frontend/src/pages/analytics/explore/AnalyticsExplore.tsx
@@ -41,7 +41,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { MetadataParameterType, MetadataSource } from 'ts/explore-types';
-import { defaultStr, pipelineAnalysisStudioEnable } from 'ts/utils';
+import { defaultStr } from 'ts/utils';
 import {
   metadataEventsConvertToCategoryItemType,
   parametersConvertToCategoryItemType,
@@ -255,7 +255,7 @@ const AnalyticsExplore: React.FC = () => {
     try {
       const { success, data }: ApiResponse<IPipeline> =
         await getPipelineDetailByProjectId(defaultStr(projectId));
-      if (success && pipelineAnalysisStudioEnable(data)) {
+      if (success && data.analysisStudioEnabled) {
         setPipeline(data);
         // async to call warm and clean
         warnAndClean(

--- a/frontend/src/pages/analytics/explore/AnalyticsExplore.tsx
+++ b/frontend/src/pages/analytics/explore/AnalyticsExplore.tsx
@@ -272,7 +272,7 @@ const AnalyticsExplore: React.FC = () => {
     }
   };
 
-  const checkProjectEnableAndLoadData = async (loadDataFunc: any) => {
+  const checkProjectEnableAndLoadData = async (loadDataFunc: () => void) => {
     setLoadingData(true);
     try {
       const { success, data }: ApiResponse<{ reportingEnabled: boolean }> =
@@ -298,7 +298,6 @@ const AnalyticsExplore: React.FC = () => {
       getAllPathNodes();
     }
   }, [selectedOption]);
-  console.log('pipeline', loadingData);
 
   return (
     <div className="flex">

--- a/frontend/src/pages/analytics/explore/AnalyticsExplore.tsx
+++ b/frontend/src/pages/analytics/explore/AnalyticsExplore.tsx
@@ -29,7 +29,6 @@ import {
   warmup,
   clean,
   getPathNodes,
-  analysisEnable,
 } from 'apis/analytics';
 import Loading from 'components/common/Loading';
 import { CategoryItemType } from 'components/eventselect/AnalyticsType';
@@ -42,7 +41,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { MetadataParameterType, MetadataSource } from 'ts/explore-types';
-import { defaultStr } from 'ts/utils';
+import { defaultStr, pipelineAnalysisStudioEnable } from 'ts/utils';
 import {
   metadataEventsConvertToCategoryItemType,
   parametersConvertToCategoryItemType,
@@ -252,10 +251,11 @@ const AnalyticsExplore: React.FC = () => {
   };
 
   const loadPipeline = async () => {
+    setLoadingData(true);
     try {
       const { success, data }: ApiResponse<IPipeline> =
         await getPipelineDetailByProjectId(defaultStr(projectId));
-      if (success) {
+      if (success && pipelineAnalysisStudioEnable(data)) {
         setPipeline(data);
         // async to call warm and clean
         warnAndClean(
@@ -272,24 +272,9 @@ const AnalyticsExplore: React.FC = () => {
     }
   };
 
-  const checkProjectEnableAndLoadData = async (loadDataFunc: () => void) => {
-    setLoadingData(true);
-    try {
-      const { success, data }: ApiResponse<{ reportingEnabled: boolean }> =
-        await analysisEnable(defaultStr(projectId));
-      if (success && data?.reportingEnabled) {
-        loadDataFunc();
-      } else {
-        setLoadingData(false);
-      }
-    } catch (error) {
-      setLoadingData(false);
-    }
-  };
-
   useEffect(() => {
     if (projectId && appId) {
-      checkProjectEnableAndLoadData(loadPipeline);
+      loadPipeline();
     }
   }, [projectId, appId]);
 

--- a/frontend/src/pages/analytics/metadata/table/MetadataTable.tsx
+++ b/frontend/src/pages/analytics/metadata/table/MetadataTable.tsx
@@ -17,6 +17,7 @@ import Pagination from '@cloudscape-design/components/pagination';
 import PropertyFilter from '@cloudscape-design/components/property-filter';
 import Table from '@cloudscape-design/components/table';
 
+import { analysisEnable } from 'apis/analytics';
 import { HelpPanelType } from 'context/reducer';
 import { cloneDeep } from 'lodash';
 import {
@@ -25,6 +26,8 @@ import {
 } from 'pages/common/common-components';
 import { useColumnWidths } from 'pages/common/use-column-widths';
 import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { defaultStr } from 'ts/utils';
 import { MetadataTableHeader } from './MetadataTableHeader';
 import '../../styles/table-select.scss';
 import { descriptionRegex, displayNameRegex } from './table-config';
@@ -73,6 +76,7 @@ const MetadataTable: React.FC<MetadataTableProps> = (
     fetchUpdateFunc,
   } = props;
 
+  const { projectId, appId } = useParams();
   const [loadingData, setLoadingData] = useState(false);
   const [data, setData] = useState<any[]>([]);
   const [itemsSnap, setItemsSnap] = useState<any[]>([]);
@@ -98,8 +102,25 @@ const MetadataTable: React.FC<MetadataTableProps> = (
     }
   };
 
+  const checkProjectEnableAndLoadData = async (loadDataFunc: any) => {
+    setLoadingData(true);
+    try {
+      const { success, data }: ApiResponse<{ reportingEnabled: boolean }> =
+        await analysisEnable(defaultStr(projectId));
+      if (success && data?.reportingEnabled) {
+        loadDataFunc();
+      } else {
+        setLoadingData(false);
+      }
+    } catch (error) {
+      setLoadingData(false);
+    }
+  };
+
   useEffect(() => {
-    fetchData();
+    if (projectId && appId) {
+      checkProjectEnableAndLoadData(fetchData);
+    }
   }, []);
 
   const {

--- a/frontend/src/pages/analytics/metadata/table/MetadataTable.tsx
+++ b/frontend/src/pages/analytics/metadata/table/MetadataTable.tsx
@@ -27,7 +27,7 @@ import {
 import { useColumnWidths } from 'pages/common/use-column-widths';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { defaultStr, pipelineAnalysisStudioEnable } from 'ts/utils';
+import { defaultStr } from 'ts/utils';
 import { MetadataTableHeader } from './MetadataTableHeader';
 import '../../styles/table-select.scss';
 import { descriptionRegex, displayNameRegex } from './table-config';
@@ -107,7 +107,7 @@ const MetadataTable: React.FC<MetadataTableProps> = (
     try {
       const { success, data }: ApiResponse<IPipeline> =
         await getPipelineDetailByProjectId(defaultStr(projectId));
-      if (success && pipelineAnalysisStudioEnable(data)) {
+      if (success && data.analysisStudioEnabled) {
         await fetchData();
       }
       setLoadingData(false);

--- a/frontend/src/pages/analytics/metadata/table/MetadataTable.tsx
+++ b/frontend/src/pages/analytics/metadata/table/MetadataTable.tsx
@@ -17,7 +17,7 @@ import Pagination from '@cloudscape-design/components/pagination';
 import PropertyFilter from '@cloudscape-design/components/property-filter';
 import Table from '@cloudscape-design/components/table';
 
-import { analysisEnable } from 'apis/analytics';
+import { getPipelineDetailByProjectId } from 'apis/analytics';
 import { HelpPanelType } from 'context/reducer';
 import { cloneDeep } from 'lodash';
 import {
@@ -27,7 +27,7 @@ import {
 import { useColumnWidths } from 'pages/common/use-column-widths';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { defaultStr } from 'ts/utils';
+import { defaultStr, pipelineAnalysisStudioEnable } from 'ts/utils';
 import { MetadataTableHeader } from './MetadataTableHeader';
 import '../../styles/table-select.scss';
 import { descriptionRegex, displayNameRegex } from './table-config';
@@ -102,24 +102,24 @@ const MetadataTable: React.FC<MetadataTableProps> = (
     }
   };
 
-  const checkProjectEnableAndLoadData = async (loadDataFunc: () => void) => {
+  const loadPipeline = async () => {
     setLoadingData(true);
     try {
-      const { success, data }: ApiResponse<{ reportingEnabled: boolean }> =
-        await analysisEnable(defaultStr(projectId));
-      if (success && data?.reportingEnabled) {
-        loadDataFunc();
-      } else {
-        setLoadingData(false);
+      const { success, data }: ApiResponse<IPipeline> =
+        await getPipelineDetailByProjectId(defaultStr(projectId));
+      if (success && pipelineAnalysisStudioEnable(data)) {
+        await fetchData();
       }
+      setLoadingData(false);
     } catch (error) {
       setLoadingData(false);
+      console.log(error);
     }
   };
 
   useEffect(() => {
     if (projectId && appId) {
-      checkProjectEnableAndLoadData(fetchData);
+      loadPipeline();
     }
   }, []);
 

--- a/frontend/src/pages/analytics/metadata/table/MetadataTable.tsx
+++ b/frontend/src/pages/analytics/metadata/table/MetadataTable.tsx
@@ -102,7 +102,7 @@ const MetadataTable: React.FC<MetadataTableProps> = (
     }
   };
 
-  const checkProjectEnableAndLoadData = async (loadDataFunc: any) => {
+  const checkProjectEnableAndLoadData = async (loadDataFunc: () => void) => {
     setLoadingData(true);
     try {
       const { success, data }: ApiResponse<{ reportingEnabled: boolean }> =

--- a/frontend/src/ts/utils.ts
+++ b/frontend/src/ts/utils.ts
@@ -15,6 +15,10 @@ import {
   DateRangePickerProps,
   SelectProps,
 } from '@cloudscape-design/components';
+import {
+  AnalyticsProjectAppStatus,
+  IProjectSelectItem,
+} from 'components/eventselect/AnalyticsType';
 import { isEqual } from 'lodash';
 import moment from 'moment';
 import { getLngFromLocalStorage } from 'pages/analytics/analytics-utils';
@@ -448,4 +452,41 @@ export const isAnalystAuthorRole = (roles: IUserRole[] | undefined) => {
   return roles.some(
     (role) => role === IUserRole.ANALYST || role === IUserRole.ADMIN
   );
+};
+
+export const getProjectAppFromOptions = (
+  projectId: string,
+  appId: string,
+  projectOptions: SelectProps.Options
+) => {
+  const projectGroupOptions = projectOptions as SelectProps.OptionGroup[];
+  for (const projectOption of projectGroupOptions) {
+    const appOptions = projectOption.options as IProjectSelectItem[];
+    for (const appOption of appOptions) {
+      if (appOption.projectId === projectId && appOption.appId === appId) {
+        return {
+          ...appOption,
+          disabled: projectOption.disabled,
+        };
+      }
+    }
+  }
+};
+
+export const getProjectAppStatusFromOptions = (
+  projectId: string,
+  appId: string,
+  projectOptions: SelectProps.Options
+) => {
+  const option = getProjectAppFromOptions(
+    projectId,
+    appId,
+    projectOptions
+  ) as IProjectSelectItem;
+  if (!option) {
+    return AnalyticsProjectAppStatus.NoExist;
+  } else if (option.disabled) {
+    return AnalyticsProjectAppStatus.Disabled;
+  }
+  return AnalyticsProjectAppStatus.Enable;
 };

--- a/frontend/src/ts/utils.ts
+++ b/frontend/src/ts/utils.ts
@@ -15,10 +15,7 @@ import {
   DateRangePickerProps,
   SelectProps,
 } from '@cloudscape-design/components';
-import {
-  AnalyticsProjectAppStatus,
-  IProjectSelectItem,
-} from 'components/eventselect/AnalyticsType';
+import { IProjectSelectItem } from 'components/eventselect/AnalyticsType';
 import { isEqual } from 'lodash';
 import moment from 'moment';
 import { getLngFromLocalStorage } from 'pages/analytics/analytics-utils';
@@ -457,9 +454,8 @@ export const isAnalystAuthorRole = (roles: IUserRole[] | undefined) => {
 export const getProjectAppFromOptions = (
   projectId: string,
   appId: string,
-  projectOptions: SelectProps.Options
+  projectGroupOptions: SelectProps.OptionGroup[]
 ) => {
-  const projectGroupOptions = projectOptions as SelectProps.OptionGroup[];
   for (const projectOption of projectGroupOptions) {
     const appOptions = projectOption.options as IProjectSelectItem[];
     for (const appOption of appOptions) {
@@ -471,22 +467,4 @@ export const getProjectAppFromOptions = (
       }
     }
   }
-};
-
-export const getProjectAppStatusFromOptions = (
-  projectId: string,
-  appId: string,
-  projectOptions: SelectProps.Options
-) => {
-  const option = getProjectAppFromOptions(
-    projectId,
-    appId,
-    projectOptions
-  ) as IProjectSelectItem;
-  if (!option) {
-    return AnalyticsProjectAppStatus.NoExist;
-  } else if (option.disabled) {
-    return AnalyticsProjectAppStatus.Disabled;
-  }
-  return AnalyticsProjectAppStatus.Enable;
 };

--- a/frontend/src/ts/utils.ts
+++ b/frontend/src/ts/utils.ts
@@ -468,3 +468,13 @@ export const getProjectAppFromOptions = (
     }
   }
 };
+
+export const pipelineAnalysisStudioEnable = (pipeline: IPipeline) => {
+  if (
+    pipeline?.reporting?.quickSight?.accountName &&
+    !pipeline?.templateVersion?.startsWith('v1.0')
+  ) {
+    return true;
+  }
+  return false;
+};

--- a/frontend/src/ts/utils.ts
+++ b/frontend/src/ts/utils.ts
@@ -468,13 +468,3 @@ export const getProjectAppFromOptions = (
     }
   }
 };
-
-export const pipelineAnalysisStudioEnable = (pipeline: IPipeline) => {
-  if (
-    pipeline?.reporting?.quickSight?.accountName &&
-    !pipeline?.templateVersion?.startsWith('v1.0')
-  ) {
-    return true;
-  }
-  return false;
-};

--- a/frontend/src/types/pipeline.d.ts
+++ b/frontend/src/types/pipeline.d.ts
@@ -170,6 +170,7 @@ declare global {
       pipelineVersion: string;
       solutionVersion: string;
     };
+    analysisStudioEnabled?: boolean;
     version?: string;
     versionTag?: string;
     createAt?: number;

--- a/frontend/src/types/project.d.ts
+++ b/frontend/src/types/project.d.ts
@@ -28,6 +28,7 @@ declare global {
     region: string;
     description: string;
     pipelineId?: string;
+    pipelineVersion?: string;
     applications?: IApplication[];
     reportingEnabled?: boolean;
     updateAt?: number;
@@ -36,7 +37,6 @@ declare global {
     createAt?: number;
     type?: string;
     status?: string;
-    pipelineId?: string;
   }
 
   interface IAlarmPromiseResult {

--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -905,6 +905,16 @@ function getAppRegistryApplicationArn(pipeline: IPipeline): string {
     getValueFromStackOutputSuffix(pipeline, PipelineStackType.APP_REGISTRY, OUTPUT_SERVICE_CATALOG_APPREGISTRY_APPLICATION_ARN) : '';
 }
 
+function pipelineAnalysisStudioEnabled(pipeline: IPipeline): boolean {
+  if (
+    pipeline?.reporting?.quickSight?.accountName &&
+    !pipeline?.templateVersion?.startsWith('v1.0')
+  ) {
+    return true;
+  }
+  return false;
+};
+
 export {
   isEmpty,
   isEmail,
@@ -946,4 +956,5 @@ export {
   getVersionFromTags,
   getAppRegistryApplicationArn,
   deserializeContext,
+  pipelineAnalysisStudioEnabled,
 };

--- a/src/control-plane/backend/lambda/api/model/project.ts
+++ b/src/control-plane/backend/lambda/api/model/project.ts
@@ -25,6 +25,7 @@ export interface IProject {
   readonly region: string;
   readonly environment: ProjectEnvironment | string;
   pipelineId: string;
+  pipelineVersion: string;
   applications: IApplication[];
   reportingEnabled: boolean;
   readonly status: string;

--- a/src/control-plane/backend/lambda/api/router/reporting.ts
+++ b/src/control-plane/backend/lambda/api/router/reporting.ts
@@ -89,6 +89,12 @@ reporting_project.post(
     return reportingServ.cleanQuickSightResources(req, res, next);
   });
 
+reporting_project.get(
+  '/enable',
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return reportingServ.enable(req, res, next);
+  });
+
 
 export {
   reporting_project,

--- a/src/control-plane/backend/lambda/api/router/reporting.ts
+++ b/src/control-plane/backend/lambda/api/router/reporting.ts
@@ -89,13 +89,6 @@ reporting_project.post(
     return reportingServ.cleanQuickSightResources(req, res, next);
   });
 
-reporting_project.get(
-  '/enable',
-  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
-    return reportingServ.enable(req, res, next);
-  });
-
-
 export {
   reporting_project,
 };

--- a/src/control-plane/backend/lambda/api/service/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/service/pipeline.ts
@@ -15,7 +15,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { StackManager } from './stack';
 import { OUTPUT_INGESTION_SERVER_DNS_SUFFIX, OUTPUT_INGESTION_SERVER_URL_SUFFIX, OUTPUT_METRICS_OBSERVABILITY_DASHBOARD_NAME, OUTPUT_REPORT_DASHBOARDS_SUFFIX } from '../common/constants-ln';
 import { ApiFail, ApiSuccess, PipelineStackType, PipelineStatusType } from '../common/types';
-import { getStackOutputFromPipelineStatus, getReportingDashboardsUrl, paginateData } from '../common/utils';
+import { getStackOutputFromPipelineStatus, getReportingDashboardsUrl, paginateData, pipelineAnalysisStudioEnabled } from '../common/utils';
 import { IPipeline, CPipeline } from '../model/pipeline';
 import { ClickStreamStore } from '../store/click-stream-store';
 import { DynamoDbStore } from '../store/dynamodb/dynamodb-store';
@@ -98,6 +98,7 @@ export class PipelineServ {
           metricsDashboardName: getStackOutputFromPipelineStatus(
             latestPipeline.status, PipelineStackType.METRICS, OUTPUT_METRICS_OBSERVABILITY_DASHBOARD_NAME),
           templateInfo,
+          analysisStudioEnabled: pipelineAnalysisStudioEnabled(latestPipeline),
         }));
       }
       return res.json(new ApiSuccess({
@@ -107,6 +108,7 @@ export class PipelineServ {
         dashboards: null,
         metricsDashboardName: null,
         templateInfo: null,
+        analysisStudioEnabled: pipelineAnalysisStudioEnabled(latestPipeline),
       }));
     } catch (error) {
       next(error);

--- a/src/control-plane/backend/lambda/api/service/project.ts
+++ b/src/control-plane/backend/lambda/api/service/project.ts
@@ -106,6 +106,7 @@ export class ProjectServ {
       if (isEmpty(defaultDataSourceArn)) {
         return res.status(400).json(new ApiFail('Default data source ARN and owner principal is required.'));
       }
+      req.body.region = latestPipeline.region;
       const dashboard: IDashboard = req.body;
       if (dashboard.sheets.length === 0) {
         return res.status(400).json(new ApiFail('Dashboard sheets is required.'));
@@ -219,9 +220,11 @@ export class ProjectServ {
         const pipeline = pipelines.find((item: IPipeline) => item.projectId === project.id);
         if (pipeline) {
           project.pipelineId = pipeline.pipelineId;
+          project.pipelineVersion = pipeline.templateVersion ?? '';
           project.reportingEnabled = !isEmpty(pipeline.reporting?.quickSight?.accountName);
         } else {
           project.pipelineId = '';
+          project.pipelineVersion = '';
           project.reportingEnabled = false;
         }
         const projectApps = apps.filter((item: IApplication) => item.projectId === project.id);

--- a/src/control-plane/backend/lambda/api/service/reporting.ts
+++ b/src/control-plane/backend/lambda/api/service/reporting.ts
@@ -48,11 +48,10 @@ import {
 } from './quicksight/reporting-utils';
 import { buildEventAnalysisView, buildEventPathAnalysisView, buildFunnelTableView, buildFunnelView, buildNodePathAnalysisView, buildRetentionAnalysisView } from './quicksight/sql-builder';
 import { awsAccountId } from '../common/constants';
-import { OUTPUT_DATA_MODELING_REDSHIFT_DATA_API_ROLE_ARN_SUFFIX, OUTPUT_DATA_MODELING_REDSHIFT_SERVERLESS_WORKGROUP_NAME, PROJECT_ID_PATTERN, QUICKSIGHT_TEMP_RESOURCE_NAME_PREFIX } from '../common/constants-ln';
+import { OUTPUT_DATA_MODELING_REDSHIFT_DATA_API_ROLE_ARN_SUFFIX, OUTPUT_DATA_MODELING_REDSHIFT_SERVERLESS_WORKGROUP_NAME, QUICKSIGHT_TEMP_RESOURCE_NAME_PREFIX } from '../common/constants-ln';
 import { ExploreLocales, AnalysisType, ExplorePathNodeType, ExploreRequestAction, ExploreTimeScopeType, ExploreVisualName, QuickSightChartType } from '../common/explore-types';
 import { logger } from '../common/powertools';
 import { SDKClient } from '../common/sdk-client';
-import { validatePattern } from '../common/stack-params-valid';
 import { ApiFail, ApiSuccess, PipelineStackType } from '../common/types';
 import { getStackOutputFromPipelineStatus } from '../common/utils';
 import { QuickSightUserArns, generateEmbedUrlForRegisteredUser, getClickstreamUserArn, waitDashboardSuccess } from '../store/aws/quicksight';
@@ -954,24 +953,6 @@ export class ReportingService {
       if ( error instanceof ThrottlingException) {
         return res.status(201).json(new ApiSuccess(null, 'resource cleaning finished with error'));
       }
-      next(error);
-    }
-  };
-
-  async enable(req: any, res: any, next: any) {
-    try {
-      const { projectId } = req.query;
-      validatePattern('ProjectId', PROJECT_ID_PATTERN, projectId);
-      const latestPipelines = await store.listPipeline(projectId, 'latest', 'asc');
-      if (latestPipelines.length === 0) {
-        return res.status(200).json(new ApiSuccess({ reportingEnabled: false }));
-      }
-      const latestPipeline = latestPipelines[0];
-      if (latestPipeline.reporting?.quickSight?.accountName && !latestPipeline.templateVersion?.startsWith('v1.0')) {
-        return res.status(200).json(new ApiSuccess({ reportingEnabled: true }));
-      }
-      return res.status(200).json(new ApiSuccess({ reportingEnabled: false }));
-    } catch (error) {
       next(error);
     }
   };

--- a/src/control-plane/backend/lambda/api/service/reporting.ts
+++ b/src/control-plane/backend/lambda/api/service/reporting.ts
@@ -963,6 +963,7 @@ export class ReportingService {
       const { projectId } = req.query;
       validatePattern('ProjectId', PROJECT_ID_PATTERN, projectId);
       const latestPipelines = await store.listPipeline(projectId, 'latest', 'asc');
+      console.log(latestPipelines);
       if (latestPipelines.length === 0) {
         return res.status(200).json(new ApiSuccess({ reportingEnabled: false }));
       }

--- a/src/control-plane/backend/lambda/api/service/reporting.ts
+++ b/src/control-plane/backend/lambda/api/service/reporting.ts
@@ -963,7 +963,6 @@ export class ReportingService {
       const { projectId } = req.query;
       validatePattern('ProjectId', PROJECT_ID_PATTERN, projectId);
       const latestPipelines = await store.listPipeline(projectId, 'latest', 'asc');
-      console.log(latestPipelines);
       if (latestPipelines.length === 0) {
         return res.status(200).json(new ApiSuccess({ reportingEnabled: false }));
       }

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -1326,6 +1326,7 @@ describe('Pipeline test', () => {
           solutionVersion: FULL_SOLUTION_VERSION,
         },
         metricsDashboardName: 'clickstream_dashboard_notepad_mtzfsocy',
+        analysisStudioEnabled: false,
       },
     });
   });
@@ -1348,13 +1349,22 @@ describe('Pipeline test', () => {
         dashboards: null,
         metricsDashboardName: null,
         templateInfo: null,
+        analysisStudioEnabled: false,
       },
     });
   });
   it('Get pipeline by ID with stack no outputs', async () => {
     projectExistedMock(ddbMock, true);
     ddbMock.on(QueryCommand).resolves({
-      Items: [{ ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW }],
+      Items: [{
+        ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW,
+        templateVersion: 'v1.1.0',
+        reporting: {
+          quickSight: {
+            accountName: 'clickstream-acc-xxx',
+          },
+        },
+      }],
     });
     cloudFormationMock.on(DescribeStacksCommand).resolves({
       Stacks: [
@@ -1405,6 +1415,7 @@ describe('Pipeline test', () => {
         ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW,
         status: {
           ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW.status,
+          status: 'Warning',
           stackDetails: [
             { ...BASE_STATUS.stackDetails[0] },
             { ...BASE_STATUS.stackDetails[1] },
@@ -1482,15 +1493,22 @@ describe('Pipeline test', () => {
             updateAt: 1667355960000,
           },
         },
+        reporting: {
+          quickSight: {
+            accountName: 'clickstream-acc-xxx',
+          },
+        },
         dns: '',
         endpoint: '',
         dashboards: [],
         metricsDashboardName: '',
         templateInfo: {
           isLatest: false,
-          pipelineVersion: MOCK_SOLUTION_VERSION,
+          pipelineVersion: 'v1.1.0',
           solutionVersion: FULL_SOLUTION_VERSION,
         },
+        templateVersion: 'v1.1.0',
+        analysisStudioEnabled: true,
       },
     });
   });
@@ -1581,6 +1599,7 @@ describe('Pipeline test', () => {
           pipelineVersion: MOCK_SOLUTION_VERSION,
           solutionVersion: FULL_SOLUTION_VERSION,
         },
+        analysisStudioEnabled: false,
       },
     });
   });

--- a/src/control-plane/backend/lambda/api/test/api/project.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/project.test.ts
@@ -274,11 +274,11 @@ describe('Project test', () => {
       message: '',
       data: {
         items: [
-          { name: 'Project-01', pipelineId: 'pipeline-01', reportingEnabled: false, applications: [{ name: 'App-01', projectId: '1' }], id: '1' },
-          { name: 'Project-02', pipelineId: 'pipeline-02', reportingEnabled: false, applications: [{ name: 'App-02', projectId: '2' }], id: '2' },
-          { name: 'Project-03', pipelineId: 'pipeline-03', reportingEnabled: false, applications: [{ name: 'App-03', projectId: '3' }], id: '3' },
-          { name: 'Project-04', pipelineId: 'pipeline-04', reportingEnabled: false, applications: [{ name: 'App-04', projectId: '4' }], id: '4' },
-          { name: 'Project-05', pipelineId: 'pipeline-05', reportingEnabled: false, applications: [{ name: 'App-05', projectId: '5' }], id: '5' },
+          { name: 'Project-01', pipelineId: 'pipeline-01', pipelineVersion: '', reportingEnabled: false, applications: [{ name: 'App-01', projectId: '1' }], id: '1' },
+          { name: 'Project-02', pipelineId: 'pipeline-02', pipelineVersion: '', reportingEnabled: false, applications: [{ name: 'App-02', projectId: '2' }], id: '2' },
+          { name: 'Project-03', pipelineId: 'pipeline-03', pipelineVersion: '', reportingEnabled: false, applications: [{ name: 'App-03', projectId: '3' }], id: '3' },
+          { name: 'Project-04', pipelineId: 'pipeline-04', pipelineVersion: '', reportingEnabled: false, applications: [{ name: 'App-04', projectId: '4' }], id: '4' },
+          { name: 'Project-05', pipelineId: 'pipeline-05', pipelineVersion: '', reportingEnabled: false, applications: [{ name: 'App-05', projectId: '5' }], id: '5' },
         ],
         totalCount: 5,
       },
@@ -340,8 +340,8 @@ describe('Project test', () => {
       message: '',
       data: {
         items: [
-          { name: 'Project-03', pipelineId: 'pipeline-03', reportingEnabled: false, applications: [{ name: 'App-03', projectId: '3' }], id: '3' },
-          { name: 'Project-04', pipelineId: 'pipeline-04', reportingEnabled: true, applications: [{ name: 'App-04', projectId: '4' }], id: '4' },
+          { name: 'Project-03', pipelineId: 'pipeline-03', pipelineVersion: '', reportingEnabled: false, applications: [{ name: 'App-03', projectId: '3' }], id: '3' },
+          { name: 'Project-04', pipelineId: 'pipeline-04', pipelineVersion: '', reportingEnabled: true, applications: [{ name: 'App-04', projectId: '4' }], id: '4' },
         ],
         totalCount: 5,
       },


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. Access Analytics Studio when no pipeline in solution 
<img width="1425" alt="截屏2023-12-01 18 49 45" src="https://github.com/awslabs/clickstream-analytics-on-aws/assets/18416040/2f0c1200-ef16-470d-8db0-5cb0e557ff63">

2. Access Analytics Studio when pipeline version is `v1.0.x` 
<img width="1427" alt="截屏2023-12-01 18 50 53" src="https://github.com/awslabs/clickstream-analytics-on-aws/assets/18416040/1ae99df3-0120-4655-992f-02a1354b17be">

3. Access Analytics Studio when project or app no exist
<img width="1427" alt="截屏2023-12-01 18 51 53" src="https://github.com/awslabs/clickstream-analytics-on-aws/assets/18416040/b3ce651b-e4db-4f12-9709-fa991e06c989">



## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend