### PR TITLE
chore: specify Lambda json log, log level and architecture

### DIFF
--- a/src/analytics/parameter.ts
+++ b/src/analytics/parameter.ts
@@ -14,7 +14,6 @@
 import { join } from 'path';
 import { CfnParameter, CfnResource, CfnRule, CustomResource, Duration, Fn } from 'aws-cdk-lib';
 import { IVpc, SubnetSelection } from 'aws-cdk-lib/aws-ec2';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Bucket, IBucket } from 'aws-cdk-lib/aws-s3';
 import { Provider } from 'aws-cdk-lib/custom-resources';
@@ -34,7 +33,6 @@ import {
 import { createLambdaRole } from '../common/lambda';
 import { REDSHIFT_MODE } from '../common/model';
 import { Parameters, SubnetParameterType } from '../common/parameters';
-import { POWERTOOLS_ENVS } from '../common/powertools';
 import { getExistVpc } from '../common/vpc-utils';
 import { SolutionNodejsFunction } from '../private/function';
 
@@ -867,7 +865,6 @@ function getSourcePrefix(scope: Construct, odsEventPrefix: string, projectId: st
 
   const lambdaRootPath = __dirname + '/lambdas/custom-resource';
   const fn = new SolutionNodejsFunction(scope, 'GetSourcePrefixCustomerResourceFn', {
-    runtime: Runtime.NODEJS_18_X,
     entry: join(
       lambdaRootPath,
       'get-source-prefix.ts',
@@ -877,9 +874,6 @@ function getSourcePrefix(scope: Construct, odsEventPrefix: string, projectId: st
     timeout: Duration.minutes(1),
     logRetention: RetentionDays.ONE_WEEK,
     role,
-    environment: {
-      ... POWERTOOLS_ENVS,
-    },
   });
   const provider = new Provider(
     scope,

--- a/src/analytics/private/app-schema.ts
+++ b/src/analytics/private/app-schema.ts
@@ -24,7 +24,6 @@ import { reportingViewsDef, schemaDefs } from './sql-def';
 import { CUSTOM_RESOURCE_RESPONSE_REDSHIFT_BI_USER_NAME } from '../../common/constant';
 import { createLambdaRole } from '../../common/lambda';
 import { attachListTagsPolicyForFunction } from '../../common/lambda/tags';
-import { POWERTOOLS_ENVS } from '../../common/powertools';
 import { SolutionNodejsFunction } from '../../private/function';
 import { RedshiftOdsTables } from '../analytics-on-redshift';
 
@@ -125,7 +124,6 @@ export class ApplicationSchemas extends Construct {
     });
 
     const fn = new SolutionNodejsFunction(this, 'CreateSchemaForApplicationsFn', {
-      runtime: Runtime.NODEJS_18_X,
       entry: join(
         lambdaRootPath,
         'create-schemas.ts',
@@ -137,9 +135,6 @@ export class ApplicationSchemas extends Construct {
       logRetention: RetentionDays.ONE_WEEK,
       role: createLambdaRole(this, 'CreateApplicationSchemaRole', false,
         [writeSecretPolicy]),
-      environment: {
-        ... POWERTOOLS_ENVS,
-      },
       layers: [sqlLayer],
     });
 

--- a/src/analytics/private/clear-expired-events-workflow.ts
+++ b/src/analytics/private/clear-expired-events-workflow.ts
@@ -17,7 +17,7 @@ import { ISecurityGroup, IVpc, SubnetSelection } from 'aws-cdk-lib/aws-ec2';
 import { Rule, Schedule } from 'aws-cdk-lib/aws-events';
 import { SfnStateMachine } from 'aws-cdk-lib/aws-events-targets';
 import { IRole } from 'aws-cdk-lib/aws-iam';
-import { IFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { IFunction } from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { StateMachine, LogLevel, IStateMachine, TaskInput, Wait, WaitTime, Succeed, Fail, Choice, Map, Condition, Pass, DefinitionBody } from 'aws-cdk-lib/aws-stepfunctions';
 import { LambdaInvoke } from 'aws-cdk-lib/aws-stepfunctions-tasks';
@@ -26,7 +26,6 @@ import { ClearExpiredEventsWorkflowData, ExistingRedshiftServerlessCustomProps, 
 import { createLambdaRole } from '../../common/lambda';
 import { createLogGroup } from '../../common/logs';
 import { REDSHIFT_MODE } from '../../common/model';
-import { POWERTOOLS_ENVS } from '../../common/powertools';
 import { SolutionNodejsFunction } from '../../private/function';
 
 export interface ClearExpiredEventsWorkflowProps {
@@ -158,7 +157,6 @@ export class ClearExpiredEventsWorkflow extends Construct {
     const fnSG = props.securityGroupForLambda;
 
     const fn = new SolutionNodejsFunction(this, 'ClearExpiredEventsFn', {
-      runtime: Runtime.NODEJS_18_X,
       entry: join(
         this.lambdaRootPath,
         'clear-expired-events.ts',
@@ -174,8 +172,8 @@ export class ClearExpiredEventsWorkflow extends Construct {
       environment: {
         ... this.toRedshiftEnvVariables(props),
         REDSHIFT_DATA_API_ROLE: props.dataAPIRole.roleArn,
-        ... POWERTOOLS_ENVS,
       },
+      applicationLogLevel: 'WARN',
     });
     props.dataAPIRole.grantAssumeRole(fn.grantPrincipal);
     return fn;
@@ -197,7 +195,6 @@ export class ClearExpiredEventsWorkflow extends Construct {
     const fnSG = props.securityGroupForLambda;
 
     const fn = new SolutionNodejsFunction(this, 'CheckClearJobStatusFn', {
-      runtime: Runtime.NODEJS_18_X,
       entry: join(
         this.lambdaRootPath,
         'check-clear-status.ts',
@@ -213,8 +210,8 @@ export class ClearExpiredEventsWorkflow extends Construct {
       environment: {
         ... this.toRedshiftEnvVariables(props),
         REDSHIFT_DATA_API_ROLE: props.dataAPIRole.roleArn,
-        ... POWERTOOLS_ENVS,
       },
+      applicationLogLevel: 'WARN',
     });
 
     props.dataAPIRole.grantAssumeRole(fn.grantPrincipal);

--- a/src/analytics/private/redshift-associate-iam-role.ts
+++ b/src/analytics/private/redshift-associate-iam-role.ts
@@ -15,14 +15,12 @@ import { join } from 'path';
 import { Duration, Arn, Stack, ArnFormat, Token, CfnCondition, CfnResource, CustomResource } from 'aws-cdk-lib';
 
 import { IRole, Policy, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 import { getOrCreateNoWorkgroupIdCondition, getOrCreateWithWorkgroupIdCondition, getOrCreateNoNamespaceIdCondition, getOrCreateWithNamespaceIdCondition } from './condition';
 import { AssociateIAMRoleToRedshift, ExistingRedshiftServerlessProps, ProvisionedRedshiftProps } from './model';
 import { createLambdaRole } from '../../common/lambda';
-import { POWERTOOLS_ENVS } from '../../common/powertools';
 import { SolutionNodejsFunction } from '../../private/function';
 
 
@@ -43,7 +41,6 @@ export function createCustomResourceAssociateIAMRole(scope: Construct, props: Re
   });
 
   const fn = new SolutionNodejsFunction(scope, 'AssociateIAMRoleToRedshiftFn', {
-    runtime: Runtime.NODEJS_18_X,
     entry: join(
       __dirname + '/../lambdas/custom-resource',
       'redshift-associate-iam-role.ts',
@@ -61,9 +58,6 @@ export function createCustomResourceAssociateIAMRole(scope: Construct, props: Re
         resources: ['*'], // have to use wildcard for keeping existing associated roles
       }),
     ]),
-    environment: {
-      ...POWERTOOLS_ENVS,
-    },
   });
 
   const provider = new Provider(

--- a/src/analytics/private/redshift-serverless.ts
+++ b/src/analytics/private/redshift-serverless.ts
@@ -14,7 +14,7 @@
 import { join } from 'path';
 import { Arn, ArnFormat, Aws, CustomResource, Duration, Fn, Stack } from 'aws-cdk-lib';
 import { AccountPrincipal, IRole, PolicyDocument, PolicyStatement, Role } from 'aws-cdk-lib/aws-iam';
-import { IFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { IFunction } from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { CfnWorkgroup } from 'aws-cdk-lib/aws-redshiftserverless';
 import { Provider } from 'aws-cdk-lib/custom-resources';
@@ -24,7 +24,6 @@ import { addCfnNagForCustomResourceProvider, addCfnNagToStack, ruleRolePolicyWit
 import { createLambdaRole } from '../../common/lambda';
 import { attachListTagsPolicyForFunction } from '../../common/lambda/tags';
 import { BuiltInTagKeys } from '../../common/model';
-import { POWERTOOLS_ENVS } from '../../common/powertools';
 import { SolutionInfo } from '../../common/solution-info';
 import { SolutionNodejsFunction } from '../../private/function';
 
@@ -224,7 +223,6 @@ export class RedshiftServerless extends Construct {
   createCreateMappingUserFunction() {
     const lambdaRootPath = __dirname + '/../lambdas/custom-resource';
     const fn = new SolutionNodejsFunction(this, 'CreateUserFn', {
-      runtime: Runtime.NODEJS_18_X,
       entry: join(
         lambdaRootPath,
         'create-redshift-user.ts',
@@ -235,9 +233,6 @@ export class RedshiftServerless extends Construct {
       timeout: Duration.minutes(3),
       logRetention: RetentionDays.ONE_WEEK,
       role: createLambdaRole(this, 'CreateRedshiftUserRole', false, []),
-      environment: {
-        ... POWERTOOLS_ENVS,
-      },
     });
     return fn;
   }
@@ -274,7 +269,6 @@ export class RedshiftServerless extends Construct {
   private createCreateNamespaceFunction(): IFunction {
     const lambdaRootPath = __dirname + '/../lambdas/custom-resource';
     const fn = new SolutionNodejsFunction(this, 'CreateNamespaceFn', {
-      runtime: Runtime.NODEJS_18_X,
       entry: join(
         lambdaRootPath,
         'create-redshift-namespace.ts',
@@ -285,9 +279,6 @@ export class RedshiftServerless extends Construct {
       timeout: Duration.minutes(3),
       logRetention: RetentionDays.ONE_WEEK,
       role: createLambdaRole(this, 'CreateRedshiftNamespaceRole', false, []),
-      environment: {
-        ... POWERTOOLS_ENVS,
-      },
     });
     return fn;
   }

--- a/src/common/lambda.ts
+++ b/src/common/lambda.ts
@@ -20,12 +20,9 @@ import {
   ServicePrincipal,
   PrincipalBase,
 } from 'aws-cdk-lib/aws-iam';
-import { IFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { IFunction } from 'aws-cdk-lib/aws-lambda';
 import { IConstruct } from 'constructs';
 import { addCfnNagSuppressRules } from './cfn-nag';
-
-
-export const LAMBDA_NODEJS_RUNTIME = Runtime.NODEJS_18_X;
 
 export function cloudWatchSendLogs(id: string, func: IFunction): IFunction {
   if (func.role !== undefined) {

--- a/src/control-plane/alb-lambda-portal.ts
+++ b/src/control-plane/alb-lambda-portal.ts
@@ -58,7 +58,6 @@ import { Constant } from './private/constant';
 import { LogProps, setAccessLogForApplicationLoadBalancer } from '../common/alb';
 import { addCfnNagSuppressRules, rulesToSuppressForLambdaVPCAndReservedConcurrentExecutions } from '../common/cfn-nag';
 import { cloudWatchSendLogs, createENI } from '../common/lambda';
-import { POWERTOOLS_ENVS } from '../common/powertools';
 
 export interface RouteProps {
   readonly routePath: string;
@@ -399,9 +398,6 @@ export class ApplicationLoadBalancerLambdaPortal extends Construct {
       vpcSubnets: props.networkProps.subnets,
       securityGroups: [frontendLambdaSG],
       architecture: Architecture.X86_64,
-      environment: {
-        ...POWERTOOLS_ENVS,
-      },
     });
 
 

--- a/src/control-plane/backend/batch-insert-ddb-custom-resource-construct.ts
+++ b/src/control-plane/backend/batch-insert-ddb-custom-resource-construct.ts
@@ -14,13 +14,11 @@
 import path from 'path';
 import { Duration, CustomResource, Stack } from 'aws-cdk-lib';
 import { Table } from 'aws-cdk-lib/aws-dynamodb';
-import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 import { addCfnNagToStack, ruleForLambdaVPCAndReservedConcurrentExecutions } from '../../common/cfn-nag';
 import { cloudWatchSendLogs, createLambdaRole } from '../../common/lambda';
-import { POWERTOOLS_ENVS } from '../../common/powertools';
 import { SolutionNodejsFunction } from '../../private/function';
 
 export interface CdkCallCustomResourceProps {
@@ -40,14 +38,9 @@ export class BatchInsertDDBCustomResource extends Construct {
       entry: path.join(__dirname, './lambda/batch-insert-ddb/index.ts'),
       handler: 'handler',
       timeout: Duration.seconds(30),
-      runtime: Runtime.NODEJS_18_X,
       memorySize: 256,
       reservedConcurrentExecutions: 1,
       role: createLambdaRole(this, 'DicInitCustomResourceRole', false, []),
-      architecture: Architecture.X86_64,
-      environment: {
-        ... POWERTOOLS_ENVS,
-      },
     });
 
     props.table.grantReadWriteData(customResourceLambda);

--- a/src/control-plane/backend/click-stream-api.ts
+++ b/src/control-plane/backend/click-stream-api.ts
@@ -40,6 +40,7 @@ import {
 } from 'aws-cdk-lib/aws-ec2';
 import { ArnPrincipal } from 'aws-cdk-lib/aws-iam';
 import { Architecture, Code, Function as LambdaFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { IBucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 import { BatchInsertDDBCustomResource } from './batch-insert-ddb-custom-resource-construct';
@@ -372,8 +373,8 @@ export class ClickStreamApiConstruct extends Construct {
       }),
       handler: 'run.sh',
       runtime: Runtime.NODEJS_18_X,
-      architecture: Architecture.X86_64,
-      layers: [new LambdaAdapterLayer(this, 'LambdaAdapterLayerX86')],
+      architecture: Architecture.ARM_64,
+      layers: [new LambdaAdapterLayer(this, 'LambdaAdapterLayer')],
       environment: {
         AWS_LAMBDA_EXEC_WRAPPER: '/opt/bootstrap',
         CLICK_STREAM_TABLE_NAME: clickStreamTable.tableName,
@@ -394,11 +395,14 @@ export class ClickStreamApiConstruct extends Construct {
         QUICKSIGHT_CONTROL_PLANE_REGION: props.targetToCNRegions ? 'cn-north-1' : 'us-east-1',
         WITH_VALIDATE_ROLE: 'true',
         FULL_SOLUTION_VERSION: SolutionInfo.SOLUTION_VERSION,
-        ... POWERTOOLS_ENVS,
+        ...POWERTOOLS_ENVS,
       },
       timeout: Duration.seconds(30),
       memorySize: 512,
       role: clickStreamApiFunctionRole,
+      logRetention: RetentionDays.ONE_MONTH,
+      logFormat: 'JSON',
+      applicationLogLevel: 'WARN',
       ...apiFunctionProps,
     });
 

--- a/src/control-plane/backend/layer/lambda-web-adapter/Dockerfile
+++ b/src/control-plane/backend/layer/lambda-web-adapter/Dockerfile
@@ -1,11 +1,13 @@
-ARG TARGET_PLATFORM=linux/amd64
 ARG ADAPTER_VERSION=0.7.1
-FROM --platform=$TARGET_PLATFORM public.ecr.aws/awsguru/aws-lambda-adapter:$ADAPTER_VERSION AS build-stage
+FROM --platform=linux/amd64 public.ecr.aws/awsguru/aws-lambda-adapter:$ADAPTER_VERSION AS build-stage-amd64
+FROM --platform=linux/aarch64 public.ecr.aws/awsguru/aws-lambda-adapter:$ADAPTER_VERSION AS build-stage-arm64
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS package-stage
 
-RUN mkdir -p /asset/extensions
-COPY --from=build-stage /lambda-adapter /asset/extensions/lambda-adapter
+RUN mkdir -p /asset/extensions && mkdir -p /asset/libs/x86_64/ && mkdir -p /asset/libs/aarch64/
+COPY --from=build-stage-amd64 /lambda-adapter /asset/libs/x86_64/lambda-adapter
+COPY --from=build-stage-arm64 /lambda-adapter /asset/libs/aarch64/lambda-adapter
 COPY ./bootstrap /asset/bootstrap
+COPY ./lambda-adapter /asset/extensions
 
 USER webadapter

--- a/src/control-plane/backend/layer/lambda-web-adapter/lambda-adapter
+++ b/src/control-plane/backend/layer/lambda-web-adapter/lambda-adapter
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+OWN_FILENAME="$(basename $0)"
+LAMBDA_EXTENSION_NAME="$OWN_FILENAME" # (external) extension name has to match the filename
+echo "[${LAMBDA_EXTENSION_NAME}] Initialization"
+
+ARCH=`uname -m`
+CMD="/opt/libs/${ARCH}/lambda-adapter"
+
+echo "[${LAMBDA_EXTENSION_NAME}] Running on ${ARCH}, forwarding to corresponding adapter ${CMD}"
+
+"$CMD"

--- a/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
+++ b/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
@@ -17,26 +17,23 @@ import { Construct } from 'constructs';
 
 export interface LambdaAdapterLayerProps {
   readonly version?: string;
-  readonly platform?: 'linux/arm64' | 'linux/amd64';
   readonly arch?: 'aarch64' | 'x86_64';
 }
 
 export class LambdaAdapterLayer extends LayerVersion {
   constructor(scope: Construct, id: string, props?: LambdaAdapterLayerProps) {
-    const defaultVersion = props?.arch ?? '0.7.1';
-    const defaultPlatform = props?.platform ?? 'linux/amd64';
+    const defaultVersion = props?.version ?? '0.7.1';
     const defaultArch = props?.arch ?? 'x86_64';
 
     super(scope, id, {
       code: Code.fromDockerBuild(path.join(__dirname, '.'), {
         file: 'Dockerfile',
         buildArgs: {
-          TARGET_PLATFORM: defaultPlatform,
           ARCH: defaultArch,
           ADAPTER_VERSION: defaultVersion,
         },
       }),
-      compatibleRuntimes: [Runtime.NODEJS_16_X, Runtime.NODEJS_18_X],
+      compatibleRuntimes: [Runtime.NODEJS_16_X, Runtime.NODEJS_18_X, Runtime.NODEJS_20_X, Runtime.NODEJS_LATEST],
     });
   }
 }

--- a/src/control-plane/backend/stack-action-state-machine-construct.ts
+++ b/src/control-plane/backend/stack-action-state-machine-construct.ts
@@ -16,7 +16,6 @@ import { Aws, aws_iam as iam, aws_lambda, Duration, Stack } from 'aws-cdk-lib';
 import { Table } from 'aws-cdk-lib/aws-dynamodb';
 import { ISecurityGroup, IVpc, SubnetSelection } from 'aws-cdk-lib/aws-ec2';
 import { Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
-import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { IBucket } from 'aws-cdk-lib/aws-s3';
 import { Choice, Condition, DefinitionBody, LogLevel, Pass, StateMachine, TaskInput, Wait, WaitTime } from 'aws-cdk-lib/aws-stepfunctions';
 import { LambdaInvoke } from 'aws-cdk-lib/aws-stepfunctions-tasks';
@@ -29,7 +28,6 @@ import {
 } from '../../common/cfn-nag';
 import { cloudWatchSendLogs, createENI } from '../../common/lambda';
 import { createLogGroup } from '../../common/logs';
-import { POWERTOOLS_ENVS } from '../../common/powertools';
 import { SolutionNodejsFunction } from '../../private/function';
 
 
@@ -63,14 +61,9 @@ export class StackActionStateMachine extends Construct {
       description: 'Lambda function for state machine action of solution Clickstream Analytics on AWS',
       entry: join(__dirname, './lambda/sfn-action/index.ts'),
       handler: 'handler',
-      runtime: Runtime.NODEJS_18_X,
       tracing: aws_lambda.Tracing.ACTIVE,
       role: actionFunctionRole,
-      architecture: Architecture.X86_64,
       timeout: Duration.seconds(15),
-      environment: {
-        ...POWERTOOLS_ENVS,
-      },
       ...props.lambdaFuncProps,
     });
     cloudWatchSendLogs('action-func-logs', this.actionFunction);

--- a/src/control-plane/backend/stack-workflow-state-machine-construct.ts
+++ b/src/control-plane/backend/stack-workflow-state-machine-construct.ts
@@ -14,7 +14,6 @@
 import { join } from 'path';
 import { Aws, aws_iam as iam, aws_lambda, Duration, Stack } from 'aws-cdk-lib';
 import { Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
-import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { IBucket } from 'aws-cdk-lib/aws-s3';
 import {
   Choice,
@@ -35,7 +34,6 @@ import { StackActionStateMachineFuncProps } from './stack-action-state-machine-c
 import { addCfnNagToStack, ruleForLambdaVPCAndReservedConcurrentExecutions, ruleRolePolicyWithWildcardResources } from '../../common/cfn-nag';
 import { cloudWatchSendLogs, createENI } from '../../common/lambda';
 import { createLogGroup } from '../../common/logs';
-import { POWERTOOLS_ENVS } from '../../common/powertools';
 import { getShortIdOfStack } from '../../common/stack';
 import { SolutionNodejsFunction } from '../../private/function';
 
@@ -77,14 +75,9 @@ export class StackWorkflowStateMachine extends Construct {
       description: 'Lambda function for state machine workflow of solution Clickstream Analytics on AWS',
       entry: join(__dirname, './lambda/sfn-workflow/index.ts'),
       handler: 'handler',
-      runtime: Runtime.NODEJS_18_X,
       tracing: aws_lambda.Tracing.ACTIVE,
       role: workflowFunctionRole,
-      architecture: Architecture.X86_64,
       timeout: Duration.seconds(15),
-      environment: {
-        ...POWERTOOLS_ENVS,
-      },
       ...props.lambdaFuncProps,
     });
     props.workflowBucket.grantReadWrite(workflowFunction, 'clickstream/*');

--- a/src/data-pipeline/utils/custom-resource.ts
+++ b/src/data-pipeline/utils/custom-resource.ts
@@ -22,8 +22,7 @@ import { IBucket } from 'aws-cdk-lib/aws-s3';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 import { addCfnNagSuppressRules, rulesToSuppressForLambdaVPCAndReservedConcurrentExecutions } from '../../common/cfn-nag';
-import { LAMBDA_NODEJS_RUNTIME, createLambdaRole } from '../../common/lambda';
-import { POWERTOOLS_ENVS } from '../../common/powertools';
+import { createLambdaRole } from '../../common/lambda';
 import { getShortIdOfStack } from '../../common/stack';
 import { EmrApplicationArchitectureType } from '../../data-pipeline-stack';
 import { SolutionNodejsFunction } from '../../private/function';
@@ -102,7 +101,6 @@ function createCopyAssetsLambda(
   props.pipelineS3Bucket.grantReadWrite(role);
 
   const fn = new SolutionNodejsFunction(scope, 'CopyAssetsCustomResourceLambda', {
-    runtime: LAMBDA_NODEJS_RUNTIME,
     entry: join(
       __dirname,
       '..',
@@ -120,7 +118,6 @@ function createCopyAssetsLambda(
       PROJECT_ID: props.projectId,
       PIPELINE_S3_BUCKET_NAME: props.pipelineS3Bucket.bucketName,
       PIPELINE_S3_PREFIX: props.pipelineS3Prefix,
-      ... POWERTOOLS_ENVS,
     },
   });
 
@@ -222,7 +219,6 @@ function createEMRServerlessApplicationLambda(
   props.pipelineS3Bucket.grantReadWrite(role);
 
   const fn = new SolutionNodejsFunction(scope, 'CreateEMRServerlessApplicationLambda', {
-    runtime: LAMBDA_NODEJS_RUNTIME,
     entry: join(
       __dirname,
       '..',
@@ -245,7 +241,6 @@ function createEMRServerlessApplicationLambda(
       SUBNETIDS: props.subnetIds,
       PIPELINE_S3_BUCKET_NAME: props.pipelineS3Bucket.bucketName,
       PIPELINE_S3_PREFIX: props.pipelineS3Prefix,
-      ... POWERTOOLS_ENVS,
     },
   });
 

--- a/src/data-pipeline/utils/utils-lambda.ts
+++ b/src/data-pipeline/utils/utils-lambda.ts
@@ -16,7 +16,7 @@ import { Database, Table } from '@aws-cdk/aws-glue-alpha';
 import { Duration, Stack } from 'aws-cdk-lib';
 
 import { ISecurityGroup, IVpc, SubnetSelection } from 'aws-cdk-lib/aws-ec2';
-import { Runtime, Tracing, Function } from 'aws-cdk-lib/aws-lambda';
+import { Tracing, Function } from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { IBucket } from 'aws-cdk-lib/aws-s3';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
@@ -25,7 +25,6 @@ import { Construct } from 'constructs';
 import { RoleUtil } from './utils-role';
 
 import { attachListTagsPolicyForFunction } from '../../common/lambda/tags';
-import { POWERTOOLS_ENVS } from '../../common/powertools';
 import { getShortIdOfStack } from '../../common/stack';
 import { SolutionNodejsFunction } from '../../private/function';
 import { ClickstreamSinkTables } from '../data-pipeline';
@@ -55,7 +54,6 @@ interface Props {
 
 const functionSettings = {
   handler: 'handler',
-  runtime: Runtime.NODEJS_18_X,
   timeout: Duration.minutes(15),
   logRetention: RetentionDays.ONE_WEEK,
   tracing: Tracing.ACTIVE,
@@ -115,10 +113,10 @@ export class LambdaUtil {
           SOURCE_TABLE_NAME: sourceTableName,
           PROJECT_ID: this.props.projectId,
           APP_IDS: this.props.appIds,
-          ...POWERTOOLS_ENVS,
         },
         ...functionSettings,
         memorySize: 256,
+        applicationLogLevel: 'WARN',
       },
     );
     return fn;
@@ -170,10 +168,10 @@ export class LambdaUtil {
         OUTPUT_FORMAT: this.props.outputFormat,
         USER_KEEP_DAYS: this.props.userKeepDays + '',
         ITEM_KEEP_DAYS: this.props.itemKeepDays + '',
-        ...POWERTOOLS_ENVS,
       },
       ...functionSettings,
       memorySize: 1024,
+      applicationLogLevel: 'WARN',
     });
     attachListTagsPolicyForFunction(this.scope, 'EmrSparkJobSubmitterFunction', fn);
     return fn;
@@ -199,10 +197,10 @@ export class LambdaUtil {
         PIPELINE_S3_BUCKET_NAME: this.props.pipelineS3Bucket.bucketName,
         PIPELINE_S3_PREFIX: this.props.pipelineS3Prefix,
         DL_QUEUE_URL: dlSqs.queueUrl,
-        ...POWERTOOLS_ENVS,
       },
       ...functionSettings,
       memorySize: 1024,
+      applicationLogLevel: 'WARN',
     });
     return fn;
   }

--- a/src/ingestion-server/custom-resource/delete-ecs-cluster.ts
+++ b/src/ingestion-server/custom-resource/delete-ecs-cluster.ts
@@ -14,13 +14,11 @@
 import { join } from 'path';
 import { CustomResource, Duration, CfnResource } from 'aws-cdk-lib';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 import { addCfnNagSuppressRules, rulesToSuppressForLambdaVPCAndReservedConcurrentExecutions } from '../../common/cfn-nag';
 import { createLambdaRole } from '../../common/lambda';
-import { POWERTOOLS_ENVS } from '../../common/powertools';
 import { SolutionNodejsFunction } from '../../private/function';
 
 export interface DeleteECSClusterCustomResourceProps {
@@ -87,7 +85,6 @@ function createDeleteECSClusterLambda(scope: Construct, ecsClusterArn: string): 
   const role = createLambdaRole(scope, 'deleteECSClusterLambdaRole', false, policyStatements);
 
   const fn = new SolutionNodejsFunction(scope, 'deleteECSClusterLambda', {
-    runtime: Runtime.NODEJS_18_X,
     entry: join(
       __dirname,
       'delete-ecs-cluster',
@@ -98,9 +95,6 @@ function createDeleteECSClusterLambda(scope: Construct, ecsClusterArn: string): 
     timeout: Duration.minutes(10),
     logRetention: RetentionDays.ONE_WEEK,
     role,
-    environment: {
-      ...POWERTOOLS_ENVS,
-    },
   });
   fn.node.addDependency(role);
   addCfnNagSuppressRules(fn.node.defaultChild as CfnResource, [

--- a/src/ingestion-server/custom-resource/update-alb-rules.ts
+++ b/src/ingestion-server/custom-resource/update-alb-rules.ts
@@ -14,13 +14,11 @@
 import { join } from 'path';
 import { CustomResource, Duration, CfnResource } from 'aws-cdk-lib';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 import { addCfnNagSuppressRules } from '../../common/cfn-nag';
 import { createLambdaRole } from '../../common/lambda';
-import { POWERTOOLS_ENVS } from '../../common/powertools';
 import { SolutionNodejsFunction } from '../../private/function';
 
 export interface UpdateAlbRulesCustomResourceProps {
@@ -95,7 +93,6 @@ function createUpdateAlbRulesLambda(scope: Construct, listenerArn: string, authe
   const role = createLambdaRole(scope, 'updateAlbRulesLambdaRole', false, policyStatements);
 
   const fn = new SolutionNodejsFunction(scope, 'updateAlbRulesLambda', {
-    runtime: Runtime.NODEJS_18_X,
     entry: join(
       __dirname,
       'update-alb-rules',
@@ -106,9 +103,6 @@ function createUpdateAlbRulesLambda(scope: Construct, listenerArn: string, authe
     timeout: Duration.minutes(5),
     logRetention: RetentionDays.ONE_WEEK,
     role,
-    environment: {
-      ...POWERTOOLS_ENVS,
-    },
   });
   fn.node.addDependency(role);
   addCfnNagSuppressRules(fn.node.defaultChild as CfnResource, [

--- a/src/ingestion-server/kafka-s3-connector/custom-resource.ts
+++ b/src/ingestion-server/kafka-s3-connector/custom-resource.ts
@@ -15,14 +15,12 @@ import { join } from 'path';
 import { CfnResource, CustomResource, Duration, Stack } from 'aws-cdk-lib';
 import { ISecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import { IRole } from 'aws-cdk-lib/aws-iam';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { IBucket } from 'aws-cdk-lib/aws-s3';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 import { createRoleForS3SinkConnectorCustomResourceLambda } from './iam';
 import { addCfnNagSuppressRules } from '../../common/cfn-nag';
-import { POWERTOOLS_ENVS } from '../../common/powertools';
 import { getShortIdOfStack } from '../../common/stack';
 import { SolutionNodejsFunction } from '../../private/function';
 
@@ -112,7 +110,6 @@ function createS3SinkConnectorLambda(
   });
 
   const fn = new SolutionNodejsFunction(scope, 's3SinkConnectorCustomResourceLambda', {
-    runtime: Runtime.NODEJS_18_X,
     entry: join(
       __dirname,
       'custom-resource',
@@ -124,9 +121,6 @@ function createS3SinkConnectorLambda(
     timeout: Duration.minutes(15),
     logRetention: RetentionDays.ONE_WEEK,
     role,
-    environment: {
-      ... POWERTOOLS_ENVS,
-    },
   });
   fn.node.addDependency(role);
   addCfnNagSuppressRules(fn.node.defaultChild as CfnResource, [

--- a/src/ingestion-server/kinesis-data-stream/private/lambda.ts
+++ b/src/ingestion-server/kinesis-data-stream/private/lambda.ts
@@ -14,14 +14,13 @@
 import { join } from 'path';
 import { CfnResource, Duration } from 'aws-cdk-lib';
 import { IVpc, SubnetSelection } from 'aws-cdk-lib/aws-ec2';
-import { Runtime, Function } from 'aws-cdk-lib/aws-lambda';
+import { Function } from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { IBucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 import { createKinesisToS3LambdaRole } from './iam';
 import { createKinesisToS3LambdaSecurityGroup } from './sg';
 import { addCfnNagSuppressRules } from '../../../common/cfn-nag';
-import { POWERTOOLS_ENVS } from '../../../common/powertools';
 import { SolutionNodejsFunction } from '../../../private/function';
 
 export interface KinesisToS3Lambda {
@@ -40,7 +39,6 @@ export function createKinesisToS3Lambda(
   const role = createKinesisToS3LambdaRole(scope);
 
   const fn = new SolutionNodejsFunction(scope, 'kinesisToS3Lambda', {
-    runtime: Runtime.NODEJS_18_X,
     entry: join(__dirname, '..', 'kinesis-to-s3-lambda', 'index.ts'),
     handler: 'handler',
     memorySize: 2048,
@@ -54,8 +52,8 @@ export function createKinesisToS3Lambda(
     environment: {
       S3_BUCKET: props.s3DataBucket.bucketName,
       S3_PREFIX: props.s3DataPrefix,
-      ... POWERTOOLS_ENVS,
     },
+    applicationLogLevel: 'WARN',
   });
 
   addCfnNagSuppressRules(fn.node.defaultChild as CfnResource, [

--- a/src/metrics/add-sns-subscription.ts
+++ b/src/metrics/add-sns-subscription.ts
@@ -14,14 +14,12 @@
 import { join } from 'path';
 import { CfnResource, CustomResource, Duration } from 'aws-cdk-lib';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 import { addCfnNagSuppressRules, rulesToSuppressForLambdaVPCAndReservedConcurrentExecutions } from '../common/cfn-nag';
 import { createLambdaRole } from '../common/lambda';
-import { POWERTOOLS_ENVS } from '../common/powertools';
 import { SolutionNodejsFunction } from '../private/function';
 
 export interface AddSubscriptionCustomResourceProps {
@@ -67,7 +65,6 @@ function createAddSubscriptionLambda(scope: Construct, props: AddSubscriptionCus
   ]);
 
   const fn = new SolutionNodejsFunction(scope, 'addSubscriptionLambda', {
-    runtime: Runtime.NODEJS_18_X,
     entry: join(
       __dirname,
       'custom-resource',
@@ -82,7 +79,6 @@ function createAddSubscriptionLambda(scope: Construct, props: AddSubscriptionCus
     environment: {
       SNS_TOPIC_ARN: props.snsTopic.topicArn,
       EMAILS: props.emails,
-      ...POWERTOOLS_ENVS,
     },
   });
   fn.node.addDependency(role);

--- a/src/metrics/get-interval-custom-resource.ts
+++ b/src/metrics/get-interval-custom-resource.ts
@@ -14,13 +14,11 @@
 
 import { join } from 'path';
 import { CfnResource, CustomResource, Duration } from 'aws-cdk-lib';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 import { addCfnNagSuppressRules, rulesToSuppressForLambdaVPCAndReservedConcurrentExecutions } from '../common/cfn-nag';
 import { createLambdaRole } from '../common/lambda';
-import { POWERTOOLS_ENVS } from '../common/powertools';
 import { SolutionNodejsFunction } from '../private/function';
 
 export interface GetIntervalProps {
@@ -69,7 +67,6 @@ function createGetIntervalCustomResource(
 function createGetIntervalResourceLambda(scope: Construct, id: string): SolutionNodejsFunction {
   const role = createLambdaRole(scope, id + 'LambdaRole', false, []);
   const fn = new SolutionNodejsFunction(scope, id + 'Lambda', {
-    runtime: Runtime.NODEJS_18_X,
     entry: join(
       __dirname,
       'custom-resource',
@@ -81,10 +78,6 @@ function createGetIntervalResourceLambda(scope: Construct, id: string): Solution
     timeout: Duration.seconds(10),
     logRetention: RetentionDays.ONE_WEEK,
     role,
-    environment: {
-      ...POWERTOOLS_ENVS,
-
-    },
   });
 
   fn.node.addDependency(role);

--- a/src/metrics/metrics-widgets-custom-resource.ts
+++ b/src/metrics/metrics-widgets-custom-resource.ts
@@ -15,14 +15,12 @@
 import { join } from 'path';
 import { Arn, ArnFormat, CfnResource, CustomResource, Duration, Resource, Stack } from 'aws-cdk-lib';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 import { addCfnNagSuppressRules, rulesToSuppressForLambdaVPCAndReservedConcurrentExecutions } from '../common/cfn-nag';
 import { createLambdaRole } from '../common/lambda';
 import { attachListTagsPolicyForFunction } from '../common/lambda/tags';
-import { POWERTOOLS_ENVS } from '../common/powertools';
 import { getShortIdOfStack } from '../common/stack';
 import { SolutionNodejsFunction } from '../private/function';
 
@@ -159,7 +157,6 @@ function createSetMetricsWidgetsResourceLambda(scope: Construct, id: string): So
 
   const stackId = getShortIdOfStack(Stack.of(scope));
   const fn = new SolutionNodejsFunction(scope, id + 'Lambda', {
-    runtime: Runtime.NODEJS_18_X,
     entry: join(
       __dirname,
       'custom-resource',
@@ -173,8 +170,6 @@ function createSetMetricsWidgetsResourceLambda(scope: Construct, id: string): So
     role,
     environment: {
       STACK_ID: stackId,
-      ...POWERTOOLS_ENVS,
-
     },
   });
 

--- a/src/metrics/metrics.ts
+++ b/src/metrics/metrics.ts
@@ -18,7 +18,6 @@ import { Dashboard, PeriodOverride } from 'aws-cdk-lib/aws-cloudwatch';
 import { Rule } from 'aws-cdk-lib/aws-events';
 import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { Provider } from 'aws-cdk-lib/custom-resources';
@@ -27,7 +26,6 @@ import { PARAMETERS_DESCRIPTION } from './settings';
 import { addCfnNagSuppressRules, rulesToSuppressForLambdaVPCAndReservedConcurrentExecutions } from '../common/cfn-nag';
 import { ALARM_NAME_PREFIX } from '../common/constant';
 import { createLambdaRole } from '../common/lambda';
-import { POWERTOOLS_ENVS } from '../common/powertools';
 import { getShortIdOfStack } from '../common/stack';
 import { SolutionNodejsFunction } from '../private/function';
 
@@ -162,7 +160,6 @@ function createPutDashboardLambda(scope: Construct, props: CustomResourceProps):
   ]);
 
   const fn = new SolutionNodejsFunction(scope, 'PutDashboardLambda', {
-    runtime: Runtime.NODEJS_18_X,
     entry: join(
       __dirname,
       'custom-resource',
@@ -180,7 +177,6 @@ function createPutDashboardLambda(scope: Construct, props: CustomResourceProps):
       LEGEND_POSITION: props.legendPosition,
       COLUMN_NUMBER: props.columnNumber + '',
       SNS_TOPIC_ARN: props.snsTopic.topicArn,
-      ...POWERTOOLS_ENVS,
     },
   });
   fn.node.addDependency(role);

--- a/src/private/function.ts
+++ b/src/private/function.ts
@@ -11,8 +11,11 @@
  *  and limitations under the License.
  */
 
+import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction, NodejsFunctionProps } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
+import { POWERTOOLS_ENVS } from '../common/powertools';
 
 export class SolutionNodejsFunction extends NodejsFunction {
 
@@ -25,6 +28,15 @@ export class SolutionNodejsFunction extends NodejsFunction {
       } : {
         externalModules: [],
       },
+      runtime: Runtime.NODEJS_18_X,
+      architecture: Architecture.ARM_64,
+      environment: {
+        ...POWERTOOLS_ENVS,
+        ...(props?.environment ?? {}),
+      },
+      logRetention: props?.logRetention ?? RetentionDays.ONE_MONTH,
+      logFormat: 'JSON',
+      applicationLogLevel: props?.applicationLogLevel ?? 'INFO',
     });
   }
 }

--- a/src/reporting/network-interface-check-custom-resource.ts
+++ b/src/reporting/network-interface-check-custom-resource.ts
@@ -13,7 +13,6 @@
 
 import { join } from 'path';
 import { Aws, CfnResource, CustomResource, Duration } from 'aws-cdk-lib';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
@@ -21,7 +20,6 @@ import { NetworkInterfaceCheckCustomResourceProps } from './private/dashboard';
 import { createNetworkInterfaceCheckCustomResourceLambda } from './private/iam';
 
 import { addCfnNagSuppressRules, rulesToSuppressForLambdaVPCAndReservedConcurrentExecutions } from '../common/cfn-nag';
-import { POWERTOOLS_ENVS } from '../common/powertools';
 import { SolutionNodejsFunction } from '../private/function';
 
 export function createNetworkInterfaceCheckCustomResource(
@@ -54,7 +52,6 @@ function createNetworkInterfaceCheckLambda(
 ): SolutionNodejsFunction {
   const role = createNetworkInterfaceCheckCustomResourceLambda(scope);
   const fn = new SolutionNodejsFunction(scope, 'NetworkInterfaceCheckCustomResourceLambda', {
-    runtime: Runtime.NODEJS_18_X,
     entry: join(
       __dirname,
       'lambda',
@@ -66,9 +63,6 @@ function createNetworkInterfaceCheckLambda(
     timeout: Duration.minutes(15),
     logRetention: RetentionDays.ONE_WEEK,
     role,
-    environment: {
-      ...POWERTOOLS_ENVS,
-    },
   });
 
   addCfnNagSuppressRules(fn.node.defaultChild as CfnResource, [

--- a/src/reporting/quicksight-custom-resource.ts
+++ b/src/reporting/quicksight-custom-resource.ts
@@ -14,7 +14,6 @@
 import { join } from 'path';
 import { TimeGranularity } from '@aws-sdk/client-quicksight';
 import { Aws, CustomResource, Duration } from 'aws-cdk-lib';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
@@ -52,7 +51,6 @@ import {
   CLICKSTREAM_LIFECYCLE_WEEKLY_VIEW_NAME,
 } from '../common/constant';
 
-import { POWERTOOLS_ENVS } from '../common/powertools';
 import { SolutionNodejsFunction } from '../private/function';
 
 export function createQuicksightCustomResource(
@@ -419,7 +417,6 @@ function createQuicksightLambda(
 ): SolutionNodejsFunction {
   const role = createRoleForQuicksightCustomResourceLambda(scope, templateArn);
   const fn = new SolutionNodejsFunction(scope, 'QuicksightCustomResourceLambda', {
-    runtime: Runtime.NODEJS_18_X,
     entry: join(
       __dirname,
       'lambda',
@@ -431,9 +428,6 @@ function createQuicksightLambda(
     timeout: Duration.minutes(15),
     logRetention: RetentionDays.ONE_WEEK,
     role,
-    environment: {
-      ...POWERTOOLS_ENVS,
-    },
   });
 
   return fn;

--- a/test/control-plane/alb-lambda-portal.test.ts
+++ b/test/control-plane/alb-lambda-portal.test.ts
@@ -257,15 +257,6 @@ describe('ApplicationLoadBalancerLambdaPortal', () => {
       ],
     });
 
-    template.hasResourceProperties('AWS::Lambda::Function', {
-      Environment: {
-        Variables: {
-          LOG_LEVEL: 'WARN',
-          POWERTOOLS_SERVICE_NAME: 'ClickStreamAnalyticsOnAWS',
-        },
-      },
-    });
-
   });
 
   test('IAM policies are created for Lambda functions', () => {

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -11,6 +11,7 @@
  *  and limitations under the License.
  */
 
+import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { findResourcesName, TestEnv } from './test-utils';
 import { removeFolder } from '../common/jest';
 
@@ -179,7 +180,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
 
     newALBApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
-        'x86_64',
+        Architecture.ARM_64.toString(),
       ],
       Description: 'Lambda function for api of solution Clickstream Analytics on AWS',
       Environment: {
@@ -234,14 +235,14 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
 
     newALBApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
-        'x86_64',
+        Architecture.ARM_64.toString(),
       ],
       Description: 'Lambda function for dictionary init of solution Click Stream Analytics on AWS',
       Runtime: 'nodejs18.x',
     });
     newALBApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
-        'x86_64',
+        Architecture.ARM_64.toString(),
       ],
       Description: 'Lambda function for state machine action of solution Clickstream Analytics on AWS',
       Environment: {
@@ -262,7 +263,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
     });
     newALBApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
-        'x86_64',
+        Architecture.ARM_64.toString(),
       ],
       Description: 'Lambda function for state machine workflow of solution Clickstream Analytics on AWS',
       Environment: {
@@ -283,7 +284,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
     });
     newALBApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
-        'x86_64',
+        Architecture.ARM_64.toString(),
       ],
       Description: 'Lambda function for api of solution Clickstream Analytics on AWS',
     });
@@ -293,21 +294,21 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
   test('Api lambda Function in GCR', () => {
     newALBApiStackCNTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
-        'x86_64',
+        Architecture.ARM_64.toString(),
       ],
       Description: 'Lambda function for dictionary init of solution Click Stream Analytics on AWS',
       Runtime: 'nodejs18.x',
     });
     newALBApiStackCNTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
-        'x86_64',
+        Architecture.ARM_64.toString(),
       ],
       Description: 'Lambda function for state machine action of solution Clickstream Analytics on AWS',
       Runtime: 'nodejs18.x',
     });
     newALBApiStackCNTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
-        'x86_64',
+        Architecture.ARM_64.toString(),
       ],
       Description: 'Lambda function for api of solution Clickstream Analytics on AWS',
     });
@@ -461,8 +462,8 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
         'testClickStreamALBApiClickStreamApiStepFunctionPolicy71DA1626',
         'testClickStreamALBApiClickStreamApiAWSSdkPolicy48F56187',
         'testClickStreamALBApiUploadRoleDefaultPolicyEBF1E156',
-        'customresourcefunclogs9B71FED3',
         'LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB',
+        'customresourcefunclogs9B71FED3',
         'actionfunclogs394D90DA',
         'actionfunceniA16F9174',
         'workflowfunclogs7A318BBF',
@@ -1333,7 +1334,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
 
     newALBApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
-        'x86_64',
+        Architecture.ARM_64.toString(),
       ],
       Description: 'Lambda function for dictionary init of solution Click Stream Analytics on AWS',
       Environment: {
@@ -1608,17 +1609,19 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
   test('Api lambda Function', () => {
     expect(findResourcesName(newCloudfrontApiStackTemplate, 'AWS::Lambda::LayerVersion'))
       .toEqual([
-        'testClickStreamCloudfrontApiLambdaAdapterLayerX868468A9C4',
+        'testClickStreamCloudfrontApiLambdaAdapterLayerF0F222D4',
       ]);
     newCloudfrontApiStackTemplate.hasResourceProperties('AWS::Lambda::LayerVersion', {
       CompatibleRuntimes: [
-        'nodejs16.x',
-        'nodejs18.x',
+        Runtime.NODEJS_16_X.toString(),
+        Runtime.NODEJS_18_X.toString(),
+        Runtime.NODEJS_20_X.toString(),
+        Runtime.NODEJS_LATEST.toString(),
       ],
     });
     newCloudfrontApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
-        'x86_64',
+        Architecture.ARM_64.toString(),
       ],
       Description: 'Lambda function for api of solution Clickstream Analytics on AWS',
       Environment: {
@@ -1665,7 +1668,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
       Handler: 'run.sh',
       Layers: [
         {
-          Ref: 'testClickStreamCloudfrontApiLambdaAdapterLayerX868468A9C4',
+          Ref: 'testClickStreamCloudfrontApiLambdaAdapterLayerF0F222D4',
         },
       ],
       MemorySize: 512,
@@ -1682,21 +1685,21 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
 
     newCloudfrontApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
-        'x86_64',
+        Architecture.ARM_64.toString(),
       ],
       Description: 'Lambda function for dictionary init of solution Click Stream Analytics on AWS',
       Runtime: 'nodejs18.x',
     });
     newCloudfrontApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
-        'x86_64',
+        Architecture.ARM_64.toString(),
       ],
       Description: 'Lambda function for state machine action of solution Clickstream Analytics on AWS',
       Runtime: 'nodejs18.x',
     });
     newCloudfrontApiStackTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
-        'x86_64',
+        Architecture.ARM_64.toString(),
       ],
       Description: 'Lambda function for api of solution Clickstream Analytics on AWS',
     });
@@ -1706,21 +1709,21 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
   test('Api lambda Function in GCR', () => {
     newALBApiStackCNTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
-        'x86_64',
+        Architecture.ARM_64.toString(),
       ],
       Description: 'Lambda function for dictionary init of solution Click Stream Analytics on AWS',
       Runtime: 'nodejs18.x',
     });
     newALBApiStackCNTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
-        'x86_64',
+        Architecture.ARM_64.toString(),
       ],
       Description: 'Lambda function for state machine action of solution Clickstream Analytics on AWS',
       Runtime: 'nodejs18.x',
     });
     newALBApiStackCNTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Architectures: [
-        'x86_64',
+        Architecture.ARM_64.toString(),
       ],
       Environment: {
         Variables: {

--- a/test/control-plane/cloudfront-control-plane-stack.test.ts
+++ b/test/control-plane/cloudfront-control-plane-stack.test.ts
@@ -550,6 +550,10 @@ describe('CloudFrontS3PortalStack - Default stack props for common features', ()
       },
       Handler: 'index.handler',
       Runtime: 'nodejs18.x',
+      LoggingConfig: {
+        ApplicationLogLevel: 'WARN',
+        LogFormat: 'JSON',
+      },
     },
     );
   });
@@ -903,9 +907,12 @@ describe('CloudFrontS3PortalStack - China region', () => {
           'Arn',
         ],
       },
-      Architectures: Match.absent(),
       Handler: 'index.handler',
       Runtime: 'nodejs18.x',
+      LoggingConfig: {
+        ApplicationLogLevel: 'WARN',
+        LogFormat: 'JSON',
+      },
     },
     );
 

--- a/test/metrics/metrics-stack.test.ts
+++ b/test/metrics/metrics-stack.test.ts
@@ -101,7 +101,7 @@ test('has Dashboard', () => {
 });
 
 
-test('has lambda Function to put dashbaord', () => {
+test('has lambda Function to put dashboard', () => {
   template.hasResourceProperties('AWS::Lambda::Function', {
     Environment: {
       Variables: {
@@ -118,6 +118,10 @@ test('has lambda Function to put dashbaord', () => {
           Ref: 'ColumnNumber',
         },
       },
+    },
+    LoggingConfig: {
+      ApplicationLogLevel: 'INFO',
+      LogFormat: 'JSON',
     },
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -25,6 +25,10 @@ export const RefAnyValue = {
   Ref: Match.anyValue(),
 };
 
+export const RefGetAtt = {
+  'Fn::GetAtt': Match.anyValue(),
+};
+
 export const JoinAnyValue = {
   'Fn::Join': Match.anyValue(),
 };
@@ -37,7 +41,6 @@ export function findResourceByCondition(template: Template, condition: string) {
       return resource;
     }
   }
-  return;
 }
 
 export function findFirstResourceByKeyPrefix(


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

- update `SolutionNodejsFunction` to consolidate the runtime, environment, architecture and log configuration
- use `INFO` level for all custom resource functions
- use `WARN` level for all data pipeline and web console functions
- use `Aspect` to handle with the unsupoorted architecture and log configuration in AWS China
- repackage the Adapter layer with both x86_64 and arm64 binaries to run on both architectures
- remove leagcy tests for data-analytics-redshift-stack

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway in both AWS standard and CN partitions
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend