### PR TITLE
fix: disable next when QuickSight not subscribe in create pipeline

### DIFF
--- a/frontend/src/pages/pipelines/create/CreatePipeline.tsx
+++ b/frontend/src/pages/pipelines/create/CreatePipeline.tsx
@@ -188,6 +188,7 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
     useState(false);
 
   const [unSupportedServices, setUnSupportedServices] = useState('');
+  const [quickSightDisabled, setQuickSightDisabled] = useState(false);
 
   const [pipelineInfo, setPipelineInfo] = useState<IExtPipeline>(
     updatePipeline
@@ -1065,6 +1066,13 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
           return;
         }
         if (detail.requestedStepIndex === 3 && !validateDataProcessing()) {
+          return;
+        }
+        if (
+          detail.requestedStepIndex === 4 &&
+          quickSightDisabled &&
+          pipelineInfo.enableReporting
+        ) {
           return;
         }
         setActiveStepIndex(detail.requestedStepIndex);
@@ -2093,6 +2101,9 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
               pipelineInfo={pipelineInfo}
               changeLoadingQuickSight={(loading) => {
                 setloadingQuickSight(loading);
+              }}
+              changeQuickSightDisabled={(disabled) => {
+                setQuickSightDisabled(disabled);
               }}
               changeEnableReporting={(enable) => {
                 setPipelineInfo((prev) => {

--- a/frontend/src/pages/pipelines/create/steps/Reporting.tsx
+++ b/frontend/src/pages/pipelines/create/steps/Reporting.tsx
@@ -38,6 +38,7 @@ interface ReportingProps {
   update?: boolean;
   pipelineInfo: IExtPipeline;
   changeEnableReporting: (enable: boolean) => void;
+  changeQuickSightDisabled: (disabled: boolean) => void;
   changeQuickSightAccountName: (accountName: string) => void;
   changeLoadingQuickSight?: (loading: boolean) => void;
 }
@@ -48,6 +49,7 @@ const Reporting: React.FC<ReportingProps> = (props: ReportingProps) => {
     update,
     pipelineInfo,
     changeEnableReporting,
+    changeQuickSightDisabled,
     changeQuickSightAccountName,
     changeLoadingQuickSight,
   } = props;
@@ -67,7 +69,12 @@ const Reporting: React.FC<ReportingProps> = (props: ReportingProps) => {
         data.accountSubscriptionStatus === 'ACCOUNT_CREATED'
       ) {
         setQuickSightEnabled(true);
+        changeQuickSightDisabled(false);
         changeQuickSightAccountName(data.accountName);
+      } else {
+        changeEnableReporting(false);
+        setQuickSightEnabled(false);
+        changeQuickSightDisabled(true);
       }
       if (success && data && data.edition.includes('ENTERPRISE')) {
         setQuickSightEnterprise(true);
@@ -118,80 +125,91 @@ const Reporting: React.FC<ReportingProps> = (props: ReportingProps) => {
     >
       {pipelineInfo.enableDataProcessing && pipelineInfo.enableRedshift ? (
         <>
-          <SpaceBetween direction="vertical" size="l">
-            <FormField>
-              <Toggle
-                controlId="test-quicksight-id"
-                disabled={
-                  isDisabled(update, pipelineInfo) ??
-                  (!pipelineInfo.serviceStatus?.QUICK_SIGHT ||
-                    !pipelineInfo.enableRedshift)
-                }
-                onChange={({ detail }) => changeEnableReporting(detail.checked)}
-                checked={pipelineInfo.enableReporting}
-                description={
-                  <div>
-                    <Trans
-                      i18nKey="pipeline:create.createSampleQuickSightDesc"
-                      components={{
-                        learnmore_anchor: (
+          {loadingQuickSight ? (
+            <Spinner />
+          ) : (
+            <>
+              <SpaceBetween direction="vertical" size="l">
+                <FormField>
+                  <Toggle
+                    controlId="test-quicksight-id"
+                    disabled={
+                      isDisabled(update, pipelineInfo) ??
+                      (!pipelineInfo.serviceStatus?.QUICK_SIGHT ||
+                        !pipelineInfo.enableRedshift)
+                    }
+                    onChange={({ detail }) =>
+                      changeEnableReporting(detail.checked)
+                    }
+                    checked={pipelineInfo.enableReporting}
+                    description={
+                      <div>
+                        <Trans
+                          i18nKey="pipeline:create.createSampleQuickSightDesc"
+                          components={{
+                            learnmore_anchor: (
+                              <Link
+                                external
+                                href={buildDocumentLink(
+                                  i18n.language,
+                                  PIPELINE_QUICKSIGHT_LEARNMORE_LINK_EN,
+                                  PIPELINE_QUICKSIGHT_LEARNMORE_LINK_CN
+                                )}
+                              />
+                            ),
+                            guide_anchor: (
+                              <Link
+                                external
+                                href={buildDocumentLink(
+                                  i18n.language,
+                                  PIPELINE_QUICKSIGHT_GUIDE_LINK_EN,
+                                  PIPELINE_QUICKSIGHT_GUIDE_LINK_CN
+                                )}
+                              />
+                            ),
+                          }}
+                        />
+                      </div>
+                    }
+                  >
+                    <b>{t('pipeline:create.createSampleQuickSight')}</b>
+                  </Toggle>
+                </FormField>
+
+                {pipelineInfo.enableReporting &&
+                  (loadingQuickSight ? (
+                    <Spinner />
+                  ) : (
+                    <>
+                      {!quickSightEnabled && (
+                        <Alert
+                          type="warning"
+                          header={t('pipeline:create.quickSightNotSub')}
+                        >
+                          {t('pipeline:create.quickSightNotSubDesc1')}
                           <Link
                             external
-                            href={buildDocumentLink(
-                              i18n.language,
-                              PIPELINE_QUICKSIGHT_LEARNMORE_LINK_EN,
-                              PIPELINE_QUICKSIGHT_LEARNMORE_LINK_CN
-                            )}
-                          />
-                        ),
-                        guide_anchor: (
-                          <Link
-                            external
-                            href={buildDocumentLink(
-                              i18n.language,
-                              PIPELINE_QUICKSIGHT_GUIDE_LINK_EN,
-                              PIPELINE_QUICKSIGHT_GUIDE_LINK_CN
-                            )}
-                          />
-                        ),
-                      }}
-                    />
-                  </div>
-                }
-              >
-                <b>{t('pipeline:create.createSampleQuickSight')}</b>
-              </Toggle>
-            </FormField>
+                            href={buildQuickSightSubscriptionLink()}
+                          >
+                            {t('pipeline:create.quickSightSubscription')}
+                          </Link>
+                          {t('pipeline:create.quickSightNotSubDesc2')}
+                        </Alert>
+                      )}
 
-            {pipelineInfo.enableReporting &&
-              (loadingQuickSight ? (
-                <Spinner />
-              ) : (
-                <>
-                  {!quickSightEnabled && (
-                    <Alert
-                      type="warning"
-                      header={t('pipeline:create.quickSightNotSub')}
-                    >
-                      {t('pipeline:create.quickSightNotSubDesc1')}
-                      <Link external href={buildQuickSightSubscriptionLink()}>
-                        {t('pipeline:create.quickSightSubscription')}
-                      </Link>
-                      {t('pipeline:create.quickSightNotSubDesc2')}
-                    </Alert>
-                  )}
-
-                  {quickSightEnabled && !quickSightEnterprise && (
-                    <Alert
-                      type="warning"
-                      header={t('pipeline:create.quickSightNotEnterprise')}
-                    >
-                      {t('pipeline:create.quickSightNotEnterpriseDesc')}
-                    </Alert>
-                  )}
-                </>
-              ))}
-          </SpaceBetween>
+                      {quickSightEnabled && !quickSightEnterprise && (
+                        <Alert
+                          type="warning"
+                          header={t('pipeline:create.quickSightNotEnterprise')}
+                        >
+                          {t('pipeline:create.quickSightNotEnterpriseDesc')}
+                        </Alert>
+                      )}
+                    </>
+                  ))}
+              </SpaceBetween>
+            </>
+          )}
         </>
       ) : (
         <Alert header={t('pipeline:create.reportNotSupported')}>


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend