### PR TITLE
fix: disallow to delete system user that created by solution

### DIFF
--- a/src/control-plane/backend/lambda/api/service/user.ts
+++ b/src/control-plane/backend/lambda/api/service/user.ts
@@ -12,6 +12,7 @@
  */
 
 import { DEFAULT_ADMIN_ROLE_NAMES, DEFAULT_ANALYST_READER_ROLE_NAMES, DEFAULT_ANALYST_ROLE_NAMES, DEFAULT_OPERATOR_ROLE_NAMES, DEFAULT_ROLE_JSON_PATH } from '../common/constants';
+import { SolutionInfo } from '../common/solution-info-ln';
 import { ApiFail, ApiSuccess } from '../common/types';
 import { getRoleFromToken, getTokenFromRequest } from '../common/utils';
 import { IUser, IUserSettings } from '../model/user';
@@ -91,8 +92,8 @@ export class UserService {
 
   public async update(req: any, res: any, next: any) {
     try {
-      if (req.body.operator === 'Clickstream') {
-        return res.status(400).json(new ApiFail('This user not allow to be modified.'));
+      if (req.body.operator === SolutionInfo.SOLUTION_SHORT_NAME) {
+        return res.status(400).json(new ApiFail('This user was created by solution and not allow to be modified.'));
       }
       req.body.operator = res.get('X-Click-Stream-Operator');
       const user: IUser = req.body as IUser;
@@ -107,6 +108,10 @@ export class UserService {
     try {
       const { id } = req.params;
       const operator = res.get('X-Click-Stream-Operator');
+      const user = await store.getUser(id);
+      if (user?.operator === SolutionInfo.SOLUTION_SHORT_NAME) {
+        return res.status(400).json(new ApiFail('This user was created by solution and not allow to be deleted.'));
+      }
       await store.deleteUser(id, operator);
       return res.status(200).json(new ApiSuccess(null, 'User deleted.'));
     } catch (error) {

--- a/src/control-plane/backend/lambda/api/service/user.ts
+++ b/src/control-plane/backend/lambda/api/service/user.ts
@@ -93,7 +93,7 @@ export class UserService {
   public async update(req: any, res: any, next: any) {
     try {
       if (req.body.operator === SolutionInfo.SOLUTION_SHORT_NAME) {
-        return res.status(400).json(new ApiFail('This user was created by solution and not allow to be modified.'));
+        return res.status(400).json(new ApiFail('This user was created by solution and not allowed to be modified.'));
       }
       req.body.operator = res.get('X-Click-Stream-Operator');
       const user: IUser = req.body as IUser;
@@ -110,7 +110,7 @@ export class UserService {
       const operator = res.get('X-Click-Stream-Operator');
       const user = await store.getUser(id);
       if (user?.operator === SolutionInfo.SOLUTION_SHORT_NAME) {
-        return res.status(400).json(new ApiFail('This user was created by solution and not allow to be deleted.'));
+        return res.status(400).json(new ApiFail('This user was created by solution and not allowed to be deleted.'));
       }
       await store.deleteUser(id, operator);
       return res.status(200).json(new ApiSuccess(null, 'User deleted.'));

--- a/src/control-plane/backend/lambda/api/test/api/user.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/user.test.ts
@@ -23,11 +23,11 @@ import request from 'supertest';
 import { MOCK_TOKEN, MOCK_USER_ID, tokenMock } from './ddb-mock';
 import { DEFAULT_ADMIN_ROLE_NAMES, DEFAULT_ANALYST_READER_ROLE_NAMES, DEFAULT_ANALYST_ROLE_NAMES, DEFAULT_OPERATOR_ROLE_NAMES, DEFAULT_ROLE_JSON_PATH, amznRequestContextHeader, clickStreamTableName } from '../../common/constants';
 import { DEFAULT_SOLUTION_OPERATOR } from '../../common/constants-ln';
+import { SolutionInfo } from '../../common/solution-info-ln';
 import { IUserRole } from '../../common/types';
 import { getRoleFromToken } from '../../common/utils';
 import { app, server } from '../../index';
 import 'aws-sdk-client-mock-jest';
-import { SolutionInfo } from '../../common/solution-info-ln';
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 

--- a/src/control-plane/backend/lambda/api/test/api/user.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/user.test.ts
@@ -179,7 +179,7 @@ describe('User test', () => {
       });
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(400);
-    expect(res.body.message).toEqual('This user was created by solution and not allow to be modified.');
+    expect(res.body.message).toEqual('This user was created by solution and not allowed to be modified.');
     expect(res.body.success).toEqual(false);
     expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
     expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
@@ -232,7 +232,7 @@ describe('User test', () => {
       .set('X-Click-Stream-Request-Id', MOCK_TOKEN);
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(400);
-    expect(res.body.message).toEqual('This user was created by solution and not allow to be deleted.');
+    expect(res.body.message).toEqual('This user was created by solution and not allowed to be deleted.');
     expect(res.body.success).toEqual(false);
     expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 2);
     expect(ddbMock).toHaveReceivedCommandTimes(UpdateCommand, 0);


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend