### PR TITLE
feat: add session attribute in the _first_open event of the example data generator

### DIFF
--- a/examples/standalone-data-generator/application/shopping/ShoppingApp.py
+++ b/examples/standalone-data-generator/application/shopping/ShoppingApp.py
@@ -110,6 +110,12 @@ def get_launch_events(user, event):
     traffic_source = enums.traffic_source.get_random_item()
     event["attributes"]["_traffic_source_source"] = traffic_source[0]
     event["attributes"]["_traffic_source_medium"] = traffic_source[1]
+    # init session
+    user.session_number += 1
+    new_session_id = get_new_session_id(event["unique_id"], user.current_timestamp)
+    event["attributes"]["_session_start_timestamp"] = user.current_timestamp
+    event["attributes"]["_session_id"] = new_session_id
+    event["attributes"]["_session_number"] = user.session_number
     # generate latest referrer for web
     if user.platform == enums.Platform.Web:
         referrer = enums.latest_referrer.get_random_item()
@@ -132,11 +138,6 @@ def get_launch_events(user, event):
         event["user"]["_user_id"] = user_id
 
     # handle session
-    user.session_number += 1
-    new_session_id = get_new_session_id(event["unique_id"], user.current_timestamp)
-    event["attributes"]["_session_start_timestamp"] = user.current_timestamp
-    event["attributes"]["_session_id"] = new_session_id
-    event["attributes"]["_session_number"] = user.session_number
     events.append(get_final_event(user, EventType.SESSION_START, clean_event(event)))
 
     app_start_event = clean_event(event)


### PR DESCRIPTION
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary
1. add session attribute in the _first_open event of the example data generator

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend