### PR TITLE
docs: add notes for ingestion auth client example

### DIFF
--- a/docs/en/pipeline-mgmt/ingestion/configure-ingestion-endpoint.md
+++ b/docs/en/pipeline-mgmt/ingestion/configure-ingestion-endpoint.md
@@ -59,6 +59,9 @@ The solution creates a web service as an ingestion endpoint to collect data sent
         ```
       **Note**: In the OIDC provider, you need to add `https://<ingestion server endpoint>/oauth2/idpresponse` to "Allowed callback URLs"
 
+        **Note**: If you need to obtain the authentication token directly without inputting credential(username/password) manually, you can refer to [alb headless authentication client code][alb-headless-authentication-client] to setup your client to obtain the authentication token automatically.
+
+
     * Access logs: ALB supports delivering detailed logs of all requests it receives. If you enable this option, the solution will automatically enable access logs for you and store the logs into the S3 bucket you selected in previous step.
 
         !!! tip "Tip"
@@ -139,3 +142,4 @@ The solution creates a web service as an ingestion endpoint to collect data sent
 -->
 
 [alb-permission]: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html
+[alb-headless-authentication-client]: https://github.com/aws-samples/alb-headless-authentication-client

--- a/docs/zh/pipeline-mgmt/ingestion/configure-ingestion-endpoint.md
+++ b/docs/zh/pipeline-mgmt/ingestion/configure-ingestion-endpoint.md
@@ -73,6 +73,8 @@
         ```
       **注意**：在 OIDC 提供程序中，您需要将 `https://<ingestion server endpoint>/oauth2/idpresponse` 添加到“允许回调 URL”。
 
+        **注意**：如果您需要在不手动输入凭据（用户名/密码）的情况下直接获取身份验证令牌，您可以参考[ALB无头身份验证客户端代码][alb-headless-authentication-client]来设置您的客户端以自动获取身份验证令牌。   
+
     * 访问日志：ALB 支持提供其接收的所有请求的详细日志。如果您启用此选项，则解决方案将自动为您启用访问日志，并将日志存储在您之前选择的 S3 存储桶中。
 
         !!! tip "提示"
@@ -153,3 +155,4 @@
 -->
 
 [alb-permission]: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html
+[alb-headless-authentication-client]: https://github.com/aws-samples/alb-headless-authentication-client


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

update doc for ingestion auth example

## Implementation highlights

update doc for ingestion auth example
<img width="1265" alt="auth-2" src="https://github.com/awslabs/clickstream-analytics-on-aws/assets/8953013/696710df-3d74-4fdb-aaa1-89603c683652">
<img width="1257" alt="auth-1" src="https://github.com/awslabs/clickstream-analytics-on-aws/assets/8953013/9b339703-80d5-4043-9bc9-cef67d22d54b">



## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend