### PR TITLE
fix: CloudFront resource name with region suffix

### DIFF
--- a/src/control-plane/cloudfront-s3-portal.ts
+++ b/src/control-plane/cloudfront-s3-portal.ts
@@ -67,7 +67,7 @@ import { Construct, IConstruct } from 'constructs';
 import { Constant } from './private/constant';
 import { LogProps } from '../common/alb';
 import { addCfnNagSuppressRules } from '../common/cfn-nag';
-import { getShortIdOfStack } from '../common/stack';
+import { getShortIdOfStackWithRegion } from '../common/stack';
 import { isEmpty } from '../common/utils';
 
 export interface DistributionProps {
@@ -221,7 +221,7 @@ export class CloudFrontS3Portal extends Construct {
       }
     }
 
-    const shortId = getShortIdOfStack(Stack.of(this));
+    const shortId = getShortIdOfStackWithRegion(Stack.of(this));
     const oac = new CfnOriginAccessControl(this, 'origin_access_control', {
       originAccessControlConfig: {
         name: 'clickstream-controlplane-oac-' + shortId,

--- a/test/control-plane/cloudfront-s3-portal.test.ts
+++ b/test/control-plane/cloudfront-s3-portal.test.ts
@@ -256,6 +256,10 @@ describe('CloudFrontS3Portal', () => {
             [
               'clickstream-controlplane-oac-',
               {
+                Ref: 'AWS::Region',
+              },
+              '-',
+              {
                 'Fn::Select': [
                   0,
                   {
@@ -638,6 +642,10 @@ test('test cache policy name uniqueness', () => {
           '',
           [
             'cachepolicy-',
+            {
+              Ref: 'AWS::Region',
+            },
+            '-',
             {
               'Fn::Select': [
                 0,


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend