### PR TITLE
fix: add integrate flutter SDK guide in application detail page

### DIFF
--- a/frontend/public/locales/en-US/application.json
+++ b/frontend/public/locales/en-US/application.json
@@ -47,7 +47,8 @@
     "iosInitSDKDesc": "Once you have configured the parameters, you need to initialize it in the AppDelegate application() method to use the SDK.",
     "webInstallSDK": "1. Install Clickstream SDK",
     "webInstallSDKDesc": "Please use npm or a module bundler to install the Clickstream SDK.",
-    "webSDKSetupDesc": "Add the initialize code to your app's root entry point, for example index.js/app.tsx in React or main.ts in Vue/Angular."
+    "webSDKSetupDesc": "Add the initialize code to your app's root entry point, for example index.js/app.tsx in React or main.ts in Vue/Angular.",
+    "flutterSDKSetupDesc": "Copy your configuration code from your clickstream solution web console, the configuration code should look like as follows. You can also manually add this code snippet and replace the values of appId and endpoint after you registered app to a data pipeline in the Clickstream Analytics solution console."
   },
   "detail": {
     "basicInfo": "Basic Information",
@@ -55,6 +56,7 @@
     "android": "Android",
     "ios": "iOS",
     "web": "Web",
+    "flutter": "Flutter",
     "pipelineInfo": "Pipeline Information",
     "serverEdp": "Server Endpoint",
     "serverDomain": "Server Domain"

--- a/frontend/public/locales/zh-CN/application.json
+++ b/frontend/public/locales/zh-CN/application.json
@@ -47,7 +47,8 @@
     "iosInitSDKDesc": "配置参数后，需要在 AppDelegate 应用程序 () 方法中对其进行初始化才能使用 SDK。",
     "webInstallSDK": "1. 安装 Clickstream SDK",
     "webInstallSDKDesc": "请使用 npm 或 yarn 等包管理器来安装 Clickstream SDK。",
-    "webSDKSetupDesc": "将初始化代码添加到您的应用的入口文件，例如 React 中的 index.js/app.tsx 或 Vue/Angular 中的 main.ts。"
+    "webSDKSetupDesc": "将初始化代码添加到您的应用的入口文件，例如 React 中的 index.js/app.tsx 或 Vue/Angular 中的 main.ts。",
+    "flutterSDKSetupDesc": "从 Clickstream Analytics 解决方案 Web 控制台复制配置代码，配置代码应如下所示。 在 Clickstream Analytics 解决方案控制台中将应用程序注册到数据管道后，您可以手动添加此代码段并替换 appId 和 endpoint 的值。"
   },
   "detail": {
     "basicInfo": "基本信息",
@@ -55,6 +56,7 @@
     "android": "Android",
     "ios": "iOS",
     "web": "Web",
+    "flutter": "Flutter",
     "pipelineInfo": "数据管道信息",
     "serverEdp": "服务器端点",
     "serverDomain": "服务器域"

--- a/frontend/src/pages/application/create/comp/RegisterApp.tsx
+++ b/frontend/src/pages/application/create/comp/RegisterApp.tsx
@@ -295,7 +295,7 @@ const RegisterApp: React.FC = () => {
               },
               {
                 label: t('application:detail.flutter'),
-                id: 'web',
+                id: 'flutter',
                 content: (
                   <div className="pd-20">
                     <ConfigFlutterSDK appInfo={application} />

--- a/frontend/src/pages/application/create/comp/RegisterApp.tsx
+++ b/frontend/src/pages/application/create/comp/RegisterApp.tsx
@@ -25,6 +25,7 @@ import {
 } from '@cloudscape-design/components';
 import { createApplication, getApplicationDetail } from 'apis/application';
 import ConfigAndroidSDK from 'pages/application/detail/comp/ConfigAndroidSDK';
+import ConfigFlutterSDK from 'pages/application/detail/comp/ConfigFlutterSDK';
 import ConfigIOSSDK from 'pages/application/detail/comp/ConfigIOSSDK';
 import ConfigWebSDK from 'pages/application/detail/comp/ConfigWebSDK';
 import React, { useState } from 'react';
@@ -289,6 +290,15 @@ const RegisterApp: React.FC = () => {
                 content: (
                   <div className="pd-20">
                     <ConfigWebSDK appInfo={application} />
+                  </div>
+                ),
+              },
+              {
+                label: t('application:detail.flutter'),
+                id: 'web',
+                content: (
+                  <div className="pd-20">
+                    <ConfigFlutterSDK appInfo={application} />
                   </div>
                 ),
               },

--- a/frontend/src/pages/application/detail/ApplicationDetail.tsx
+++ b/frontend/src/pages/application/detail/ApplicationDetail.tsx
@@ -37,6 +37,7 @@ import { useParams } from 'react-router-dom';
 import { TIME_FORMAT } from 'ts/const';
 import { defaultStr } from 'ts/utils';
 import ConfigAndroidSDK from './comp/ConfigAndroidSDK';
+import ConfigFlutterSDK from './comp/ConfigFlutterSDK';
 import ConfigIOSSDK from './comp/ConfigIOSSDK';
 import ConfigWebSDK from './comp/ConfigWebSDK';
 
@@ -292,6 +293,15 @@ const ApplicationDetail: React.FC = () => {
                       content: (
                         <div className="pd-20">
                           <ConfigWebSDK appInfo={applicationInfo} />
+                        </div>
+                      ),
+                    },
+                    {
+                      label: t('application:detail.flutter'),
+                      id: 'flutter',
+                      content: (
+                        <div className="pd-20">
+                          <ConfigFlutterSDK appInfo={applicationInfo} />
                         </div>
                       ),
                     },

--- a/frontend/src/pages/application/detail/comp/ConfigFlutterSDK.tsx
+++ b/frontend/src/pages/application/detail/comp/ConfigFlutterSDK.tsx
@@ -1,0 +1,106 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import {
+  FormField,
+  Header,
+  Link,
+  SpaceBetween,
+} from '@cloudscape-design/components';
+import CopyCode from 'components/common/CopyCode';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  TEMPLATE_SERVER_ENDPOINT,
+  TEMPLATE_APP_ID,
+  FLUTTER_INSTALL_GUIDE,
+  FLUTTER_INIT_SDK_TEXT,
+  FLUTTER_RECORD_EVENT,
+  FLUTTER_ADD_USER_ATTR,
+  buildSDKDocumentLink,
+} from 'ts/guideConst';
+import { defaultStr } from 'ts/utils';
+
+interface ConfigSDKProps {
+  appInfo?: IApplication;
+}
+
+const ConfigFlutterSDK: React.FC<ConfigSDKProps> = (props: ConfigSDKProps) => {
+  const { appInfo } = props;
+  const { t, i18n } = useTranslation();
+
+  return (
+    <SpaceBetween direction="vertical" size="l">
+      <div>
+        <Header variant="h3">{t('application:sdkGuide.webInstallSDK')}</Header>
+        <div className="mt-10">
+          <FormField>
+            <CopyCode code={FLUTTER_INSTALL_GUIDE} />
+          </FormField>
+        </div>
+      </div>
+
+      <Header
+        variant="h3"
+        description={t('application:sdkGuide.flutterSDKSetupDesc')}
+      >
+        {t('application:sdkGuide.setupSDK')}
+      </Header>
+
+      <SpaceBetween direction="vertical" size="l">
+        <FormField>
+          <CopyCode
+            code={FLUTTER_INIT_SDK_TEXT.replace(
+              TEMPLATE_APP_ID,
+              defaultStr(appInfo?.appId)
+            ).replace(
+              TEMPLATE_SERVER_ENDPOINT,
+              defaultStr(appInfo?.pipeline?.endpoint)
+            )}
+          />
+        </FormField>
+      </SpaceBetween>
+
+      <Header variant="h3">{t('application:sdkGuide.startUsing')}</Header>
+
+      <SpaceBetween direction="vertical" size="l">
+        <FormField
+          label={t('application:sdkGuide.recordEvents')}
+          description={t('application:sdkGuide.recordEventsDesc')}
+        >
+          <CopyCode code={FLUTTER_RECORD_EVENT} />
+        </FormField>
+
+        <FormField label={t('application:sdkGuide.addUserAttr')}>
+          <div className="mt-10">
+            <CopyCode code={FLUTTER_ADD_USER_ATTR} />
+          </div>
+        </FormField>
+
+        <p>
+          {t('application:sdkGuide.moreInfoLink', {
+            sdkType: 'Flutter',
+          })}
+          <Link
+            href={buildSDKDocumentLink(i18n.language, '/sdk-manual/flutter')}
+            external
+          >
+            {t('application:sdkGuide.devGuide')}
+          </Link>
+        </p>
+      </SpaceBetween>
+    </SpaceBetween>
+  );
+};
+
+export default ConfigFlutterSDK;

--- a/frontend/src/ts/guideConst.ts
+++ b/frontend/src/ts/guideConst.ts
@@ -193,3 +193,39 @@ ClickstreamAnalytics.setUserId("UserId");
 // when user logout
 ClickstreamAnalytics.setUserId(null);
 `;
+
+export const FLUTTER_INSTALL_GUIDE = `// Install SDK
+flutter pub add clickstream_analytics
+
+// After complete, rebuild your Flutter application.
+flutter run`;
+
+export const FLUTTER_INIT_SDK_TEXT = `import 'package:clickstream_analytics/clickstream_analytics.dart';
+
+final analytics = ClickstreamAnalytics();
+analytics.init(
+  appId: "${TEMPLATE_APP_ID}", // Your application ID
+  endpoint: "${TEMPLATE_SERVER_ENDPOINT}" // Your server endpoint
+);
+`;
+
+export const FLUTTER_RECORD_EVENT = `import 'package:clickstream_analytics/clickstream_analytics.dart';
+
+final analytics = ClickstreamAnalytics();
+
+// record event with attributes
+analytics.record(name: 'button_click', attributes: {
+  "event_category": "shoes",
+  "currency": "CNY",
+  "value": 279.9
+});
+
+// record event with name
+analytics.record(name: "button_click");
+`;
+
+export const FLUTTER_ADD_USER_ATTR = `analytics.setUserAttributes({
+  "userName":"carl",
+  "userAge": 22
+});
+`;


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend