### PR TITLE
fix: update old pipeline don't change Transformer class name

### DIFF
--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -341,6 +341,9 @@ export class CPipeline {
       if (stackName.startsWith(`Clickstream-${PipelineStackType.REPORTING}`) && oldPipeline.templateVersion?.startsWith('v1.0')) {
         continue; // skip reporting stack when template version is v1.0
       }
+      if (stackName.startsWith(`Clickstream-${PipelineStackType.DATA_PROCESSING}`) && oldPipeline.templateVersion?.startsWith('v1.0')) {
+        continue; // skip reporting stack when template version is v1.0
+      }
       if (!editStacks.includes(stackName)) {
         editStacks.push(stackName);
       }

--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -341,19 +341,25 @@ export class CPipeline {
       if (stackName.startsWith(`Clickstream-${PipelineStackType.REPORTING}`) && oldPipeline.templateVersion?.startsWith('v1.0')) {
         continue; // skip reporting stack when template version is v1.0
       }
-      if (stackName.startsWith(`Clickstream-${PipelineStackType.DATA_PROCESSING}`) && oldPipeline.templateVersion?.startsWith('v1.0')) {
-        continue; // skip reporting stack when template version is v1.0
-      }
       if (!editStacks.includes(stackName)) {
         editStacks.push(stackName);
       }
       if (!AllowedList.includes(paramName)) {
         notAllowEdit.push(paramName);
       } else {
+        let parameterValue = diffParameters.edited.find(p => p[0] === key)?.[1];
+        if (stackName.startsWith(`Clickstream-${PipelineStackType.DATA_PROCESSING}`) &&
+        paramName === 'TransformerAndEnrichClassNames' &&
+        oldPipeline.templateVersion?.startsWith('v1.0')) {
+          parameterValue = parameterValue.replace(
+            'software.aws.solution.clickstream.TransformerV2',
+            'software.aws.solution.clickstream.Transformer',
+          );
+        }
         editParameters.push({
           stackName: stackName,
           parameterKey: paramName,
-          parameterValue: diffParameters.edited.find(p => p[0] === key)?.[1],
+          parameterValue: parameterValue,
         });
       }
     }

--- a/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
@@ -1460,7 +1460,12 @@ export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_UPDATE_PIPELINE_WITH_WORKFLOW:
                   Region: 'ap-southeast-1',
                   TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-pipeline-stack.template.json',
                   Action: 'Create',
-                  Parameters: [],
+                  Parameters: [
+                    {
+                      ParameterKey: 'TransformerAndEnrichClassNames',
+                      ParameterValue: 'software.aws.solution.clickstream.Transformer,software.aws.solution.clickstream.UAEnrichment,software.aws.solution.clickstream.IPEnrichment',
+                    },
+                  ],
                   StackName: `Clickstream-DataProcessing-${MOCK_PIPELINE_ID}`,
                 },
                 Callback: {

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -3553,10 +3553,12 @@ describe('Pipeline test', () => {
 
     ddbMock.on(TransactWriteItemsCommand).callsFake(input => {
       const expressionAttributeValues = input.TransactItems[1].Update.ExpressionAttributeValues;
+      const dataProcessingInput = expressionAttributeValues[':workflow'].M.Workflow.M.Branches.L[1].M.States.M.DataProcessing.M.Data.M.Input;
       const reportInput = expressionAttributeValues[':workflow'].M.Workflow.M.Branches.L[1].M.States.M.Reporting.M.Data.M.Input;
       expect(
         expressionAttributeValues[':templateVersion'].S === 'v1.0.0' &&
         expressionAttributeValues[':tags'].L[0].M.value.S === 'v1.0.0' &&
+        dataProcessingInput.M.Parameters.L[0].M.ParameterValue.S === 'software.aws.solution.clickstream.Transformer,software.aws.solution.clickstream.UAEnrichment,software.aws.solution.clickstream.IPEnrichment,test.aws.solution.main' &&
         reportInput.M.Parameters.L[0].M.ParameterValue.S === 'Admin/fakeUser' &&
         reportInput.M.Parameters.L[1].M.ParameterValue.S === 'arn:aws:quicksight:us-west-2:555555555555:user/default/Admin/fakeUser',
       ).toBeTruthy();


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend