### PR TITLE
chore: support example data generator run in other path

### DIFF
--- a/examples/standalone-data-generator/configure.py
+++ b/examples/standalone-data-generator/configure.py
@@ -12,6 +12,7 @@ and limitations under the License.
 """
 import json
 import enums
+import os
 
 # application type, you can switch to `enums.Application.Shopping` to send shopping events.
 APP_TYPE = enums.Application.Shopping
@@ -58,9 +59,11 @@ ENDPOINT = ""
 
 
 def init_config():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    config_path = os.path.join(script_dir, 'amplifyconfiguration.json')
     global APP_ID, ENDPOINT, IS_GZIP, REQUEST_SLEEP_TIME, MAX_UPLOAD_THREAD_NUMBER, EVENTS_PER_REQUEST
     try:
-        with open('amplifyconfiguration.json') as file:
+        with open(config_path) as file:
             data = json.load(file)
             APP_ID = data['analytics']['plugins']['awsClickstreamPlugin']['appId']
             ENDPOINT = data['analytics']['plugins']['awsClickstreamPlugin']['endpoint']


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary
1. support example data generator run in other path

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend