### PR TITLE
fix: check XSS in update user api

### DIFF
--- a/src/control-plane/backend/lambda/api/router/user.ts
+++ b/src/control-plane/backend/lambda/api/router/user.ts
@@ -46,6 +46,7 @@ router_user.get(
 router_user.put(
   '/:id',
   validate([
+    body().custom(isValidEmpty).custom(isXSSRequest),
     body('id').custom(isEmail).custom(isUserValid),
     body('name').isLength({ max: 100 }),
     header('X-Click-Stream-Request-Id').custom(isRequestIdExisted),

--- a/src/control-plane/backend/lambda/api/test/api/user.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/user.test.ts
@@ -185,6 +185,32 @@ describe('User test', () => {
     expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
   });
 
+  it('Update user with XSS', async () => {
+    tokenMock(ddbMock, false).resolvesOnce({});
+    ddbMock.on(GetCommand).resolvesOnce({
+      Item: {
+        id: MOCK_USER_ID,
+        deleted: false,
+      },
+    });
+    const res = await request(app)
+      .put(`/api/user/${MOCK_USER_ID}`)
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        id: MOCK_USER_ID,
+        name: '<script>alert(1)</script>',
+        roles: [IUserRole.OPERATOR],
+        operator: DEFAULT_SOLUTION_OPERATOR,
+        deleted: false,
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toEqual('Parameter verification failed.');
+    expect(res.body.success).toEqual(false);
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
+  });
+
   it('Delete user', async () => {
     tokenMock(ddbMock, false);
     ddbMock.on(GetCommand,


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend