### PR TITLE
fix: QuickSight dataset parameter default value

### DIFF
--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -479,7 +479,7 @@ const buildDataSetParameter = function (dateTimeDatasetParameter: DateTimeParame
           ValueType: ParameterValueType.SINGLE_VALUED,
           TimeGranularity: param.timeGranularity,
           DefaultValues: {
-            StaticValues: [new Date()],
+            StaticValues: [new Date(param.defaultValue)],
           },
         },
       });

--- a/src/reporting/private/dashboard.ts
+++ b/src/reporting/private/dashboard.ts
@@ -59,6 +59,7 @@ export interface ColumnGroupsProps {
 export interface DateTimeParameter {
   name: string;
   timeGranularity: TimeGranularity;
+  defaultValue: Date[];
 };
 
 export interface DataSetProps {

--- a/src/reporting/private/dashboard.ts
+++ b/src/reporting/private/dashboard.ts
@@ -59,7 +59,7 @@ export interface ColumnGroupsProps {
 export interface DateTimeParameter {
   name: string;
   timeGranularity: TimeGranularity;
-  defaultValue: Date[];
+  defaultValue: Date;
 };
 
 export interface DataSetProps {

--- a/src/reporting/quicksight-custom-resource.ts
+++ b/src/reporting/quicksight-custom-resource.ts
@@ -146,12 +146,12 @@ export function createQuicksightCustomResource(
           {
             name: 'startDate',
             timeGranularity: TimeGranularity.DAY,
-            defaultValue: [tenYearsAgo],
+            defaultValue: tenYearsAgo,
           },
           {
             name: 'endDate',
             timeGranularity: TimeGranularity.DAY,
-            defaultValue: [futureDate],
+            defaultValue: futureDate,
           },
         ],
         projectedColumns: [
@@ -198,12 +198,12 @@ export function createQuicksightCustomResource(
           {
             name: 'startDate',
             timeGranularity: TimeGranularity.DAY,
-            defaultValue: [tenYearsAgo],
+            defaultValue: tenYearsAgo,
           },
           {
             name: 'endDate',
             timeGranularity: TimeGranularity.DAY,
-            defaultValue: [futureDate],
+            defaultValue: futureDate,
           },
         ],
         tagColumnOperations: [
@@ -279,12 +279,12 @@ export function createQuicksightCustomResource(
           {
             name: 'startDate',
             timeGranularity: TimeGranularity.DAY,
-            defaultValue: [tenYearsAgo],
+            defaultValue: tenYearsAgo,
           },
           {
             name: 'endDate',
             timeGranularity: TimeGranularity.DAY,
-            defaultValue: [futureDate],
+            defaultValue: futureDate,
           },
         ],
         projectedColumns: [
@@ -323,12 +323,12 @@ export function createQuicksightCustomResource(
           {
             name: 'startDate',
             timeGranularity: TimeGranularity.DAY,
-            defaultValue: [tenYearsAgo],
+            defaultValue: tenYearsAgo,
           },
           {
             name: 'endDate',
             timeGranularity: TimeGranularity.DAY,
-            defaultValue: [futureDate],
+            defaultValue: futureDate,
           },
         ],
         projectedColumns: [
@@ -356,12 +356,12 @@ export function createQuicksightCustomResource(
           {
             name: 'startDate',
             timeGranularity: TimeGranularity.DAY,
-            defaultValue: [tenYearsAgo],
+            defaultValue: tenYearsAgo,
           },
           {
             name: 'endDate',
             timeGranularity: TimeGranularity.DAY,
-            defaultValue: [futureDate],
+            defaultValue: futureDate,
           },
         ],
         projectedColumns: [
@@ -379,12 +379,12 @@ export function createQuicksightCustomResource(
           {
             name: 'startDate',
             timeGranularity: TimeGranularity.DAY,
-            defaultValue: [tenYearsAgo],
+            defaultValue: tenYearsAgo,
           },
           {
             name: 'endDate',
             timeGranularity: TimeGranularity.DAY,
-            defaultValue: [futureDate],
+            defaultValue: futureDate,
           },
         ],
         projectedColumns: [

--- a/src/reporting/quicksight-custom-resource.ts
+++ b/src/reporting/quicksight-custom-resource.ts
@@ -69,6 +69,12 @@ export function createQuicksightCustomResource(
     },
   );
 
+  const currentDate = new Date();
+  const tenYearsAgo = new Date(currentDate);
+  tenYearsAgo.setFullYear(currentDate.getFullYear() - 10);
+  const futureDate = new Date(currentDate);
+  futureDate.setFullYear(currentDate.getFullYear() + 10);
+
   const databaseName = props.databaseName;
   const dashboardDefProps: QuickSightDashboardDefProps = {
     analysisName: 'Clickstream Analysis',
@@ -140,10 +146,12 @@ export function createQuicksightCustomResource(
           {
             name: 'startDate',
             timeGranularity: TimeGranularity.DAY,
+            defaultValue: [tenYearsAgo],
           },
           {
             name: 'endDate',
             timeGranularity: TimeGranularity.DAY,
+            defaultValue: [futureDate],
           },
         ],
         projectedColumns: [
@@ -190,10 +198,12 @@ export function createQuicksightCustomResource(
           {
             name: 'startDate',
             timeGranularity: TimeGranularity.DAY,
+            defaultValue: [tenYearsAgo],
           },
           {
             name: 'endDate',
             timeGranularity: TimeGranularity.DAY,
+            defaultValue: [futureDate],
           },
         ],
         tagColumnOperations: [
@@ -269,10 +279,12 @@ export function createQuicksightCustomResource(
           {
             name: 'startDate',
             timeGranularity: TimeGranularity.DAY,
+            defaultValue: [tenYearsAgo],
           },
           {
             name: 'endDate',
             timeGranularity: TimeGranularity.DAY,
+            defaultValue: [futureDate],
           },
         ],
         projectedColumns: [
@@ -311,10 +323,12 @@ export function createQuicksightCustomResource(
           {
             name: 'startDate',
             timeGranularity: TimeGranularity.DAY,
+            defaultValue: [tenYearsAgo],
           },
           {
             name: 'endDate',
             timeGranularity: TimeGranularity.DAY,
+            defaultValue: [futureDate],
           },
         ],
         projectedColumns: [
@@ -342,10 +356,12 @@ export function createQuicksightCustomResource(
           {
             name: 'startDate',
             timeGranularity: TimeGranularity.DAY,
+            defaultValue: [tenYearsAgo],
           },
           {
             name: 'endDate',
             timeGranularity: TimeGranularity.DAY,
+            defaultValue: [futureDate],
           },
         ],
         projectedColumns: [
@@ -363,10 +379,12 @@ export function createQuicksightCustomResource(
           {
             name: 'startDate',
             timeGranularity: TimeGranularity.DAY,
+            defaultValue: [tenYearsAgo],
           },
           {
             name: 'endDate',
             timeGranularity: TimeGranularity.DAY,
+            defaultValue: [futureDate],
           },
         ],
         projectedColumns: [

--- a/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
+++ b/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
@@ -705,7 +705,6 @@ describe('DataReportingQuickSightStack resource test', () => {
     },
   }, 1);
 
-
   template.resourcePropertiesCountIs('AWS::QuickSight::DataSource', {
     AwsAccountId: {
       Ref: 'AWS::AccountId',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [x] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend