### PR TITLE
fix: support updating domain, endpoint path and auth secret of ingestion server

### DIFF
--- a/src/ingestion-server/custom-resource/update-alb-rules/index.ts
+++ b/src/ingestion-server/custom-resource/update-alb-rules/index.ts
@@ -12,7 +12,7 @@
  */
 import { ElasticLoadBalancingV2Client, DescribeRulesCommand, CreateRuleCommand, DeleteRuleCommand, ModifyListenerCommand, ModifyRuleCommand, Rule, RuleCondition, ActionTypeEnum, AuthenticateCognitoActionConditionalBehaviorEnum } from '@aws-sdk/client-elastic-load-balancing-v2';
 import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
-import { CloudFormationCustomResourceEvent, Context } from 'aws-lambda';
+import { CloudFormationCustomResourceEvent, CloudFormationCustomResourceUpdateEvent, Context } from 'aws-lambda';
 import { logger } from '../../../common/powertools';
 import { aws_sdk_client_common_config } from '../../../common/sdk-client-config';
 
@@ -87,7 +87,20 @@ async function _handler(
   }
 
   if (requestType === 'Update') {
-    await handleUpdate(listenerArn, endpointPath);
+    const oldProps = (event as CloudFormationCustomResourceUpdateEvent).OldResourceProperties as ResourcePropertiesType;
+    const oldEndpointPath = oldProps.endpointPath;
+    const oldDomainName = oldProps.domainName;
+    const oldAuthenticationSecretArn = oldProps.authenticationSecretArn;
+    await handleUpdate(
+      listenerArn,
+      protocol,
+      endpointPath,
+      domainName,
+      authenticationSecretArn,
+      oldEndpointPath,
+      oldDomainName,
+      oldAuthenticationSecretArn,
+    );
   }
 
   if (clickStreamSDK === 'Yes') {
@@ -105,6 +118,8 @@ async function _handler(
 
     await deleteRules(removeRules);
   }
+
+  await modifyFallbackRule(listenerArn);
 }
 
 async function handleCreate(
@@ -121,31 +136,121 @@ async function handleCreate(
   if (authenticationSecretArn && authenticationSecretArn.length > 0) {
     await createAuthLogindRule(authenticationSecretArn, listenerArn);
   }
-
-  await modifyFallbackRule(listenerArn);
 }
 
-async function handleUpdate(listenerArn: string, endpointPath: string) {
-  const allExistingRules = await getAllExistingAppIdRules(listenerArn);
-  for (const rule of allExistingRules) {
-    if (!rule.Conditions) continue;
-    const pathPatternCondition = rule.Conditions.find((condition) => condition.Field === 'path-pattern');
-    if (pathPatternCondition && pathPatternCondition.Values && pathPatternCondition.Values[0] !== endpointPath) {
+async function handleUpdate(
+  listenerArn: string,
+  protocol: string,
+  endpointPath: string,
+  hostHeader: string,
+  authenticationSecretArn: string,
+  oldEndpointPath: string,
+  oldHostHeader: string,
+  oldAuthenticationSecretArn: string,
+) {
+  if (endpointPath !== oldEndpointPath || hostHeader !== oldHostHeader) {
+    const allExistingPathPatternRules = await getExistingRulesByEndpointPath(listenerArn, oldEndpointPath);
+    if (!allExistingPathPatternRules) return;
+    for (const rule of allExistingPathPatternRules) {
+      if (!rule.Conditions) continue;
       const modifyCommand = new ModifyRuleCommand({
         RuleArn: rule.RuleArn,
-        Actions: rule.Actions,
         Conditions: [
-          {
-            Field: 'path-pattern',
-            Values: [endpointPath], // Update the path-pattern value
-          },
-          ...rule.Conditions.filter((condition) => condition.Field !== 'path-pattern'),
+          ...generateBaseForwardConditions(protocol, endpointPath, hostHeader),
+          ...rule.Conditions.filter((condition) => condition.Field !== 'path-pattern' && condition.Field !== 'host-header'),
         ],
       });
       await albClient.send(modifyCommand);
     }
   }
+
+  if (authenticationSecretArn !== oldAuthenticationSecretArn) {
+    const rulesWithActionTypeIsAuthenticateOidc = await getRulesWithActionTypeIsAuthenticateOidc(listenerArn);
+    const { issuer, userEndpoint, authorizationEndpoint, tokenEndpoint, appClientId, appClientSecret } = await getOidcInfo(authenticationSecretArn);
+    if (!rulesWithActionTypeIsAuthenticateOidc) return;
+    for (const rule of rulesWithActionTypeIsAuthenticateOidc) {
+      if (rule.Conditions?.some(condition => condition.Field === 'path-pattern' && condition.Values?.includes('/login'))) {
+        const authLoginActions = [
+          {
+            Type: ActionTypeEnum.AUTHENTICATE_OIDC,
+            Order: 1,
+            AuthenticateOidcConfig: {
+              ...createAuthenticateOidcConfig(issuer, userEndpoint, authorizationEndpoint, tokenEndpoint, appClientId, appClientSecret),
+              OnUnauthenticatedRequest: AuthenticateCognitoActionConditionalBehaviorEnum.AUTHENTICATE,
+            },
+          },
+          {
+            Type: ActionTypeEnum.FIXED_RESPONSE,
+            Order: 2,
+            FixedResponseConfig: {
+              MessageBody: 'Authenticated',
+              StatusCode: '200',
+              ContentType: 'text/plain',
+            },
+          },
+        ];
+        const modifyCommand = new ModifyRuleCommand({
+          RuleArn: rule.RuleArn,
+          Actions: authLoginActions,
+        });
+        await albClient.send(modifyCommand);
+      } else {
+        const authForwardActions = [
+          {
+            Type: ActionTypeEnum.AUTHENTICATE_OIDC,
+            Order: 1,
+            AuthenticateOidcConfig: {
+              ...createAuthenticateOidcConfig(issuer, userEndpoint, authorizationEndpoint, tokenEndpoint, appClientId, appClientSecret),
+              OnUnauthenticatedRequest: AuthenticateCognitoActionConditionalBehaviorEnum.DENY,
+            },
+          },
+          {
+            Type: ActionTypeEnum.FORWARD,
+            Order: 2,
+            TargetGroupArn: rule.Actions?.find(action => action.Type === ActionTypeEnum.FORWARD)?.TargetGroupArn,
+          },
+        ];
+        const modifyCommand = new ModifyRuleCommand({
+          RuleArn: rule.RuleArn,
+          Actions: authForwardActions,
+        });
+        await albClient.send(modifyCommand);
+      }
+    }
+  }
 }
+
+function createAuthenticateOidcConfig(
+  issuer: string,
+  userEndpoint: string,
+  authorizationEndpoint: string,
+  tokenEndpoint: string,
+  appClientId: string,
+  appClientSecret: string,
+) {
+  const authenticateOidcConfig = {
+    Issuer: issuer,
+    ClientId: appClientId,
+    ClientSecret: appClientSecret,
+    TokenEndpoint: tokenEndpoint,
+    UserInfoEndpoint: userEndpoint,
+    AuthorizationEndpoint: authorizationEndpoint,
+  };
+  return authenticateOidcConfig;
+}
+
+async function getRulesWithActionTypeIsAuthenticateOidc(listenerArn: string) {
+  const describeRulesCommand = new DescribeRulesCommand({
+    ListenerArn: listenerArn,
+  });
+  const allAlbRulesResponse = await albClient.send(describeRulesCommand);
+  const allAlbRules: Rule[] = allAlbRulesResponse.Rules?.filter(rule => !rule.IsDefault) || [];
+  const rulesWithActionTypeIsAuthenticateOidc = allAlbRules.filter(rule =>
+    rule.Actions?.some(action => action.Type === ActionTypeEnum.AUTHENTICATE_OIDC),
+  );
+  return rulesWithActionTypeIsAuthenticateOidc;
+}
+
 
 async function handleClickStreamSDK(input: HandleClickStreamSDKInput) {
   const shouldDeleteRules = [];
@@ -338,6 +443,22 @@ async function getAllExistingAppIdRules(listenerArn: string) {
     parseInt(rule.Priority!) > 3,
   );
   return allExistingAppIdRules;
+}
+
+// create a function, get all rules which contains path-pattern condition and the value equal input endpointPath
+async function getExistingRulesByEndpointPath(listenerArn: string, endpointPath: string) {
+  const describeRulesCommand = new DescribeRulesCommand({
+    ListenerArn: listenerArn,
+  });
+
+  const allAlbRulesResponse = await albClient.send(describeRulesCommand);
+  const allAlbRules: Rule[] = allAlbRulesResponse.Rules?.filter(rule => !rule.IsDefault) || [];
+  const existingRules = allAlbRules.filter(rule =>
+    rule.Conditions?.some(condition =>
+      condition.Field === 'path-pattern' && condition.Values?.includes(endpointPath),
+    ),
+  );
+  return existingRules;
 }
 
 async function createDefaultForwardRule(


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Support updating domain name, endpoint path and auth secret arn

## Implementation highlights

1, Support updating 
  - domain name
  - endpoint path
  - auth secret arn

2, Add unit test cases for above changes

## Test below cases:

1, third sdk + http
  - change endpoint path
  - add appId
  - change endpoint path again

2, third sdk + https + disable auth
  - change endpoint path
  - add appId
  - change endpoint path again

3, third sdk, https, enable auth
  - change auth arn
  - change domain
  - change endpoint path
  - change above together
  - add appId

4, clickstream sdk + http
  - change endpoint path
  - add appId
  - change endpoint path again
  - add and remove appId

5, clickstream sdk + https + disable auth
  - change endpoint path
  - change domain name
  - add appId
  - change endpoint path and domain name again
  - add and remove appId

6, clickstream sdk + https + enable auth
  - change endpoint path, domain name and auth arn
  - add appIds
  - change endpoint path, domain name and auth arn again
  - remove one of appId

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend