### PR TITLE
chore: improve Powertools Logger usage

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -118,12 +118,12 @@
     },
     {
       "name": "@aws-lambda-powertools/logger",
-      "version": "^1.8.0",
+      "version": "^1.17.0",
       "type": "runtime"
     },
     {
       "name": "@aws-lambda-powertools/metrics",
-      "version": "^1.8.0",
+      "version": "^1.17.0",
       "type": "runtime"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -24,8 +24,8 @@ const cdkAlphaModules = [
 const commonDeps = [
   'uuid@^9.0.0',
   '@types/aws-lambda@^8.10.110',
-  '@aws-lambda-powertools/logger@^1.8.0',
-  '@aws-lambda-powertools/metrics@^1.8.0',
+  '@aws-lambda-powertools/logger@^1.17.0',
+  '@aws-lambda-powertools/metrics@^1.17.0',
   'jsonwebtoken@^9.0.0',
   'jwks-rsa@^3.0.1',
   'mustache@^4.2.0',

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
   "dependencies": {
     "@aws-cdk/aws-glue-alpha": "^2.81.0-alpha.0",
     "@aws-cdk/aws-servicecatalogappregistry-alpha": "^2.81.0-alpha.0",
-    "@aws-lambda-powertools/logger": "^1.8.0",
-    "@aws-lambda-powertools/metrics": "^1.8.0",
+    "@aws-lambda-powertools/logger": "^1.17.0",
+    "@aws-lambda-powertools/metrics": "^1.17.0",
     "@aws-sdk/client-acm": "^3.405.0",
     "@aws-sdk/client-cloudformation": "^3.405.0",
     "@aws-sdk/client-cloudwatch": "^3.405.0",

--- a/src/analytics/lambdas/clear-expired-events-workflow/check-clear-status.ts
+++ b/src/analytics/lambdas/clear-expired-events-workflow/check-clear-status.ts
@@ -33,7 +33,7 @@ export interface ClearExpiredEventsEvent {
  * @returns The clear expired events results of query_id.
  */
 export const handler = async (event: ClearExpiredEventsEvent) => {
-  logger.debug('request event:', JSON.stringify(event));
+  logger.debug('request event:', {event});
 
   const queryId = event.detail.id;
   const appId = event.detail.appId;

--- a/src/analytics/lambdas/clear-expired-events-workflow/check-clear-status.ts
+++ b/src/analytics/lambdas/clear-expired-events-workflow/check-clear-status.ts
@@ -33,7 +33,7 @@ export interface ClearExpiredEventsEvent {
  * @returns The clear expired events results of query_id.
  */
 export const handler = async (event: ClearExpiredEventsEvent) => {
-  logger.debug('request event:', {event});
+  logger.debug('request event:', { event });
 
   const queryId = event.detail.id;
   const appId = event.detail.appId;

--- a/src/analytics/lambdas/custom-resource/create-redshift-namespace.ts
+++ b/src/analytics/lambdas/custom-resource/create-redshift-namespace.ts
@@ -26,8 +26,6 @@ type ResourcePropertiesType = NewNamespaceCustomProperties & {
 }
 
 export const handler: CdkCustomResourceHandler = async (event: CdkCustomResourceEvent, context: Context) => {
-  logger.info(JSON.stringify(event));
-
   const resourceProps = event.ResourceProperties as ResourcePropertiesType;
   const physicalRequestId = `redshift-serverless-namespace-${resourceProps.namespaceName}`;
   let namespace: Namespace | undefined;

--- a/src/analytics/lambdas/custom-resource/create-redshift-user.ts
+++ b/src/analytics/lambdas/custom-resource/create-redshift-user.ts
@@ -20,7 +20,6 @@ type ResourcePropertiesType = CreateMappingRoleUser & {
 }
 
 export const handler: CdkCustomResourceHandler = async (event) => {
-  logger.info(JSON.stringify(event));
   const response: CdkCustomResourceResponse = {
     PhysicalResourceId: 'create-redshift-db-user-custom-resource',
     Data: {

--- a/src/analytics/lambdas/custom-resource/redshift-associate-iam-role.ts
+++ b/src/analytics/lambdas/custom-resource/redshift-associate-iam-role.ts
@@ -74,7 +74,6 @@ function excludeToBeUnassociated(roles: string[], toBeUnasscoiated?: string): st
 }
 
 export const handler: CdkCustomResourceHandler = async (event: CdkCustomResourceEvent) => {
-  logger.info(JSON.stringify(event));
   let physicalRequestId: string | undefined;
   try {
     const resourceProps = event.ResourceProperties as ResourcePropertiesType;

--- a/src/analytics/lambdas/load-data-workflow/check-load-status.ts
+++ b/src/analytics/lambdas/load-data-workflow/check-load-status.ts
@@ -79,7 +79,7 @@ export const handler = async (event: CheckLoadStatusEvent, context: Context) => 
         logger.debug(`delFinishedJobInDynamodb s3Uri:${url}`);
         try {
           const dynamodbResponse = await delFinishedJobInDynamodb(dynamodbTableName, url);
-          logger.debug('delFinishedJobInDynamodb response:', {dynamodbResponse});
+          logger.debug('delFinishedJobInDynamodb response:', { dynamodbResponse });
         } catch (err) {
           errMsg = 'Error when deleting loaded jobs in DDB.';
           throw err;
@@ -92,7 +92,7 @@ export const handler = async (event: CheckLoadStatusEvent, context: Context) => 
       logger.debug(`delFinishedJobInS3 s3Bucket:${s3Bucket}, s3Object:${s3Object}`);
       try {
         const s3Response = await delFinishedJobInS3(s3Bucket, s3Object);
-        logger.debug('delFinishedJobInS3 response:', {s3Response});
+        logger.debug('delFinishedJobInS3 response:', { s3Response });
       } catch (err) {
         logger.error(`Error when deleting manifest file ${s3Object} in S3 bucket ${s3Bucket}.`, (err as Error));
       }
@@ -148,9 +148,9 @@ export const checkLoadStatus = async (queryId: string) => {
   try {
     const response = await redshiftDataApiClient.send(params);
     if (response.Status == 'FAILED') {
-      logger.error(`Get load status: ${response.Status}`, {response});
+      logger.error(`Get load status: ${response.Status}`, { response });
     } else {
-      logger.info(`Get load status: ${response.Status}`, {response});
+      logger.info(`Get load status: ${response.Status}`, { response });
     }
     return response;
   } catch (err) {

--- a/src/analytics/lambdas/load-data-workflow/check-load-status.ts
+++ b/src/analytics/lambdas/load-data-workflow/check-load-status.ts
@@ -79,7 +79,7 @@ export const handler = async (event: CheckLoadStatusEvent, context: Context) => 
         logger.debug(`delFinishedJobInDynamodb s3Uri:${url}`);
         try {
           const dynamodbResponse = await delFinishedJobInDynamodb(dynamodbTableName, url);
-          logger.debug('delFinishedJobInDynamodb response:', JSON.stringify(dynamodbResponse));
+          logger.debug('delFinishedJobInDynamodb response:', {dynamodbResponse});
         } catch (err) {
           errMsg = 'Error when deleting loaded jobs in DDB.';
           throw err;
@@ -92,7 +92,7 @@ export const handler = async (event: CheckLoadStatusEvent, context: Context) => 
       logger.debug(`delFinishedJobInS3 s3Bucket:${s3Bucket}, s3Object:${s3Object}`);
       try {
         const s3Response = await delFinishedJobInS3(s3Bucket, s3Object);
-        logger.debug('delFinishedJobInS3 response:', JSON.stringify(s3Response));
+        logger.debug('delFinishedJobInS3 response:', {s3Response});
       } catch (err) {
         logger.error(`Error when deleting manifest file ${s3Object} in S3 bucket ${s3Bucket}.`, (err as Error));
       }
@@ -148,9 +148,9 @@ export const checkLoadStatus = async (queryId: string) => {
   try {
     const response = await redshiftDataApiClient.send(params);
     if (response.Status == 'FAILED') {
-      logger.error(`Get load status: ${response.Status}`, JSON.stringify(response));
+      logger.error(`Get load status: ${response.Status}`, {response});
     } else {
-      logger.info(`Get load status: ${response.Status}`, JSON.stringify(response));
+      logger.info(`Get load status: ${response.Status}`, {response});
     }
     return response;
   } catch (err) {

--- a/src/analytics/lambdas/load-data-workflow/load-manifest-to-redshift.ts
+++ b/src/analytics/lambdas/load-data-workflow/load-manifest-to-redshift.ts
@@ -82,10 +82,8 @@ export const handler = async (event: LoadManifestEvent, context: Context) => {
   let appId = event.detail.appId;
   const manifestFileName = event.detail.manifestFileName;
   const jobList = event.detail.jobList;
-  logger.info(`appId:${appId}, manifestFileName:${manifestFileName}, jobList:${JSON.stringify(jobList)}`);
-  /**
-   * The appId will be used as the schema of Redshift, '.' and '-' are not supported.
-   */
+  logger.info('Event details',{details: event.detail})
+  // The appId will be used as the schema of Redshift, '.' and '-' are not supported.
   appId = appId.replace(/\./g, '_').replace(/\-/g, '_');
   logger.debug(`appId:${appId}`);
 

--- a/src/analytics/lambdas/load-data-workflow/load-manifest-to-redshift.ts
+++ b/src/analytics/lambdas/load-data-workflow/load-manifest-to-redshift.ts
@@ -82,7 +82,7 @@ export const handler = async (event: LoadManifestEvent, context: Context) => {
   let appId = event.detail.appId;
   const manifestFileName = event.detail.manifestFileName;
   const jobList = event.detail.jobList;
-  logger.info('Event details',{details: event.detail})
+  logger.info('Event details', { details: event.detail });
   // The appId will be used as the schema of Redshift, '.' and '-' are not supported.
   appId = appId.replace(/\./g, '_').replace(/\-/g, '_');
   logger.debug(`appId:${appId}`);

--- a/src/analytics/lambdas/load-data-workflow/put-ods-source-to-store.ts
+++ b/src/analytics/lambdas/load-data-workflow/put-ods-source-to-store.ts
@@ -66,7 +66,6 @@ const REDSHIFT_ODS_TABLE_NAME = process.env.REDSHIFT_ODS_TABLE_NAME;
  * @returns The result of putting item to dynamodb.
  */
 export const handler = async (event: EventBridgeEvent<'Object Created', S3ObjectCreatedNotificationEventDetail>) => {
-  logger.info('requestJson:', JSON.stringify(event, undefined, 2));
   // Create a Date object from the date string
   let date = new Date(event.time);
   // Get the timestamp as a number

--- a/src/analytics/lambdas/scan-metadata-workflow/check-metadata-workflow-start.ts
+++ b/src/analytics/lambdas/scan-metadata-workflow/check-metadata-workflow-start.ts
@@ -55,7 +55,6 @@ export interface CheckMetadataWorkflowEvent {
   };
  */
 export const handler = async (event: CheckMetadataWorkflowEvent) => {
-  logger.debug('request event:', JSON.stringify(event));
   try {
     const eventSource = event.originalInput.eventSource;
     const hasRunningExecution: boolean = await hasOtherRunningExecutions(event.executionId);

--- a/src/analytics/lambdas/scan-metadata-workflow/check-scan-metadata-status.ts
+++ b/src/analytics/lambdas/scan-metadata-workflow/check-scan-metadata-status.ts
@@ -33,8 +33,6 @@ export interface CheckScanMetadataStatusEvent {
  * @returns The scan metadata results of query_id.
  */
 export const handler = async (event: CheckScanMetadataStatusEvent) => {
-  logger.debug('request event:', JSON.stringify(event));
-
   const queryId = event.detail.id;
   const appId = event.detail.appId;
   logger.debug(`query_id:${queryId}`);

--- a/src/analytics/lambdas/scan-metadata-workflow/scan-metadata.ts
+++ b/src/analytics/lambdas/scan-metadata-workflow/scan-metadata.ts
@@ -37,7 +37,6 @@ export interface ScanMetadataEvent {
   @returns The query_id and relevant properties.
  */
 export const handler = async (event: ScanMetadataEvent) => {
-  logger.debug('request event:', JSON.stringify(event));
   const redshiftProps = getRedshiftProps(
     process.env.REDSHIFT_MODE!,
     REDSHIFT_DATABASE,

--- a/src/analytics/lambdas/scan-metadata-workflow/store-metadata-into-ddb.ts
+++ b/src/analytics/lambdas/scan-metadata-workflow/store-metadata-into-ddb.ts
@@ -46,8 +46,6 @@ const ddbDocClient = DynamoDBDocumentClient.from(ddbClient);
  * @returns.
  */
 export const handler = async (event: StoreMetadataEvent) => {
-  logger.debug('request event:', JSON.stringify(event));
-
   const appId = event.detail.appId;
   const metadataItems: any[] = [];
   try {

--- a/src/analytics/lambdas/scan-metadata-workflow/update-workflow-info.ts
+++ b/src/analytics/lambdas/scan-metadata-workflow/update-workflow-info.ts
@@ -48,8 +48,6 @@ export interface UpdateWorkflowInfoEvent {
   @returns.
  */
 export const handler = async (event: UpdateWorkflowInfoEvent) => {
-  logger.debug('request event:', JSON.stringify(event));
-
   try {
     const lastJobStartTimestamp = event.lastJobStartTimestamp;
     const lastScanEndDate = event.lastScanEndDate;

--- a/src/control-plane/backend/lambda/api/.projen/deps.json
+++ b/src/control-plane/backend/lambda/api/.projen/deps.json
@@ -102,12 +102,12 @@
     },
     {
       "name": "@aws-lambda-powertools/logger",
-      "version": "^1.8.0",
+      "version": "^1.17.0",
       "type": "runtime"
     },
     {
       "name": "@aws-lambda-powertools/metrics",
-      "version": "^1.8.0",
+      "version": "^1.17.0",
       "type": "runtime"
     },
     {

--- a/src/control-plane/backend/lambda/api/package.json
+++ b/src/control-plane/backend/lambda/api/package.json
@@ -41,8 +41,8 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@aws-lambda-powertools/logger": "^1.8.0",
-    "@aws-lambda-powertools/metrics": "^1.8.0",
+    "@aws-lambda-powertools/logger": "^1.17.0",
+    "@aws-lambda-powertools/metrics": "^1.17.0",
     "@aws-sdk/client-acm": "^3.405.0",
     "@aws-sdk/client-cloudformation": "^3.405.0",
     "@aws-sdk/client-cloudwatch": "^3.405.0",

--- a/src/control-plane/backend/lambda/api/service/quicksight/sql-builder.ts
+++ b/src/control-plane/backend/lambda/api/service/quicksight/sql-builder.ts
@@ -2020,7 +2020,7 @@ function buildSqlFromCondition(condition: Condition, propertyPrefix?: string) : 
     case MetadataValueType.INTEGER:
       return _buildSqlFromNumberCondition(condition, prefix);
     default:
-      logger.error('unsupported condition', {condition});
+      logger.error('unsupported condition', { condition });
       throw new Error('Unsupported condition');
   }
 }
@@ -2035,7 +2035,7 @@ function buildSqlForUserCondition(condition: Condition, tablePrefix: string = ''
     case MetadataValueType.INTEGER:
       return buildSqlForNestAttributeNumberCondition(condition, `${tablePrefix}custom_attr_key`, `${tablePrefix}custom_attr_value`);
     default:
-      logger.error('unsupported condition', {condition});
+      logger.error('unsupported condition', { condition });
       throw new Error('Unsupported condition');
   }
 }
@@ -2049,7 +2049,7 @@ function buildSqlForEventCondition(condition: Condition, tablePrefix: string = '
     case MetadataValueType.INTEGER:
       return buildSqlForNestAttributeNumberCondition(condition, `${tablePrefix}event_parameter_key`, `${tablePrefix}event_parameter_value`);
     default:
-      logger.error('unsupported condition', {condition});
+      logger.error('unsupported condition', { condition });
       throw new Error('Unsupported condition');
   }
 }
@@ -2078,7 +2078,7 @@ function buildSqlForNestAttributeStringCondition(condition: Condition, propertyK
     case ExploreAnalyticsOperators.NOT_NULL:
       return `(${propertyKey} = '${condition.property}' and ${propertyValue} is not null)`;
     default:
-      logger.error('unsupported condition', {condition});
+      logger.error('unsupported condition', { condition });
       throw new Error('Unsupported condition');
   }
 
@@ -2104,7 +2104,7 @@ function buildSqlForNestAttributeNumberCondition(condition: Condition, propertyK
     case ExploreAnalyticsOperators.NOT_NULL:
       return `(${propertyKey} = '${condition.property}' and ${propertyValue} is not null)`;
     default:
-      logger.error('unsupported condition', {condition});
+      logger.error('unsupported condition', { condition });
       throw new Error('Unsupported condition');
   }
 
@@ -2134,7 +2134,7 @@ function _buildSqlFromStringCondition(condition: Condition, prefix: string) : st
     case ExploreAnalyticsOperators.NOT_NULL:
       return `${prefix}${condition.property} is not null `;
     default:
-      logger.error('unsupported condition', {condition});
+      logger.error('unsupported condition', { condition });
       throw new Error('Unsupported condition');
   }
 
@@ -2160,7 +2160,7 @@ function _buildSqlFromNumberCondition(condition: Condition, prefix: string) : st
     case ExploreAnalyticsOperators.NOT_NULL:
       return `${prefix}${condition.property} is not null `;
     default:
-      logger.error('unsupported condition', {condition});
+      logger.error('unsupported condition', { condition });
       throw new Error('Unsupported condition');
   }
 

--- a/src/control-plane/backend/lambda/api/service/quicksight/sql-builder.ts
+++ b/src/control-plane/backend/lambda/api/service/quicksight/sql-builder.ts
@@ -2020,7 +2020,7 @@ function buildSqlFromCondition(condition: Condition, propertyPrefix?: string) : 
     case MetadataValueType.INTEGER:
       return _buildSqlFromNumberCondition(condition, prefix);
     default:
-      logger.error(`unsupported condition ${JSON.stringify(condition)}`);
+      logger.error('unsupported condition', {condition});
       throw new Error('Unsupported condition');
   }
 }
@@ -2035,7 +2035,7 @@ function buildSqlForUserCondition(condition: Condition, tablePrefix: string = ''
     case MetadataValueType.INTEGER:
       return buildSqlForNestAttributeNumberCondition(condition, `${tablePrefix}custom_attr_key`, `${tablePrefix}custom_attr_value`);
     default:
-      logger.error(`unsupported condition ${JSON.stringify(condition)}`);
+      logger.error('unsupported condition', {condition});
       throw new Error('Unsupported condition');
   }
 }
@@ -2049,7 +2049,7 @@ function buildSqlForEventCondition(condition: Condition, tablePrefix: string = '
     case MetadataValueType.INTEGER:
       return buildSqlForNestAttributeNumberCondition(condition, `${tablePrefix}event_parameter_key`, `${tablePrefix}event_parameter_value`);
     default:
-      logger.error(`unsupported condition ${JSON.stringify(condition)}`);
+      logger.error('unsupported condition', {condition});
       throw new Error('Unsupported condition');
   }
 }
@@ -2078,7 +2078,7 @@ function buildSqlForNestAttributeStringCondition(condition: Condition, propertyK
     case ExploreAnalyticsOperators.NOT_NULL:
       return `(${propertyKey} = '${condition.property}' and ${propertyValue} is not null)`;
     default:
-      logger.error(`unsupported condition ${JSON.stringify(condition)}`);
+      logger.error('unsupported condition', {condition});
       throw new Error('Unsupported condition');
   }
 
@@ -2104,7 +2104,7 @@ function buildSqlForNestAttributeNumberCondition(condition: Condition, propertyK
     case ExploreAnalyticsOperators.NOT_NULL:
       return `(${propertyKey} = '${condition.property}' and ${propertyValue} is not null)`;
     default:
-      logger.error(`unsupported condition ${JSON.stringify(condition)}`);
+      logger.error('unsupported condition', {condition});
       throw new Error('Unsupported condition');
   }
 
@@ -2134,7 +2134,7 @@ function _buildSqlFromStringCondition(condition: Condition, prefix: string) : st
     case ExploreAnalyticsOperators.NOT_NULL:
       return `${prefix}${condition.property} is not null `;
     default:
-      logger.error(`unsupported condition ${JSON.stringify(condition)}`);
+      logger.error('unsupported condition', {condition});
       throw new Error('Unsupported condition');
   }
 
@@ -2160,7 +2160,7 @@ function _buildSqlFromNumberCondition(condition: Condition, prefix: string) : st
     case ExploreAnalyticsOperators.NOT_NULL:
       return `${prefix}${condition.property} is not null `;
     default:
-      logger.error(`unsupported condition ${JSON.stringify(condition)}`);
+      logger.error('unsupported condition', {condition});
       throw new Error('Unsupported condition');
   }
 

--- a/src/control-plane/backend/lambda/api/service/reporting.ts
+++ b/src/control-plane/backend/lambda/api/service/reporting.ts
@@ -66,8 +66,7 @@ export class ReportingService {
   async createFunnelVisual(req: any, res: any, next: any) {
 
     try {
-      logger.info('start to create funnel analysis visuals');
-      logger.info(`request: ${JSON.stringify(req.body)}`);
+      logger.info('start to create funnel analysis visuals', {request: req.body});
 
       const query = req.body;
       const checkResult = checkFunnelAnalysisParameter(query);
@@ -280,8 +279,7 @@ export class ReportingService {
 
   async createEventVisual(req: any, res: any, next: any) {
     try {
-      logger.info('start to create event analysis visuals');
-      logger.info(`request: ${JSON.stringify(req.body)}`);
+      logger.info('start to create event analysis visuals', {request: req.body});
 
       const query = req.body;
       const checkResult = checkEventAnalysisParameter(query);
@@ -453,8 +451,7 @@ export class ReportingService {
 
   async createPathAnalysisVisual(req: any, res: any, next: any) {
     try {
-      logger.info('start to create path analysis visuals');
-      logger.info(`request: ${JSON.stringify(req.body)}`);
+      logger.info('start to create path analysis visuals', {request: req.body});
 
       const query = req.body;
       const checkResult = checkPathAnalysisParameter(query);
@@ -531,8 +528,7 @@ export class ReportingService {
 
   async createRetentionVisual(req: any, res: any, next: any) {
     try {
-      logger.info('start to create retention analysis visuals');
-      logger.info(`request: ${JSON.stringify(req.body)}`);
+      logger.info('start to create retention analysis visuals', {request: req.body});
 
       const query = req.body;
       const checkResult = checkRetentionAnalysisParameter(query);
@@ -675,12 +671,12 @@ export class ReportingService {
         DataSetArn: datasetOutput?.Arn,
       });
 
-      logger.info(`created dataset arn: ${JSON.stringify(datasetOutput?.Arn)}`);
+      logger.info('created dataset:', {arn: datasetOutput?.Arn});
     }
 
     visualPropsArray[0].dataSetIdentifierDeclaration.push(...dataSetIdentifierDeclaration);
 
-    logger.info(`visualPropsArray[0] ${JSON.stringify(visualPropsArray[0])}`);
+    logger.info('Got first element of visual props', {visualPropsArray: visualPropsArray[0]});
 
     const result = await this._buildDashboard(query, visualPropsArray, quickSight,
       sheetId, resourceName, principals, dashboardCreateParameters);
@@ -718,7 +714,7 @@ export class ReportingService {
       visuals: visualPropsArray,
       dashboardDef: dashboardDef,
     });
-    logger.info(`final dashboard def: ${JSON.stringify(dashboard)}`);
+    logger.info('final dashboard def:', {dashboard});
 
     let result: CreateDashboardResult;
     if (!query.dashboardId) {
@@ -851,8 +847,7 @@ export class ReportingService {
 
   async warmup(req: any, res: any, next: any) {
     try {
-      logger.info('start to warm up reporting service');
-      logger.info(`request: ${JSON.stringify(req.body)}`);
+      logger.info('start to warm up reporting service', {request: req.body});
 
       const projectId = req.body.projectId;
       const appId = req.body.appId;
@@ -910,7 +905,10 @@ export class ReportingService {
           logger.info(`Get statement status: ${resp.Status}`);
         }
         if (resp.Status == StatusString.FAILED) {
-          logger.warn('Warmup redshift serverless with error: '+ resp.Status, JSON.stringify(resp));
+          logger.warn('Warmup redshift serverless with error,', {
+            status: resp.Status,
+            response: resp
+          });
         }
       }
 
@@ -929,8 +927,7 @@ export class ReportingService {
 
   async cleanQuickSightResources(req: any, res: any, next: any) {
     try {
-      logger.info('start to clean QuickSight temp resources');
-      logger.info(`request: ${JSON.stringify(req.body)}`);
+      logger.info('start to clean QuickSight temp resources', {request: req.body});
 
       const region = req.body.region;
       const quickSight = sdkClient.QuickSight({ region: region });

--- a/src/control-plane/backend/lambda/api/service/reporting.ts
+++ b/src/control-plane/backend/lambda/api/service/reporting.ts
@@ -66,7 +66,7 @@ export class ReportingService {
   async createFunnelVisual(req: any, res: any, next: any) {
 
     try {
-      logger.info('start to create funnel analysis visuals', {request: req.body});
+      logger.info('start to create funnel analysis visuals', { request: req.body });
 
       const query = req.body;
       const checkResult = checkFunnelAnalysisParameter(query);
@@ -279,7 +279,7 @@ export class ReportingService {
 
   async createEventVisual(req: any, res: any, next: any) {
     try {
-      logger.info('start to create event analysis visuals', {request: req.body});
+      logger.info('start to create event analysis visuals', { request: req.body });
 
       const query = req.body;
       const checkResult = checkEventAnalysisParameter(query);
@@ -451,7 +451,7 @@ export class ReportingService {
 
   async createPathAnalysisVisual(req: any, res: any, next: any) {
     try {
-      logger.info('start to create path analysis visuals', {request: req.body});
+      logger.info('start to create path analysis visuals', { request: req.body });
 
       const query = req.body;
       const checkResult = checkPathAnalysisParameter(query);
@@ -528,7 +528,7 @@ export class ReportingService {
 
   async createRetentionVisual(req: any, res: any, next: any) {
     try {
-      logger.info('start to create retention analysis visuals', {request: req.body});
+      logger.info('start to create retention analysis visuals', { request: req.body });
 
       const query = req.body;
       const checkResult = checkRetentionAnalysisParameter(query);
@@ -671,12 +671,12 @@ export class ReportingService {
         DataSetArn: datasetOutput?.Arn,
       });
 
-      logger.info('created dataset:', {arn: datasetOutput?.Arn});
+      logger.info('created dataset:', { arn: datasetOutput?.Arn });
     }
 
     visualPropsArray[0].dataSetIdentifierDeclaration.push(...dataSetIdentifierDeclaration);
 
-    logger.info('Got first element of visual props', {visualPropsArray: visualPropsArray[0]});
+    logger.info('Got first element of visual props', { visualPropsArray: visualPropsArray[0] });
 
     const result = await this._buildDashboard(query, visualPropsArray, quickSight,
       sheetId, resourceName, principals, dashboardCreateParameters);
@@ -714,7 +714,7 @@ export class ReportingService {
       visuals: visualPropsArray,
       dashboardDef: dashboardDef,
     });
-    logger.info('final dashboard def:', {dashboard});
+    logger.info('final dashboard def:', { dashboard });
 
     let result: CreateDashboardResult;
     if (!query.dashboardId) {
@@ -847,7 +847,7 @@ export class ReportingService {
 
   async warmup(req: any, res: any, next: any) {
     try {
-      logger.info('start to warm up reporting service', {request: req.body});
+      logger.info('start to warm up reporting service', { request: req.body });
 
       const projectId = req.body.projectId;
       const appId = req.body.appId;
@@ -907,7 +907,7 @@ export class ReportingService {
         if (resp.Status == StatusString.FAILED) {
           logger.warn('Warmup redshift serverless with error,', {
             status: resp.Status,
-            response: resp
+            response: resp,
           });
         }
       }
@@ -927,7 +927,7 @@ export class ReportingService {
 
   async cleanQuickSightResources(req: any, res: any, next: any) {
     try {
-      logger.info('start to clean QuickSight temp resources', {request: req.body});
+      logger.info('start to clean QuickSight temp resources', { request: req.body });
 
       const region = req.body.region;
       const quickSight = sdkClient.QuickSight({ region: region });

--- a/src/control-plane/backend/lambda/api/yarn.lock
+++ b/src/control-plane/backend/lambda/api/yarn.lock
@@ -92,7 +92,7 @@
   resolved "https://registry.yarnpkg.com/@aws-lambda-powertools/commons/-/commons-1.17.0.tgz#01c78e1c9344dcd8209160f54229269ef6981086"
   integrity sha512-eZbOUGKH+oNG49oObXucffTdUyj0XmQTnddgDWmSWLgAQ4/L60n7x80hYOTCmDqATxPoA4ADa+fzAxGx0hyaxQ==
 
-"@aws-lambda-powertools/logger@^1.8.0":
+"@aws-lambda-powertools/logger@^1.17.0":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@aws-lambda-powertools/logger/-/logger-1.17.0.tgz#b62ae91c9ea5cd79630ccd5d6efa55ce89b1f75e"
   integrity sha512-HdesKvINDebLsxEyLzjEvn4ZiO3lYnl9Ol7GuRGgSTsB4byEeRbhAghCGCPZb0CA/NaDVQleaLTTjjsJjm6I7A==
@@ -100,7 +100,7 @@
     "@aws-lambda-powertools/commons" "^1.17.0"
     lodash.merge "^4.6.2"
 
-"@aws-lambda-powertools/metrics@^1.8.0":
+"@aws-lambda-powertools/metrics@^1.17.0":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@aws-lambda-powertools/metrics/-/metrics-1.17.0.tgz#a09f1b43da07e2691172e0df83419bb7f274f4df"
   integrity sha512-Jd23c5ceXyV0rqLyd9w73cRCe8AGsKmUhov1pnE2Txj31MuXKAm2u8zApJqSaFddW9URWGiz2ETHix22tcgENw==

--- a/src/control-plane/backend/lambda/batch-insert-ddb/index.ts
+++ b/src/control-plane/backend/lambda/batch-insert-ddb/index.ts
@@ -47,7 +47,6 @@ export const handler = async (
   event: CdkCustomResourceEvent,
   context: Context,
 ): Promise<CdkCustomResourceResponse> => {
-  logger.info('Lambda is invoked', JSON.stringify(event, null, 2));
 
   const response: CdkCustomResourceResponse = {
     StackId: event.StackId,

--- a/src/control-plane/backend/lambda/sfn-action/index.ts
+++ b/src/control-plane/backend/lambda/sfn-action/index.ts
@@ -62,7 +62,6 @@ interface SfnStackCallback {
 }
 
 export const handler = async (event: SfnStackEvent, _context: any): Promise<any> => {
-  logger.info('Lambda is invoked', JSON.stringify(event, null, 2));
   if (event.Action === StackAction.CREATE) {
     return createStack(event);
   } else if (event.Action === StackAction.UPDATE) {

--- a/src/control-plane/backend/lambda/sfn-workflow/index.ts
+++ b/src/control-plane/backend/lambda/sfn-workflow/index.ts
@@ -42,7 +42,6 @@ interface SfnStackCallback {
 }
 
 export const handler = async (event: any): Promise<any> => {
-  logger.info('Lambda is invoked', JSON.stringify(event, null, 2));
   try {
     const eventData = event.MapRun? event.Data: event;
     if (eventData.Type === 'Pass') {

--- a/src/data-pipeline/lambda/emr-serverless-app/index.ts
+++ b/src/data-pipeline/lambda/emr-serverless-app/index.ts
@@ -48,7 +48,6 @@ const emrServerlessClient = new EMRServerlessClient({
 });
 
 export const handler = async (event: CloudFormationCustomResourceEvent, context: Context) => {
-  logger.info(JSON.stringify(event));
   try {
     const res = await _handler(event, context);
     logger.info('lambda returned', { res });

--- a/src/data-pipeline/lambda/partition-syncer/index.ts
+++ b/src/data-pipeline/lambda/partition-syncer/index.ts
@@ -36,7 +36,6 @@ type ScheduledEvent = EventBridgeEvent<'Scheduled Event', EmptyEventDetail>;
 type EventType = ScheduledEvent | PartitionDateEvent | CloudFormationCustomResourceEvent;
 
 export const handler = async (event: EventType, context: Context) => {
-  logger.info(JSON.stringify(event));
 
   const date = isAnPartitionDate(event) ? new Date(event.year, event.month - 1, event.day) : new Date();
 

--- a/src/ingestion-server/custom-resource/delete-ecs-cluster/index.ts
+++ b/src/ingestion-server/custom-resource/delete-ecs-cluster/index.ts
@@ -42,7 +42,6 @@ interface ResourcePropertiesType {
 type ResourceEvent = CloudFormationCustomResourceEvent;
 
 export const handler = async (event: ResourceEvent, context: Context) => {
-  logger.info(JSON.stringify(event));
   try {
     await _handler(event, context);
     logger.info('=== complete ===');

--- a/src/ingestion-server/custom-resource/update-alb-rules/index.ts
+++ b/src/ingestion-server/custom-resource/update-alb-rules/index.ts
@@ -54,7 +54,6 @@ interface HandleClickStreamSDKInput {
 type ResourceEvent = CloudFormationCustomResourceEvent;
 
 export const handler = async (event: ResourceEvent, context: Context) => {
-  logger.info(JSON.stringify(event));
   try {
     await _handler(event, context);
     logger.info('=== complete ===');

--- a/src/ingestion-server/kafka-s3-connector/custom-resource/kafka-s3-sink-connector/index.ts
+++ b/src/ingestion-server/kafka-s3-connector/custom-resource/kafka-s3-sink-connector/index.ts
@@ -86,7 +86,6 @@ interface ResourcePropertiesType {
 type ResourceEvent = CloudFormationCustomResourceEvent;
 
 export const handler = async (event: ResourceEvent, context: Context) => {
-  logger.info(JSON.stringify(event));
   const { connectorName } = getResourceName(event);
   try {
     await _handler(event, context);
@@ -102,11 +101,9 @@ export const handler = async (event: ResourceEvent, context: Context) => {
   }
 };
 
-async function _handler(event: ResourceEvent, context: Context) {
+async function _handler(event: ResourceEvent, _context: Context) {
+  logger.injectLambdaContext();
   let requestType = event.RequestType;
-  logger.info('functionName: ' + context.functionName);
-
-  logger.info('RequestType: ' + requestType);
   if (requestType == 'Create') {
     await onCreate(event);
   }
@@ -291,7 +288,7 @@ async function createConnector(event: ResourceEvent, customPluginArn: string) {
     },
     serviceExecutionRoleArn: props.s3SinkConnectorRole,
   });
-  logger.info(JSON.stringify(command));
+  logger.info('command', {command});
   let resConnectorArn;
   try {
     let res = await kafkaConnectClient.send(command);
@@ -383,7 +380,7 @@ function getConnectorConfiguration(
     };
   }
 
-  logger.info('configuration:' + JSON.stringify(configuration));
+  logger.info('Configuration:', {configuration})
 
   return configuration;
 }
@@ -391,7 +388,7 @@ function getConnectorConfiguration(
 async function onUpdate(event: CloudFormationCustomResourceEvent) {
   logger.info('onUpdate()');
   const properties = event.ResourceProperties;
-  logger.info(JSON.stringify(properties));
+  logger.info('properties', {properties})
   try {
     await updateConnector(event);
   } catch (e: any) {
@@ -466,7 +463,8 @@ async function updateConnector(event: ResourceEvent) {
 async function onDelete(event: ResourceEvent) {
   logger.info('onDelete()');
   const properties = event.ResourceProperties;
-  logger.info(JSON.stringify(properties));
+
+  logger.info('properties', {properties})
 
   await deleteConnector(event);
   await deletePlugin(event);

--- a/src/ingestion-server/kafka-s3-connector/custom-resource/kafka-s3-sink-connector/index.ts
+++ b/src/ingestion-server/kafka-s3-connector/custom-resource/kafka-s3-sink-connector/index.ts
@@ -288,7 +288,7 @@ async function createConnector(event: ResourceEvent, customPluginArn: string) {
     },
     serviceExecutionRoleArn: props.s3SinkConnectorRole,
   });
-  logger.info('command', {command});
+  logger.info('command', { command });
   let resConnectorArn;
   try {
     let res = await kafkaConnectClient.send(command);
@@ -380,7 +380,7 @@ function getConnectorConfiguration(
     };
   }
 
-  logger.info('Configuration:', {configuration})
+  logger.info('Configuration:', { configuration });
 
   return configuration;
 }
@@ -388,7 +388,7 @@ function getConnectorConfiguration(
 async function onUpdate(event: CloudFormationCustomResourceEvent) {
   logger.info('onUpdate()');
   const properties = event.ResourceProperties;
-  logger.info('properties', {properties})
+  logger.info('properties', { properties });
   try {
     await updateConnector(event);
   } catch (e: any) {
@@ -464,7 +464,7 @@ async function onDelete(event: ResourceEvent) {
   logger.info('onDelete()');
   const properties = event.ResourceProperties;
 
-  logger.info('properties', {properties})
+  logger.info('properties', { properties });
 
   await deleteConnector(event);
   await deletePlugin(event);

--- a/src/metrics/custom-resource/get-interval/index.ts
+++ b/src/metrics/custom-resource/get-interval/index.ts
@@ -15,7 +15,6 @@ import parser from 'cron-parser';
 import { logger } from '../../../common/powertools';
 
 export const handler: CdkCustomResourceHandler = async (event) => {
-  logger.info(JSON.stringify(event));
   try {
     return await _handler(event);
   } catch (e) {

--- a/src/metrics/custom-resource/put-dashboard/index.ts
+++ b/src/metrics/custom-resource/put-dashboard/index.ts
@@ -116,7 +116,7 @@ async function _handler(
     dashboardName: dashboardName,
     proejctId: projectId,
     columnNumber: columnNumber,
-    snsTopicArn: snsTopicArn
+    snsTopicArn: snsTopicArn,
 
   });
 

--- a/src/metrics/custom-resource/put-dashboard/index.ts
+++ b/src/metrics/custom-resource/put-dashboard/index.ts
@@ -94,7 +94,6 @@ export const handler = async (
   event: CloudFormationCustomResourceEvent | SSMEventType,
   context: Context,
 ) => {
-  logger.info(JSON.stringify(event));
   try {
     return await _handler(event, context);
   } catch (e: any) {
@@ -105,21 +104,21 @@ export const handler = async (
 
 async function _handler(
   event: CloudFormationCustomResourceEvent | SSMEventType,
-  context: Context,
+  _context: Context,
 ) {
-
+  logger.injectLambdaContext();
   let requestType = (event as CloudFormationCustomResourceEvent).RequestType;
   let parameterName = (event as SSMEventType).detail?.name;
+  logger.info('Inputs: ', {
+    requestType: requestType,
+    parameterName: parameterName,
+    region: region,
+    dashboardName: dashboardName,
+    proejctId: projectId,
+    columnNumber: columnNumber,
+    snsTopicArn: snsTopicArn
 
-  logger.info('requestType: ' + requestType);
-  logger.info('parameterName: ' + parameterName);
-
-  logger.info('functionName: ' + context.functionName);
-  logger.info('region: ' + region);
-  logger.info('dashboardName: ' + dashboardName);
-  logger.info('projectId: ' + projectId);
-  logger.info('columnNumber: ' + columnNumber);
-  logger.info('snsTopicArn: ' + snsTopicArn);
+  });
 
   if (requestType == 'Delete') {
     logger.info('ignore requestType ' + requestType);

--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -115,8 +115,8 @@ const _onCreate = async (quickSight: QuickSight, awsAccountId: string, sharePrin
       const dashboardDefProps: QuickSightDashboardDefProps = props.dashboardDefProps;
       logger.info('creating quicksight dashboard with params', {
         schemaName: schemaName,
-        dashboardDefProps: dashboardDefProps
-      })
+        dashboardDefProps: dashboardDefProps,
+      });
 
       const dashboard = await createQuickSightDashboard(quickSight, awsAccountId, sharePrincipalArn, ownerPrincipalArn,
         schemaName,
@@ -147,8 +147,8 @@ const _onDelete = async (quickSight: QuickSight, awsAccountId: string, event: Cl
 
       logger.info('deleting quicksight dashboard with params', {
         schemaName: schemaName,
-        dashboardDefProps: dashboardDefProps
-      })
+        dashboardDefProps: dashboardDefProps,
+      });
 
       const dashboard = await deleteQuickSightDashboard(quickSight, awsAccountId, schemaName, dashboardDefProps);
       logger.info(`delete dashboard: ${dashboard?.DashboardId}`);
@@ -179,8 +179,8 @@ const _onUpdate = async (quickSight: QuickSight, awsAccountId: string, sharePrin
     propsSchemas: props.schemas,
     oldPropsSchemas: oldProps.schemas,
     databaseSchemanameArray: databaseSchemaNameArray,
-    oldDatabaseSchemaNameArray: oldDatabaseSchemaNameArray
-  })
+    oldDatabaseSchemaNameArray: oldDatabaseSchemaNameArray,
+  });
 
   const updateSchemas = databaseSchemaNameArray.filter(item => oldDatabaseSchemaNameArray.includes(item));
   const deleteSchemas = oldDatabaseSchemaNameArray.filter(item => !databaseSchemaNameArray.includes(item));
@@ -189,8 +189,8 @@ const _onUpdate = async (quickSight: QuickSight, awsAccountId: string, sharePrin
   logger.info('schemas to process', {
     updateSchemas: updateSchemas,
     deleteSchemas: deleteSchemas,
-    createSchemas: createSchemas
-  })
+    createSchemas: createSchemas,
+  });
 
   for (const schemaName of updateSchemas) {
     const dashboardDefProps: QuickSightDashboardDefProps = props.dashboardDefProps;
@@ -199,8 +199,8 @@ const _onUpdate = async (quickSight: QuickSight, awsAccountId: string, sharePrin
     logger.info('Updating schema', {
       schemaName: schemaName,
       dashboardDefProps: dashboardDefProps,
-      oldDashboardDefProps: oldDashboardDefProps
-    })
+      oldDashboardDefProps: oldDashboardDefProps,
+    });
 
     const dashboard = await updateQuickSightDashboard(quickSight, awsAccountId,
       schemaName,
@@ -222,8 +222,8 @@ const _onUpdate = async (quickSight: QuickSight, awsAccountId: string, sharePrin
     logger.info('Creating schema', {
       schemaName: schemaName,
       dashboardDefProps: dashboardDefProps,
-      oldDashboardDefProps: dashboard?.DashboardId
-    })
+      oldDashboardDefProps: dashboard?.DashboardId,
+    });
 
     dashboards.push({
       appId: schemaName,
@@ -241,8 +241,8 @@ const _onUpdate = async (quickSight: QuickSight, awsAccountId: string, sharePrin
     logger.info('Deleting schema', {
       schemaName: schemaName,
       dashboardDefProps: dashboardDefProps,
-      oldDashboardDefProps: dashboard?.DashboardId
-    })
+      oldDashboardDefProps: dashboard?.DashboardId,
+    });
 
   };
 
@@ -388,7 +388,7 @@ const updateQuickSightDashboard = async (quickSight: QuickSight,
 
   logger.info('Delete and update dataset and table names', {
     needDeleteDataSets: needDeleteDataSets,
-    needUpdateDataSetTableNames: needUpdateDataSetTableNames
+    needUpdateDataSetTableNames: needUpdateDataSetTableNames,
   });
 
   for ( const dataSet of dataSets) {
@@ -417,8 +417,8 @@ const updateQuickSightDashboard = async (quickSight: QuickSight,
   logger.info('template info', {
     templateId: dashboardDef.templateId,
     templateArn: dashboardDef.templateArn,
-    latestVersion: latestVersion
-  })
+    latestVersion: latestVersion,
+  });
 
   const sourceEntity = {
     SourceTemplate: {
@@ -564,11 +564,11 @@ const createDataSet = async (quickSight: QuickSight, commonParams: ResourceCommo
         DisableUseAsImportedSource: false,
       },
     };
-    logger.info('dataset params', {datasetParams});
+    logger.info('dataset params', { datasetParams });
     const dataset = await quickSight.createDataSet(datasetParams);
 
     await waitForDataSetCreateCompleted(quickSight, commonParams.awsAccountId, datasetId);
-    logger.info('create dataset finished', {datasetId});
+    logger.info('create dataset finished', { datasetId });
 
     return dataset;
 
@@ -601,7 +601,7 @@ const createAnalysis = async (quickSight: QuickSight, commonParams: ResourceComm
       SourceEntity: sourceEntity,
     });
     await waitForAnalysisChangeCompleted(quickSight, commonParams.awsAccountId, analysisId);
-    logger.info('Create analysis finished', {Id: analysisId});
+    logger.info('Create analysis finished', { Id: analysisId });
 
     return analysis;
 
@@ -925,7 +925,7 @@ const updateDashboard = async (quickSight: QuickSight, commonParams: ResourceCom
     const identifier = buildDashBoardId(commonParams.databaseName, commonParams.schema);
     const dashboardId = identifier.id;
 
-    logger.info('start to update dashboard', {sourceEntity});
+    logger.info('start to update dashboard', { sourceEntity });
     const dashboard = await quickSight.updateDashboard({
       AwsAccountId: commonParams.awsAccountId,
       DashboardId: dashboardId,
@@ -934,7 +934,7 @@ const updateDashboard = async (quickSight: QuickSight, commonParams: ResourceCom
       SourceEntity: sourceEntity,
 
     });
-    logger.info('update dashboard finished.', {id: dashboardId});
+    logger.info('update dashboard finished.', { id: dashboardId });
 
     await waitForDashboardChangeCompleted(quickSight, commonParams.awsAccountId, dashboardId);
 

--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -113,7 +113,7 @@ const _onCreate = async (quickSight: QuickSight, awsAccountId: string, sharePrin
   if ( databaseSchemaNames.trim().length > 0 ) {
     for (const schemaName of databaseSchemaNames.split(',')) {
       const dashboardDefProps: QuickSightDashboardDefProps = props.dashboardDefProps;
-      logger.info('creating quicksigh dashboard with params', {
+      logger.info('creating quicksight dashboard with params', {
         schemaName: schemaName,
         dashboardDefProps: dashboardDefProps
       })

--- a/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
+++ b/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
@@ -478,11 +478,11 @@ describe('DataAnalyticsRedshiftStack serverless parameter test', () => {
       },
     );
 
-    logger.info('templateParams:', {templateParams});
+    logger.info('templateParams:', { templateParams });
     for (const ep of exceptedParams) {
       logger.info('input', {
         ep: ep,
-        inludesInTemplate: templateParams.includes(ep)
+        inludesInTemplate: templateParams.includes(ep),
       });
       expect(templateParams.includes(ep)).toBeTruthy();
     }
@@ -592,7 +592,7 @@ describe('DataAnalyticsRedshiftStack serverless parameter test', () => {
 
   test('Should has Rules for existing RedshiftServerless', () => {
     const rule = template.toJSON().Rules.ExistingRedshiftServerlessParameters;
-    logger.info('Params', {ExistingRedshiftServerlessParameters: rule.Assertions[0].Assert[CFN_FN.AND]})
+    logger.info('Params', { ExistingRedshiftServerlessParameters: rule.Assertions[0].Assert[CFN_FN.AND] });
     for (const e of rule.Assertions[0].Assert[CFN_FN.AND]) {
       expect(e[CFN_FN.NOT][0][CFN_FN.EQUALS][0].Ref === 'RedshiftServerlessWorkgroupName' ||
         e[CFN_FN.NOT][0][CFN_FN.EQUALS][0].Ref === 'RedshiftServerlessIAMRole').toBeTruthy();

--- a/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
+++ b/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
@@ -478,9 +478,12 @@ describe('DataAnalyticsRedshiftStack serverless parameter test', () => {
       },
     );
 
-    logger.info(`templateParams: ${JSON.stringify(templateParams)}`);
+    logger.info('templateParams:', {templateParams});
     for (const ep of exceptedParams) {
-      logger.info(`ep: ${ep}, ${templateParams.includes(ep)}`);
+      logger.info('input', {
+        ep: ep,
+        inludesInTemplate: templateParams.includes(ep)
+      });
       expect(templateParams.includes(ep)).toBeTruthy();
     }
     expect(templateParams.length).toEqual(exceptedParams.length + 1);
@@ -589,7 +592,7 @@ describe('DataAnalyticsRedshiftStack serverless parameter test', () => {
 
   test('Should has Rules for existing RedshiftServerless', () => {
     const rule = template.toJSON().Rules.ExistingRedshiftServerlessParameters;
-    logger.info(`ExistingRedshiftServerlessParameters:${JSON.stringify(rule.Assertions[0].Assert[CFN_FN.AND])}`);
+    logger.info('Params', {ExistingRedshiftServerlessParameters: rule.Assertions[0].Assert[CFN_FN.AND]})
     for (const e of rule.Assertions[0].Assert[CFN_FN.AND]) {
       expect(e[CFN_FN.NOT][0][CFN_FN.EQUALS][0].Ref === 'RedshiftServerlessWorkgroupName' ||
         e[CFN_FN.NOT][0][CFN_FN.EQUALS][0].Ref === 'RedshiftServerlessIAMRole').toBeTruthy();

--- a/yarn.lock
+++ b/yarn.lock
@@ -127,7 +127,7 @@
   resolved "https://registry.yarnpkg.com/@aws-lambda-powertools/commons/-/commons-1.17.0.tgz#01c78e1c9344dcd8209160f54229269ef6981086"
   integrity sha512-eZbOUGKH+oNG49oObXucffTdUyj0XmQTnddgDWmSWLgAQ4/L60n7x80hYOTCmDqATxPoA4ADa+fzAxGx0hyaxQ==
 
-"@aws-lambda-powertools/logger@^1.8.0":
+"@aws-lambda-powertools/logger@^1.17.0":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@aws-lambda-powertools/logger/-/logger-1.17.0.tgz#b62ae91c9ea5cd79630ccd5d6efa55ce89b1f75e"
   integrity sha512-HdesKvINDebLsxEyLzjEvn4ZiO3lYnl9Ol7GuRGgSTsB4byEeRbhAghCGCPZb0CA/NaDVQleaLTTjjsJjm6I7A==
@@ -135,7 +135,7 @@
     "@aws-lambda-powertools/commons" "^1.17.0"
     lodash.merge "^4.6.2"
 
-"@aws-lambda-powertools/metrics@^1.8.0":
+"@aws-lambda-powertools/metrics@^1.17.0":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@aws-lambda-powertools/metrics/-/metrics-1.17.0.tgz#a09f1b43da07e2691172e0df83419bb7f274f4df"
   integrity sha512-Jd23c5ceXyV0rqLyd9w73cRCe8AGsKmUhov1pnE2Txj31MuXKAm2u8zApJqSaFddW9URWGiz2ETHix22tcgENw==


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary
In this PR I have made several changes to logging statements to improve Powertools logger usage in the project. As described in the issue, many statements use `JSON.stringify()` which is not necessary when using Powertools, you can simply pass an object as an extra input. Further, I have combined multiple logging statements to a structured logging statement. Three consecutive statements to log one variable in each can be combined to a single log statement by passing an object. Finally, I have removed log event statement in all lambda handler, because we have already set `POWERTOOLS_LOGGER_LOG_EVENT` to `true` with will automatically capture incoming events in the logs. 

This PR closes #534 . 

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend