### PR TITLE
chore: add cache control to web console files not to cache index html

### DIFF
--- a/src/cloudfront-control-plane-stack.ts
+++ b/src/cloudfront-control-plane-stack.ts
@@ -194,10 +194,15 @@ export class CloudFrontControlPlaneStack extends Stack {
         assetPath: join(__dirname, '..'),
 
         dockerImage: DockerImage.fromRegistry(Constant.NODE_IMAGE_V18),
-        buildCommand: [
-          'bash', '-c',
-          'export APP_PATH=/tmp/app && mkdir $APP_PATH && cd ./frontend/ && find -L . -type f -not -path "./build/*" -not -path "./node_modules/*" ' +
-          '-exec cp --parents {} $APP_PATH \\; && cd $APP_PATH && yarn install --loglevel error && yarn run build --loglevel error && cp -r ./build/* /asset-output/',
+        buildCommands: [
+          'export APP_PATH=/tmp/app',
+          'mkdir $APP_PATH',
+          'cd ./frontend/',
+          'find -L . -type f -not -path "./build/*" -not -path "./node_modules/*" -exec cp --parents {} $APP_PATH \\;',
+          'cd $APP_PATH',
+          'yarn install --loglevel error',
+          'yarn run build --loglevel error',
+          'cp -r ./build/* /asset-output/',
         ],
         environment: {
           GENERATE_SOURCEMAP: process.env.GENERATE_SOURCEMAP ?? 'false',

--- a/src/control-plane/cloudfront-s3-portal.ts
+++ b/src/control-plane/cloudfront-s3-portal.ts
@@ -61,6 +61,7 @@ import {
 import {
   Source,
   BucketDeployment,
+  CacheControl,
 } from 'aws-cdk-lib/aws-s3-deployment';
 
 import { Construct, IConstruct } from 'constructs';
@@ -188,6 +189,9 @@ export class CloudFrontS3Portal extends Construct {
       prune: false,
       distribution: this.distribution,
       distributionPaths: props.frontendProps.autoInvalidFilePaths,
+      cacheControl: [
+        CacheControl.maxAge(Duration.days(1)),
+      ],
     });
   }
 

--- a/src/control-plane/cloudfront-s3-portal.ts
+++ b/src/control-plane/cloudfront-s3-portal.ts
@@ -82,7 +82,7 @@ export interface DistributionProps {
 export interface FrontendProps {
   readonly assetPath: string;
   readonly dockerImage: DockerImage;
-  readonly buildCommand: string[];
+  readonly buildCommands: string[];
   readonly user?: string;
   readonly autoInvalidFilePaths?: string[];
   readonly assetHash?: string;
@@ -117,6 +117,7 @@ export class CloudFrontS3Portal extends Construct {
   public readonly logBucket: IBucket;
   public readonly controlPlaneUrl: string;
   public readonly bucketDeployment: BucketDeployment;
+  public readonly htmlDeployment: BucketDeployment;
   private origins: Array<CfnDistribution.OriginProperty | IResolvable> | IResolvable;
   private cacheBehaviors: Array<CfnDistribution.CacheBehaviorProperty | IResolvable> | IResolvable;
 
@@ -169,30 +170,61 @@ export class CloudFrontS3Portal extends Construct {
 
     portalBucket.addToResourcePolicy(portalBucketPolicyStatement);
 
-
     // upload static web assets
     this.bucketDeployment = new BucketDeployment(this, 'portal_deploy', {
-      sources: process.env.IS_SKIP_ASSET_BUNDLE === 'true' ? [Source.data('test', 'test')] : [
-        Source.asset(props.frontendProps.assetPath, {
-          bundling: {
-            image: props.frontendProps.dockerImage,
-            command: props.frontendProps.buildCommand,
-            user: props.frontendProps.user,
-            outputType: BundlingOutput.NOT_ARCHIVED,
-            environment: props.frontendProps.environment,
-          },
-          assetHash: props.frontendProps.assetHash ?? undefined,
-          assetHashType: props.frontendProps.assetHashType ?? AssetHashType.SOURCE,
-        }),
+      sources: [
+        this.getWebAssets(props, true),
       ],
       destinationBucket: portalBucket,
       prune: false,
       distribution: this.distribution,
       distributionPaths: props.frontendProps.autoInvalidFilePaths,
       cacheControl: [
-        CacheControl.maxAge(Duration.days(1)),
+        CacheControl.maxAge(Duration.days(30)),
+        CacheControl.immutable(),
       ],
     });
+    this.htmlDeployment = new BucketDeployment(this, 'portal_html_deploy', {
+      sources: [
+        this.getWebAssets(props, false),
+      ],
+      destinationBucket: portalBucket,
+      prune: false,
+      distribution: this.distribution,
+      distributionPaths: props.frontendProps.autoInvalidFilePaths,
+      cacheControl: [
+        CacheControl.maxAge(Duration.seconds(0)),
+      ],
+    });
+  }
+
+  private getWebAssets(props: CloudFrontS3PortalProps, excludeIndexHtml: boolean) {
+    if (process.env.IS_SKIP_ASSET_BUNDLE === 'true') {
+      return Source.data('test', 'test');
+    } else {
+      const commands = [...props.frontendProps.buildCommands];
+      if (excludeIndexHtml) {
+        commands.push('cd /asset-output');
+        commands.push('rm /asset-output/index.html');
+      } else {
+        commands.push('cd /asset-output');
+        commands.push('ls | grep -xv index.html | xargs rm -rf');
+      }
+      return Source.asset(props.frontendProps.assetPath, {
+        bundling: {
+          image: props.frontendProps.dockerImage,
+          command: [
+            'bash', '-c',
+            commands.join(' && '),
+          ],
+          user: props.frontendProps.user,
+          outputType: BundlingOutput.NOT_ARCHIVED,
+          environment: props.frontendProps.environment,
+        },
+        assetHash: props.frontendProps.assetHash ?? undefined,
+        assetHashType: props.frontendProps.assetHashType ?? AssetHashType.SOURCE,
+      });
+    }
   }
 
   private createDistribution(portalBucket: IBucket, distDescription: string,

--- a/test/control-plane/cloudfront-control-plane-stack.test.ts
+++ b/test/control-plane/cloudfront-control-plane-stack.test.ts
@@ -32,8 +32,8 @@ describe('CloudFrontS3PortalStack - Default stack props for common features', ()
   test('Global region', () => {
     commonTemplate.resourceCountIs('AWS::CloudFront::CloudFrontOriginAccessIdentity', 1);
     commonTemplate.resourceCountIs('AWS::CloudFront::Distribution', 1);
-    commonTemplate.resourceCountIs('AWS::Lambda::LayerVersion', 2);
-    commonTemplate.resourceCountIs('Custom::CDKBucketDeployment', 1);
+    commonTemplate.resourceCountIs('AWS::Lambda::LayerVersion', 3);
+    commonTemplate.resourceCountIs('Custom::CDKBucketDeployment', 2);
 
     commonTemplate.hasOutput(OUTPUT_CONTROL_PLANE_URL, {});
     commonTemplate.hasOutput(OUTPUT_CONTROL_PLANE_BUCKET, {});
@@ -170,6 +170,10 @@ describe('CloudFrontS3PortalStack - Default stack props for common features', ()
           Key: Match.stringLikeRegexp('aws-cdk:cr-owned:[a-zA-Z0-9]'),
           Value: 'true',
         },
+        {
+          Key: Match.stringLikeRegexp('aws-cdk:cr-owned:[a-zA-Z0-9]'),
+          Value: 'true',
+        },
       ],
     });
   });
@@ -232,7 +236,7 @@ describe('CloudFrontS3PortalStack - Default stack props for common features', ()
     );
   });
 
-  test('at least two BucketDeployment sources', () => {
+  test('at least three BucketDeployment sources', () => {
 
     const capture = new Capture();
     commonTemplate.hasResourceProperties('Custom::CDKBucketDeployment', {
@@ -240,7 +244,12 @@ describe('CloudFrontS3PortalStack - Default stack props for common features', ()
     });
     commonTemplate.hasResourceProperties('Custom::CDKBucketDeployment', {
       SystemMetadata: {
-        'cache-control': 'max-age=86400',
+        'cache-control': 'max-age=2592000, immutable',
+      },
+    });
+    commonTemplate.hasResourceProperties('Custom::CDKBucketDeployment', {
+      SystemMetadata: {
+        'cache-control': 'max-age=0',
       },
     });
     expect(capture.asArray().length).toBeGreaterThanOrEqual(2);
@@ -406,8 +415,8 @@ describe('CloudFrontS3PortalStack - Default stack props for common features', ()
     commonTemplate.resourceCountIs('AWS::S3::Bucket', 2);
     commonTemplate.resourceCountIs('AWS::CloudFront::CloudFrontOriginAccessIdentity', 1);
     commonTemplate.resourceCountIs('AWS::CloudFront::Distribution', 1);
-    commonTemplate.resourceCountIs('AWS::Lambda::LayerVersion', 2);
-    commonTemplate.resourceCountIs('Custom::CDKBucketDeployment', 1);
+    commonTemplate.resourceCountIs('AWS::Lambda::LayerVersion', 3);
+    commonTemplate.resourceCountIs('Custom::CDKBucketDeployment', 2);
     expect(findResourcesName(commonTemplate, 'AWS::Lambda::Function').sort())
       .toEqual([
         'AWS679f53fac002430cb0da5b7982bd22872D164C4C',
@@ -801,8 +810,8 @@ describe('CloudFrontS3PortalStack - custom domain', () => {
     template.resourceCountIs('AWS::CloudFront::CloudFrontOriginAccessIdentity', 1);
     template.resourceCountIs('AWS::CloudFront::Distribution', 1);
     template.resourceCountIs('AWS::Route53::RecordSet', 1);
-    template.resourceCountIs('AWS::Lambda::LayerVersion', 2);
-    template.resourceCountIs('Custom::CDKBucketDeployment', 1);
+    template.resourceCountIs('AWS::Lambda::LayerVersion', 3);
+    template.resourceCountIs('Custom::CDKBucketDeployment', 2);
 
     template.hasOutput(OUTPUT_CONTROL_PLANE_URL, {});
     template.hasOutput(OUTPUT_CONTROL_PLANE_BUCKET, {});
@@ -876,8 +885,8 @@ describe('CloudFrontS3PortalStack - China region', () => {
     template.resourceCountIs('AWS::CloudFront::CloudFrontOriginAccessIdentity', 1);
     template.resourceCountIs('AWS::CloudFront::Distribution', 1);
     template.resourceCountIs('AWS::Route53::RecordSet', 0);
-    template.resourceCountIs('AWS::Lambda::LayerVersion', 2);
-    template.resourceCountIs('Custom::CDKBucketDeployment', 1);
+    template.resourceCountIs('AWS::Lambda::LayerVersion', 3);
+    template.resourceCountIs('Custom::CDKBucketDeployment', 2);
 
     // Check Origin Request Policy
     template.resourceCountIs('AWS::CloudFront::OriginRequestPolicy', 0);

--- a/test/control-plane/cloudfront-control-plane-stack.test.ts
+++ b/test/control-plane/cloudfront-control-plane-stack.test.ts
@@ -238,6 +238,11 @@ describe('CloudFrontS3PortalStack - Default stack props for common features', ()
     commonTemplate.hasResourceProperties('Custom::CDKBucketDeployment', {
       SourceObjectKeys: capture,
     });
+    commonTemplate.hasResourceProperties('Custom::CDKBucketDeployment', {
+      SystemMetadata: {
+        'cache-control': 'max-age=86400',
+      },
+    });
     expect(capture.asArray().length).toBeGreaterThanOrEqual(2);
 
   });

--- a/test/control-plane/cloudfront-s3-portal.test.ts
+++ b/test/control-plane/cloudfront-s3-portal.test.ts
@@ -36,8 +36,7 @@ const commonApp = new TestApp(cdkOut);
 const frontendProps = {
   assetPath: 'frontend',
   dockerImage: DockerImage.fromRegistry(Constant.NODE_IMAGE_V18),
-  buildCommand: [
-    'bash', '-c',
+  buildCommands: [
     'echo test > /asset-output/test',
   ],
   autoInvalidFilePaths: ['/index.html'],
@@ -156,7 +155,7 @@ describe('CloudFrontS3Portal', () => {
     });
 
     //Distribution
-    commonTemplate.resourceCountIs('Custom::CDKBucketDeployment', 1);
+    commonTemplate.resourceCountIs('Custom::CDKBucketDeployment', 2);
 
     //Lambda function
     commonTemplate.hasResourceProperties('AWS::Lambda::Function', {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend