### PR TITLE
fix: intermitent failure of creating data source of QuickSight

### DIFF
--- a/src/reporting/lambda/custom-resource/quicksight/network-interface-check.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/network-interface-check.ts
@@ -1,0 +1,78 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { EC2, NetworkInterfaceStatus } from '@aws-sdk/client-ec2';
+import { Context, CloudFormationCustomResourceEvent, CdkCustomResourceResponse } from 'aws-lambda';
+import { logger } from '../../../../common/powertools';
+import { aws_sdk_client_common_config } from '../../../../common/sdk-client-config';
+import { NetworkInterfaceCheckCustomResourceLambdaProps, sleep } from '../../../private/dashboard';
+
+type ResourceEvent = CloudFormationCustomResourceEvent;
+
+type NetworkInterfaceCheckCustomResourceLambdaPropsType = NetworkInterfaceCheckCustomResourceLambdaProps & {
+  readonly ServiceToken: string;
+}
+
+export type MustacheParamType = {
+  schema: string;
+}
+
+export const handler = async (event: ResourceEvent, _context: Context): Promise<CdkCustomResourceResponse|void> => {
+  const props = event.ResourceProperties as NetworkInterfaceCheckCustomResourceLambdaPropsType;
+  const region = props.awsRegion;
+  const ec2Client = new EC2({
+    region,
+    ...aws_sdk_client_common_config,
+  });
+
+  if (event.RequestType === 'Create' || event.RequestType === 'Update' ) {
+    return _onCreate(ec2Client, props);
+  }
+};
+
+const _onCreate = async (ec2Client: EC2, props: NetworkInterfaceCheckCustomResourceLambdaPropsType): Promise<CdkCustomResourceResponse> => {
+
+  const networkInterfaceIds: string[] = [];
+  for (const ni of props.networkInterfaces) {
+    networkInterfaceIds.push(ni.NetworkInterfaceId);
+  }
+
+  logger.info('networkInterfaceIds:', { networkInterfaceIds });
+
+  let isNetworkInterfaceReady: boolean = false;
+  let checkCnt = 0;
+  while (!isNetworkInterfaceReady && checkCnt <= 600) {
+    await sleep(500);
+    const networkInterfacesDescribeResult = await ec2Client.describeNetworkInterfaces({
+      NetworkInterfaceIds: networkInterfaceIds,
+    });
+    checkCnt += 1;
+
+    if (networkInterfacesDescribeResult.NetworkInterfaces !== undefined) {
+      let ready = true;
+      for (const networkInterface of networkInterfacesDescribeResult.NetworkInterfaces) {
+        logger.info(`network interface status: ${networkInterface.NetworkInterfaceId} - ${networkInterface.Status}`);
+        if (networkInterface.Status !== NetworkInterfaceStatus.in_use) {
+          ready = false;
+        }
+      }
+      isNetworkInterfaceReady = ready;
+    }
+  }
+
+  return {
+    Data: {
+      isReady: isNetworkInterfaceReady,
+    },
+  };
+};

--- a/src/reporting/network-interface-check-custom-resource.ts
+++ b/src/reporting/network-interface-check-custom-resource.ts
@@ -1,0 +1,79 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { join } from 'path';
+import { Aws, CfnResource, CustomResource, Duration } from 'aws-cdk-lib';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { Provider } from 'aws-cdk-lib/custom-resources';
+import { Construct } from 'constructs';
+import { NetworkInterfaceCheckCustomResourceProps } from './private/dashboard';
+import { createNetworkInterfaceCheckCustomResourceLambda } from './private/iam';
+
+import { addCfnNagSuppressRules, rulesToSuppressForLambdaVPCAndReservedConcurrentExecutions } from '../common/cfn-nag';
+import { POWERTOOLS_ENVS } from '../common/powertools';
+import { SolutionNodejsFunction } from '../private/function';
+
+export function createNetworkInterfaceCheckCustomResource(
+  scope: Construct,
+  props: NetworkInterfaceCheckCustomResourceProps,
+): CustomResource {
+
+  const fn = createNetworkInterfaceCheckLambda(scope);
+  const provider = new Provider(
+    scope,
+    'NetworkInterfaceCheckCustomResourceProvider',
+    {
+      onEventHandler: fn,
+      logRetention: RetentionDays.ONE_WEEK,
+    },
+  );
+
+  const cr = new CustomResource(scope, 'NetworkInterfaceCheckCustomResource', {
+    serviceToken: provider.serviceToken,
+    properties: {
+      awsRegion: Aws.REGION,
+      networkInterfaces: props.networkInterfaces,
+    },
+  });
+  return cr;
+}
+
+function createNetworkInterfaceCheckLambda(
+  scope: Construct,
+): SolutionNodejsFunction {
+  const role = createNetworkInterfaceCheckCustomResourceLambda(scope);
+  const fn = new SolutionNodejsFunction(scope, 'NetworkInterfaceCheckCustomResourceLambda', {
+    runtime: Runtime.NODEJS_18_X,
+    entry: join(
+      __dirname,
+      'lambda',
+      'custom-resource/quicksight',
+      'network-interface-check.ts',
+    ),
+    handler: 'handler',
+    memorySize: 256,
+    timeout: Duration.minutes(15),
+    logRetention: RetentionDays.ONE_WEEK,
+    role,
+    environment: {
+      ...POWERTOOLS_ENVS,
+    },
+  });
+
+  addCfnNagSuppressRules(fn.node.defaultChild as CfnResource, [
+    ...rulesToSuppressForLambdaVPCAndReservedConcurrentExecutions('network-interface-check-custom-resource'),
+  ]);
+
+  return fn;
+}

--- a/src/reporting/private/dashboard.ts
+++ b/src/reporting/private/dashboard.ts
@@ -34,6 +34,15 @@ export interface QuicksightCustomResourceProps {
   readonly redshiftProps: RedShiftProps;
 };
 
+export interface NetworkInterfaceCheckCustomResourceProps {
+  readonly networkInterfaces: string;
+};
+
+export type NetworkInterfaceCheckCustomResourceLambdaProps = {
+  readonly awsRegion: string;
+  readonly networkInterfaces: any[];
+};
+
 export interface QuicksightCustomResourceLambdaProps {
   readonly awsAccountId: string;
   readonly awsRegion: string;

--- a/src/reporting/private/iam.ts
+++ b/src/reporting/private/iam.ts
@@ -111,3 +111,35 @@ export function createRoleForQuicksightCustomResourceLambda(
   return createLambdaRole(scope, 'QuicksightCustomResourceLambdaRole', false, policyStatements, principal, logGroupArn);
 
 }
+
+export function createNetworkInterfaceCheckCustomResourceLambda(
+  scope: Construct,
+) {
+  const logGroupArn = Arn.format(
+    {
+      resource: 'log-group',
+      service: 'logs',
+      resourceName: '/aws/lambda/*',
+      arnFormat: ArnFormat.COLON_RESOURCE_NAME,
+      region: Aws.REGION,
+      account: Aws.ACCOUNT_ID,
+      partition: Aws.PARTITION,
+    },
+  );
+
+  const policyStatements = [
+    new PolicyStatement({
+      effect: Effect.ALLOW,
+      resources: [
+        '*',
+      ],
+      actions: [
+        'ec2:DescribeNetworkInterfaces',
+      ],
+    }),
+  ];
+
+  const principal = new ServicePrincipal('lambda.amazonaws.com');
+  return createLambdaRole(scope, 'NetworkInterfaceCheckCustomResourceLambdaRole', false, policyStatements, principal, logGroupArn);
+
+}

--- a/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
+++ b/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
@@ -1765,6 +1765,25 @@ describe('DataReportingQuickSightStack resource test', () => {
       },
     }, 1);
 
+  template.resourcePropertiesCountIs('AWS::CloudFormation::CustomResource',
+    {
+      ServiceToken: {
+        'Fn::GetAtt': [
+          'NetworkInterfaceCheckCustomResourceProviderframeworkonEvent123C1881',
+          'Arn',
+        ],
+      },
+      awsRegion: {
+        Ref: 'AWS::Region',
+      },
+      networkInterfaces: {
+        'Fn::GetAtt': [
+          'ClickstreamVPCConnectionResource',
+          'NetworkInterfaces',
+        ],
+      },
+    }, 1);
+
   test('Should has ApplicationArnCondition', () => {
     template.hasCondition('ApplicationArnCondition', {
       'Fn::Not': [

--- a/test/reporting/quicksight/lambda/network-interface-check.test.ts
+++ b/test/reporting/quicksight/lambda/network-interface-check.test.ts
@@ -1,0 +1,172 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { DescribeNetworkInterfacesCommand, EC2Client, NetworkInterfaceStatus } from '@aws-sdk/client-ec2';
+import { CdkCustomResourceResponse } from 'aws-lambda';
+import { mockClient } from 'aws-sdk-client-mock';
+import { handler } from '../../../../src/reporting/lambda/custom-resource/quicksight/network-interface-check';
+import { getMockContext } from '../../../common/lambda-context';
+import 'aws-sdk-client-mock-jest';
+import {
+  basicCloudFormationEvent,
+  basicCloudFormationUpdateEvent,
+} from '../../../common/lambda-events';
+
+describe('QuickSight Lambda function', () => {
+  const context = getMockContext();
+  const ec2ClientMock = mockClient(EC2Client);
+
+  const commonProps = {
+    awsRegion: 'us-east-1',
+    networkInterfaces: [
+      {
+        NetworkInterfaceId: 'eni-test11111',
+      },
+      {
+        NetworkInterfaceId: 'eni-test11112',
+      },
+      {
+        NetworkInterfaceId: 'eni-test11113',
+      },
+    ],
+  };
+
+  const createEvent = {
+    ...basicCloudFormationEvent,
+    ResourceProperties: {
+      ...basicCloudFormationEvent.ResourceProperties,
+      ...commonProps,
+    },
+
+  };
+
+  const updateEvent = {
+    ...basicCloudFormationUpdateEvent,
+    ResourceProperties: {
+      ...basicCloudFormationEvent.ResourceProperties,
+      ...commonProps,
+    },
+
+  };
+
+  beforeEach(() => {
+    ec2ClientMock.reset();
+  });
+
+  test('NetworkInterface check custom resource test - create', async () => {
+
+    ec2ClientMock.on(DescribeNetworkInterfacesCommand).resolves({
+      NetworkInterfaces: [
+        {
+          NetworkInterfaceId: 'eni-test11111',
+          Status: NetworkInterfaceStatus.in_use,
+        },
+        {
+          NetworkInterfaceId: 'eni-test11112',
+          Status: NetworkInterfaceStatus.in_use,
+        },
+        {
+          NetworkInterfaceId: 'eni-test11113',
+          Status: NetworkInterfaceStatus.in_use,
+        },
+      ],
+    });
+    const resp = await handler(createEvent, context) as CdkCustomResourceResponse;
+    expect(ec2ClientMock).toHaveReceivedCommandTimes(DescribeNetworkInterfacesCommand, 1);
+    expect(resp.Data?.isReady).toBeDefined();
+    expect(resp.Data?.isReady).toEqual(true);
+
+  });
+
+  test('NetworkInterface check custom resource test - update', async () => {
+
+    ec2ClientMock.on(DescribeNetworkInterfacesCommand).resolves({
+      NetworkInterfaces: [
+        {
+          NetworkInterfaceId: 'eni-test11111',
+          Status: NetworkInterfaceStatus.in_use,
+        },
+        {
+          NetworkInterfaceId: 'eni-test11112',
+          Status: NetworkInterfaceStatus.in_use,
+        },
+        {
+          NetworkInterfaceId: 'eni-test11113',
+          Status: NetworkInterfaceStatus.in_use,
+        },
+      ],
+    });
+    const resp = await handler(updateEvent, context) as CdkCustomResourceResponse;
+    expect(ec2ClientMock).toHaveReceivedCommandTimes(DescribeNetworkInterfacesCommand, 1);
+    expect(resp.Data?.isReady).toBeDefined();
+    expect(resp.Data?.isReady).toEqual(true);
+
+  });
+
+  test('NetworkInterface check custom resource test - wait 2 time', async () => {
+
+    ec2ClientMock.on(DescribeNetworkInterfacesCommand).resolvesOnce({
+      NetworkInterfaces: [
+        {
+          NetworkInterfaceId: 'eni-test11111',
+          Status: NetworkInterfaceStatus.available,
+        },
+        {
+          NetworkInterfaceId: 'eni-test11112',
+          Status: NetworkInterfaceStatus.available,
+        },
+        {
+          NetworkInterfaceId: 'eni-test11113',
+          Status: NetworkInterfaceStatus.in_use,
+        },
+      ],
+    }).resolvesOnce({
+      NetworkInterfaces: [
+        {
+          NetworkInterfaceId: 'eni-test11111',
+          Status: NetworkInterfaceStatus.available,
+        },
+        {
+          NetworkInterfaceId: 'eni-test11112',
+          Status: NetworkInterfaceStatus.in_use,
+        },
+        {
+          NetworkInterfaceId: 'eni-test11113',
+          Status: NetworkInterfaceStatus.in_use,
+        },
+      ],
+    }).resolvesOnce({
+      NetworkInterfaces: [
+        {
+          NetworkInterfaceId: 'eni-test11111',
+          Status: NetworkInterfaceStatus.in_use,
+        },
+        {
+          NetworkInterfaceId: 'eni-test11112',
+          Status: NetworkInterfaceStatus.in_use,
+        },
+        {
+          NetworkInterfaceId: 'eni-test11113',
+          Status: NetworkInterfaceStatus.in_use,
+        },
+      ],
+    });
+
+    const resp = await handler(createEvent, context) as CdkCustomResourceResponse;
+    expect(ec2ClientMock).toHaveReceivedCommandTimes(DescribeNetworkInterfacesCommand, 3);
+    expect(resp.Data?.isReady).toBeDefined();
+    expect(resp.Data?.isReady).toEqual(true);
+
+  });
+
+});


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend