### PR TITLE
fix: redshift stack upgrade issue in UPDATE_ROLLBACK_FAILED

### DIFF
--- a/docs/en/upgrade.md
+++ b/docs/en/upgrade.md
@@ -36,6 +36,8 @@
 
 You can view the status of the stack in the AWS CloudFormation console in the **Status** column. You should receive an `UPDATE_COMPLETE` status after a few minutes.
 
+If you encounter any issues during the upgrade process, please refer to the [troubleshooting page][troubleshooting].
+
 ### Upgrade the pipeline of project
 
 1. Log in to the web console of the solution.
@@ -103,3 +105,4 @@ When you upgraded the pipeline from v1.0.x, you need to perform the below action
 [cloudfront-s3-oidc-cn-template]: https://{{ aws_cn_bucket }}.s3.cn-north-1.amazonaws.com.cn/{{ aws_cn_prefix }}/{{ aws_cn_version }}/cloudfront-s3-control-plane-stack-cn.template.json
 [intranet-template]: https://{{ aws_bucket }}.s3.amazonaws.com/{{ aws_prefix }}/{{ aws_version }}/private-exist-vpc-control-plane-stack.template.json
 [intranet-cn-template]: https://{{ aws_cn_bucket }}.s3.cn-north-1.amazonaws.com.cn/{{ aws_cn_prefix }}/{{ aws_cn_version }}/private-exist-vpc-control-plane-stack.template.json
+[troubleshooting]: ./troubleshooting.md

--- a/docs/zh/troubleshooting.md
+++ b/docs/zh/troubleshooting.md
@@ -83,3 +83,46 @@ aws logs put-resource-policy --policy-name AWSLogDeliveryWrite20150319 \
 **解决方法：**
 
 登录解决方案控制台，在管道详情页点击"重试"按钮。
+
+
+## 问题: Clickstream-DataModelingRedshift-xxxxx 堆栈更新失败，状态显示为 UPDATE_ROLLBACK_FAILED
+
+从 1.0.x 升级到 1.1.x 时, 如果 CloudFormation 堆栈 `Clickstream-DataModelingRedshift-xxxxx` 的状态显示为 `UPDATE_ROLLBACK_FAILED`，您需要按照以下步骤手动修复。
+
+**解决方法：**
+1. 在 CloudFormation 的 **资源** 选项卡中，找到逻辑 ID 为 `CreateApplicationSchemasCreateSchemaForApplicationsFn` 的 Lambda 函数名称。
+
+2. 在下面的脚本中更新函数名称，并在 shell 终端中执行该脚本（您必须已安装并配置了 AWS CLI）：
+
+```sh
+aws_region=<us-east-1> # replace this with your AWS region, and remove '<', '>'
+fn_name=<fn_name_to_replace> # replace this with actual function name in step 1 and remove '<', '>'
+
+cat <<END | > ./index.mjs
+export const handler = async (event) => {
+  console.log('No ops!')
+  const response = {
+    Status: 'SUCCESS',
+    Data: {
+      DatabaseName: '',
+      RedshiftBIUsername: ''
+    }
+  };
+  return response;
+};
+END
+
+rm ./noops-lambda.zip > /dev/null 2>&1
+zip ./noops-lambda.zip ./index.mjs
+
+aws lambda update-function-code --function-name ${fn_name} \
+ --zip-file fileb://./noops-lambda.zip \
+ --region ${aws_region} | tee /dev/null
+
+```
+
+3. 在 CloudFormation Web 控制台中，选择 **堆栈操作** -> **继续更新回滚**。
+
+4. 等待堆栈状态变为 **UPDATE_ROLLBACK_COMPLETE**。
+
+5. 从 Clickstream Web 控制台中重试升级。

--- a/docs/zh/upgrade.md
+++ b/docs/zh/upgrade.md
@@ -48,6 +48,8 @@
 
 您可以在解决方案控制台的 **状态** 列中查看管道的状态。 几分钟后您应该会收到`活跃`状态。
 
+如果您在升级过程中遇到任何问题，请参考[故障排除页面][troubleshooting]。
+
 ## 升级后操作
 
 ### 从1.0.x升级后迁移现有数据
@@ -103,3 +105,4 @@
 [cloudfront-s3-oidc-cn-template]: https://{{ aws_cn_bucket }}.s3.cn-north-1.amazonaws.com.cn/{{ aws_cn_prefix }}/{{ aws_cn_version }}/cloudfront-s3-control-plane-stack-cn.template.json
 [intranet-template]: https://{{ aws_bucket }}.s3.amazonaws.com/{{ aws_prefix }}/{{ aws_version }}/private-exist-vpc-control-plane-stack.template.json
 [intranet-cn-template]: https://{{ aws_cn_bucket }}.s3.cn-north-1.amazonaws.com.cn/{{ aws_cn_prefix }}/{{ aws_cn_version }}/private-exist-vpc-control-plane-stack.template.json
+[troubleshooting]: ./troubleshooting.md

--- a/src/analytics/private/app-schema.ts
+++ b/src/analytics/private/app-schema.ts
@@ -129,10 +129,14 @@ export class ApplicationSchemas extends Construct {
         'create-schemas.ts',
       ),
       handler: 'handler',
-      memorySize: 128,
+      memorySize: 256,
       reservedConcurrentExecutions: 1,
-      timeout: Duration.minutes(5),
+      timeout: Duration.minutes(15),
       logRetention: RetentionDays.ONE_WEEK,
+      environment: {
+        SUPPRESS_DB_ERROR: 'true',
+        SUPPRESS_ALL_ERROR: 'false',
+      },
       role: createLambdaRole(this, 'CreateApplicationSchemaRole', false,
         [writeSecretPolicy]),
       layers: [sqlLayer],
@@ -148,8 +152,8 @@ export class ApplicationSchemas extends Construct {
     const reportingViewsPath = resolve(__dirname, 'sqls/redshift/dashboard');
 
     // Get latest timestamp from both directories
-    const latestSchemaTimestamp = this.getLatestTimestampForDirectory(schemaPath, schemaDefs);
-    const latestReportingViewTimestamp = this.getLatestTimestampForDirectory(reportingViewsPath, reportingViewsDef);
+    const latestSchemaTimestamp = this.getLatestTimestampForDirectory(schemaPath);
+    const latestReportingViewTimestamp = this.getLatestTimestampForDirectory(reportingViewsPath);
 
     // Return the max of both timestamps
     const latestTimestamp = Math.max(latestSchemaTimestamp, latestReportingViewTimestamp);
@@ -157,20 +161,15 @@ export class ApplicationSchemas extends Construct {
     return latestTimestamp;
   }
 
-  private getLatestTimestampForDirectory(directory: string, definitions: any[]): number {
+  private getLatestTimestampForDirectory(directory: string): number {
     let latestTimestamp = 0;
 
-    const updatableFiles = definitions
-      .filter(def => def.updatable === 'true')
-      .map(def => def.sqlFile || (def.viewName + '.sql'));
     const files = readdirSync(directory);
     files.forEach(file => {
-      if (updatableFiles.includes(file)) {
-        const filePath = join(directory, file);
-        const stats = statSync(filePath);
-        if (stats.isFile()) {
-          latestTimestamp = Math.max(stats.mtime.getTime(), latestTimestamp);
-        }
+      const filePath = join(directory, file);
+      const stats = statSync(filePath);
+      if (stats.isFile()) {
+        latestTimestamp = Math.max(stats.mtime.getTime(), latestTimestamp);
       }
     });
 

--- a/src/analytics/private/model.ts
+++ b/src/analytics/private/model.ts
@@ -19,7 +19,6 @@ export interface LoadDataConfig {
   readonly maxFilesLimit: number;
 }
 
-
 interface BucketInfo {
   readonly s3Bucket: IBucket;
   readonly prefix: string;
@@ -84,7 +83,6 @@ interface CustomProperties {
 }
 
 type SQLBasic = {
-  readonly updatable: 'true' | 'false';
   readonly multipleLine?: 'true' | 'false';
 }
 

--- a/src/analytics/private/sql-def.ts
+++ b/src/analytics/private/sql-def.ts
@@ -16,43 +16,33 @@ import { CLICKSTREAM_DEVICE_VIEW_NAME, CLICKSTREAM_EVENT_PARAMETER_VIEW_NAME, CL
 
 export const reportingViewsDef: SQLViewDef[] = [
   {
-    updatable: 'false',
     viewName: CLICKSTREAM_EVENT_VIEW_NAME,
   },
   {
-    updatable: 'false',
     viewName: CLICKSTREAM_EVENT_PARAMETER_VIEW_NAME,
   },
   {
-    updatable: 'false',
     viewName: CLICKSTREAM_LIFECYCLE_DAILY_VIEW_NAME,
   },
   {
-    updatable: 'false',
     viewName: CLICKSTREAM_LIFECYCLE_WEEKLY_VIEW_NAME,
   },
   {
-    updatable: 'false',
     viewName: CLICKSTREAM_USER_FIRST_ATTR_VIEW_NAME,
   },
   {
-    updatable: 'true',
     viewName: CLICKSTREAM_USER_DIM_VIEW_NAME,
   },
   {
-    updatable: 'false',
     viewName: CLICKSTREAM_SESSION_VIEW_NAME,
   },
   {
-    updatable: 'false',
     viewName: CLICKSTREAM_DEVICE_VIEW_NAME,
   },
   {
-    updatable: 'false',
     viewName: CLICKSTREAM_RETENTION_VIEW_NAME,
   },
   {
-    updatable: 'true',
     viewName: CLICKSTREAM_USER_ATTR_VIEW_NAME,
   },
 ];
@@ -61,63 +51,48 @@ export const reportingViewsDef: SQLViewDef[] = [
 // keep order
 export const schemaDefs: SQLDef[] = [
   {
-    updatable: 'true',
     sqlFile: 'clickstream-log.sql',
   },
   {
-    updatable: 'true',
     sqlFile: 'event.sql',
   },
   {
-    updatable: 'true',
     sqlFile: 'event-parameter.sql',
   },
   {
-    updatable: 'true',
     sqlFile: 'user.sql',
   },
   {
-    updatable: 'true',
     sqlFile: 'item.sql',
   },
   {
-    updatable: 'false',
     sqlFile: 'item-m-view.sql',
   },
   {
-    updatable: 'false',
     sqlFile: 'user-m-view.sql',
   },
   {
-    updatable: 'true',
     sqlFile: 'sp-clickstream-log.sql',
   },
   {
-    updatable: 'true',
     sqlFile: 'sp-clickstream-log-non-atomic.sql',
   },
   {
-    updatable: 'true',
     sqlFile: 'grant-permissions-to-bi-user-1.sql',
   },
   {
-    updatable: 'true',
     sqlFile: 'grant-permissions-to-bi-user-2.sql',
   },
   {
-    updatable: 'true',
     sqlFile: 'sp-scan-metadata.sql',
   },
   {
-    updatable: 'true',
     sqlFile: 'sp-clear-expired-events.sql',
   },
   {
-    updatable: 'true',
     sqlFile: 'sp-clear-item-and-user.sql',
   },
   {
-    updatable: 'true',
     sqlFile: 'sp-migrate-ods-events-1.0-to-1.1.sql',
   },
 ];

--- a/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
@@ -10,20 +10,20 @@
  *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
  *  and limitations under the License.
  */
+//@ts-nocheck
 
 import { readFileSync } from 'fs';
 import { LambdaClient, ListTagsCommand } from '@aws-sdk/client-lambda';
-import { DescribeStatementCommand, BatchExecuteStatementCommand, BatchExecuteStatementCommandInput, ExecuteStatementCommand, RedshiftDataClient, ExecuteStatementCommandInput } from '@aws-sdk/client-redshift-data';
+import { DescribeStatementCommand, ExecuteStatementCommand, RedshiftDataClient } from '@aws-sdk/client-redshift-data';
 import { CreateSecretCommand, DescribeSecretCommand, ResourceNotFoundException, SecretsManagerClient, UpdateSecretCommand } from '@aws-sdk/client-secrets-manager';
 import { CdkCustomResourceEvent, CdkCustomResourceCallback, CdkCustomResourceResponse } from 'aws-lambda';
 import { mockClient } from 'aws-sdk-client-mock';
 import mockfs from 'mock-fs';
 import { RedshiftOdsTables } from '../../../../../src/analytics/analytics-on-redshift';
-import { ResourcePropertiesType, TABLES_VIEWS_FOR_REPORTING, handler, physicalIdPrefix } from '../../../../../src/analytics/lambdas/custom-resource/create-schemas';
+import { ResourcePropertiesType, handler, physicalIdPrefix } from '../../../../../src/analytics/lambdas/custom-resource/create-schemas';
 import 'aws-sdk-client-mock-jest';
-import { ProvisionedRedshiftProps, SQLViewDef } from '../../../../../src/analytics/private/model';
+import { ProvisionedRedshiftProps } from '../../../../../src/analytics/private/model';
 import { reportingViewsDef, schemaDefs } from '../../../../../src/analytics/private/sql-def';
-import { CLICKSTREAM_EVENT_VIEW_NAME, CLICKSTREAM_USER_ATTR_VIEW_NAME, TABLE_NAME_EVENT, TABLE_NAME_EVENT_PARAMETER } from '../../../../../src/common/constant';
 import { getMockContext } from '../../../../common/lambda-context';
 import { basicCloudFormationEvent } from '../../../../common/lambda-events';
 
@@ -92,108 +92,6 @@ describe('Custom resource - Create schemas for applications in Redshift database
     RequestType: 'Update',
   };
 
-  const updateServerlessEvent2: CdkCustomResourceEvent = {
-    ...createServerlessEvent,
-    OldResourceProperties: {
-      ...createServerlessEvent.ResourceProperties,
-      appIds: 'app1',
-    },
-    ResourceProperties: {
-      ...createServerlessEvent.ResourceProperties,
-      appIds: 'app2',
-    },
-    PhysicalResourceId: `${physicalIdPrefix}abcde`,
-    RequestType: 'Update',
-  };
-
-  const updateServerlessEvent3: CdkCustomResourceEvent = {
-    ...createServerlessEvent,
-    OldResourceProperties: {
-      ...createServerlessEvent.ResourceProperties,
-      appIds: 'app1',
-    },
-    ResourceProperties: {
-      ...createServerlessEvent.ResourceProperties,
-      appIds: 'app1,app2',
-    },
-    PhysicalResourceId: `${physicalIdPrefix}abcde`,
-    RequestType: 'Update',
-  };
-
-
-  //mock upgrade from 1.0.x
-  const updateServerlessEvent4: CdkCustomResourceEvent = {
-    ...createServerlessEvent,
-    OldResourceProperties: {
-      ...basicCloudFormationEvent.ResourceProperties,
-      ServiceToken: 'token-1',
-      projectId: 'project1',
-      odsTableNames,
-      databaseName: projectDBName,
-      dataAPIRole: `arn:aws:iam::1234567890:role/${roleName}`,
-      redshiftBIUserParameter: '/clickstream/report/user/1111',
-      redshiftBIUsernamePrefix: biUserNamePrefix,
-      reportingViewsDef: [
-        {
-          updatable: 'false',
-          sqlFile: 'clickstream_event_view.sql',
-        },
-        {
-          updatable: 'false',
-          sqlFile: 'clickstream_event_parameter_view.sql',
-        },
-        {
-          updatable: 'false',
-          sqlFile: 'clickstream_lifecycle_daily_view.sql',
-        },
-        {
-          updatable: 'false',
-          sqlFile: 'clickstream_lifecycle_weekly_view_v1.sql',
-        },
-        {
-          updatable: 'true',
-          sqlFile: 'clickstream_user_dim_view.sql',
-        },
-        {
-          updatable: 'false',
-          sqlFile: 'clickstream_session_view.sql',
-        },
-        {
-          updatable: 'false',
-          sqlFile: 'clickstream_device_view.sql',
-        },
-        {
-          updatable: 'false',
-          sqlFile: 'clickstream_retention_view.sql',
-        },
-        {
-          updatable: 'false',
-          sqlFile: 'clickstream_user_attr_view.sql',
-        },
-      ],
-      schemaDefs,
-      appIds: 'app1',
-      serverlessRedshiftProps: {
-        workgroupName: workgroupName,
-        databaseName: defaultDBName,
-        dataAPIRoleArn: 'arn:aws:iam::1234567890:role/RedshiftDBUserRole',
-      },
-    },
-    ResourceProperties: {
-      ...createServerlessEvent.ResourceProperties,
-      appIds: 'app1',
-    },
-    PhysicalResourceId: `${physicalIdPrefix}abcde`,
-    RequestType: 'Update',
-  };
-
-  const newReportingView = 'clickstream_new_reporting_view_v0';
-  const testReportingViewsDef2: SQLViewDef[] = reportingViewsDef.slice();
-  testReportingViewsDef2.push({
-    updatable: 'false',
-    viewName: newReportingView,
-  });
-
   const clusterId = 'redshift-cluster-1';
   const dbUser = 'aDBUser';
   const provisionedRedshiftProps: ProvisionedRedshiftProps = {
@@ -221,26 +119,16 @@ describe('Custom resource - Create schemas for applications in Redshift database
     RequestType: 'Update',
   };
 
-  const updateAdditionalProvisionedEvent2: CdkCustomResourceEvent = {
-    ...createProvisionedEvent,
-    OldResourceProperties: {
-      ...createProvisionedEvent.ResourceProperties,
-      reportingViewsDef: reportingViewsDef,
-      schemaDefs: schemaDefs,
-      appIds: 'app1',
-    },
-    ResourceProperties: {
-      ...createProvisionedEvent.ResourceProperties,
-      appIds: 'app1,app2',
-      reportingViewsDef: testReportingViewsDef2,
-      schemaDefs: schemaDefs,
-    },
-    PhysicalResourceId: 'physical-resource-id',
-    RequestType: 'Update',
-  };
+  const databaseSQLCount = 1;
+  const biUserSQLCount = 1;
+  const appReportingCount = reportingViewsDef.length;
+  const appSchemaCount = schemaDefs.length;
+
+  const baseCount = databaseSQLCount + biUserSQLCount; // total: 2
+  const appNewCount = appReportingCount * 2 + appSchemaCount + 7; // total: 42
 
   const defs: { [key: string]: string } = {};
-  defs[`/opt/dashboard/${newReportingView}.sql`] = '';
+
   beforeEach(async () => {
     redshiftDataMock.reset();
     smMock.reset();
@@ -273,11 +161,10 @@ describe('Custom resource - Create schemas for applications in Redshift database
       },
     };
     redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
-    redshiftDataMock.on(BatchExecuteStatementCommand).resolves({ Id: 'Id-2' });
     redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
     const resp = await handler(eventWithoutApp, context, callback) as CdkCustomResourceResponse;
     expect(resp.Status).toEqual('SUCCESS');
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 2);
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, baseCount);
     expect(redshiftDataMock).toHaveReceivedNthSpecificCommandWith(1, ExecuteStatementCommand, {
       Sql: `CREATE DATABASE ${projectDBName};`,
       WorkgroupName: workgroupName,
@@ -285,7 +172,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
       ClusterIdentifier: undefined,
       DbUser: undefined,
     });
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 2);
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, baseCount);
   });
 
   test('BI user is created in creation event', async () => {
@@ -301,23 +188,14 @@ describe('Custom resource - Create schemas for applications in Redshift database
         appIds: '',
       },
     };
-    redshiftDataMock.on(ExecuteStatementCommand).resolvesOnce({ Id: 'id-1' })
-      .callsFake(input => {
-        if (input as ExecuteStatementCommandInput) {
-          if (input.Sql.includes('CREATE USER')) {
-            return { Id: 'id-2' };
-          }
-        }
-        throw new Error('Sql-1 are not expected');
-      }).resolves({ Id: 'Id-1' });
-    redshiftDataMock.on(BatchExecuteStatementCommand).resolves({ Id: 'Id-2' });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
     redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
     const resp = await handler(eventWithoutApp, context, callback) as CdkCustomResourceResponse;
     expect(resp.Status).toEqual('SUCCESS');
     expect(smMock).toHaveReceivedCommandTimes(CreateSecretCommand, 1);
     expect(smMock).toHaveReceivedCommandTimes(DescribeSecretCommand, 1);
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 2);
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 2);
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, baseCount);
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, baseCount);
   });
 
   test('BI user is created in creation event - secret already exist', async () => {
@@ -333,43 +211,15 @@ describe('Custom resource - Create schemas for applications in Redshift database
         appIds: '',
       },
     };
-    redshiftDataMock.on(ExecuteStatementCommand).resolvesOnce({ Id: 'id-1' })
-      .callsFake(input => {
-        if (input as ExecuteStatementCommandInput) {
-          if (input.Sql.includes('CREATE USER')) {
-            return { Id: 'id-2' };
-          }
-        }
-        throw new Error('Sql-2 are not expected');
-      }).resolves({ Id: 'Id-1' });
-    redshiftDataMock.on(BatchExecuteStatementCommand).resolves({ Id: 'Id-2' });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
     redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
     const resp = await handler(eventWithoutApp, context, callback) as CdkCustomResourceResponse;
     expect(resp.Status).toEqual('SUCCESS');
     expect(smMock).toHaveReceivedCommandTimes(CreateSecretCommand, 0);
     expect(smMock).toHaveReceivedCommandTimes(UpdateSecretCommand, 1);
     expect(smMock).toHaveReceivedCommandTimes(DescribeSecretCommand, 1);
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 2);
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 2);
-  });
-
-  test('Created bi user with lower case characters only', async () => {
-    smMock.onAnyCommand().resolves({});
-    lambdaMock.on(ListTagsCommand).resolves({
-      Tags: { tag_key: 'tag_value' },
-    });
-    const regex = new RegExp(`^CREATE USER ${biUserNamePrefix}[a-z0-9A-Z$%]{8} PASSWORD '[a-zA-Z0-9!#$%^&-_=+|]{32}'$`);
-    redshiftDataMock.on(ExecuteStatementCommand).resolvesOnce({ Id: 'Id-1' })
-      .callsFakeOnce(input => {
-        if (input as ExecuteStatementCommandInput && regex.test(input.Sql)) {
-          return 'Id-2';
-        }
-        throw new Error(`Sql '${input.Sql}' are not expected, the bi user does not meet the pattern.`);
-      });
-    redshiftDataMock.on(BatchExecuteStatementCommand).resolves({ Id: 'Id-2' });
-    redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
-    const resp = await handler(createServerlessEvent, context, callback) as CdkCustomResourceResponse;
-    expect(resp.Status).toEqual('SUCCESS');
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, baseCount);
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, baseCount);
   });
 
   test('Created database, bi user, schemas and views in Redshift serverless', async () => {
@@ -378,34 +228,13 @@ describe('Custom resource - Create schemas for applications in Redshift database
       Tags: { tag_key: 'tag_value' },
     });
     redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
-    redshiftDataMock.on(BatchExecuteStatementCommand).callsFakeOnce(input => {
-      const sqlStr = input.Sqls.join(';\n');
-      if (input as BatchExecuteStatementCommandInput) {
-        if (sqlStr.includes('CREATE SCHEMA IF NOT EXISTS app1')) {
-          return { Id: 'Id-1' };
-        }
-      }
-      throw new Error('Sql-6 are not expected');
-    }).callsFakeOnce(input => {
-      if (input as BatchExecuteStatementCommandInput) {
-        for (const sql of input.Sqls) {
-          if (sql.includes('{{')) {
-            throw new Error(`The SQL '${sql}' contains the mustache variables!`);
-          }
-        }
-      }
-      return 'Id-22';
-    });
     redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
+
     const resp = await handler(createServerlessEvent, context, callback) as CdkCustomResourceResponse;
+
     expect(resp.Status).toEqual('SUCCESS');
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 2);
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 2);
-    expect(redshiftDataMock).toHaveReceivedNthSpecificCommandWith(1, BatchExecuteStatementCommand, {
-      Sqls: expect.arrayContaining([
-        expect.stringMatching(`GRANT USAGE ON SCHEMA app1 TO ${biUserNamePrefix}\\w{8}`),
-      ]),
-    });
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, baseCount + appNewCount);
+
     expect(redshiftDataMock).toHaveReceivedNthSpecificCommandWith(1, ExecuteStatementCommand, {
       Sql: `CREATE DATABASE ${projectDBName};`,
       WorkgroupName: workgroupName,
@@ -413,14 +242,18 @@ describe('Custom resource - Create schemas for applications in Redshift database
       ClusterIdentifier: undefined,
       DbUser: undefined,
     });
-    expect(redshiftDataMock).toHaveReceivedNthSpecificCommandWith(1, BatchExecuteStatementCommand, {
-      WorkgroupName: workgroupName,
-      Database: projectDBName,
-      ClusterIdentifier: undefined,
-      DbUser: undefined,
+
+    expect(redshiftDataMock).toHaveReceivedNthSpecificCommandWith(2, ExecuteStatementCommand, {
+      Sql: expect.stringMatching(`CREATE USER ${biUserNamePrefix}[a-z0-9]{8} PASSWORD .*`),
     });
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 4);
+
+    expect(redshiftDataMock).toHaveReceivedNthSpecificCommandWith(3, ExecuteStatementCommand, {
+      Sql: expect.stringContaining('CREATE SCHEMA IF NOT EXISTS app1'),
+    });
+
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, baseCount + appNewCount);
   });
+
 
   test('Created database, bi user, schemas and views in Redshift serverless - check status multiple times to wait success', async () => {
     smMock.onAnyCommand().resolves({});
@@ -428,18 +261,16 @@ describe('Custom resource - Create schemas for applications in Redshift database
       Tags: { tag_key: 'tag_value' },
     });
     redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
-    redshiftDataMock.on(BatchExecuteStatementCommand).resolves({ Id: 'Id-2' });
     redshiftDataMock.on(DescribeStatementCommand)
-      .resolvesOnce({ Status: 'FINISHED' }) // create db
-      .resolvesOnce({ Status: 'FINISHED' }) // create bi user
-      .resolvesOnce({ Status: 'STARTED' }) // create schemas
       .resolvesOnce({ Status: 'FINISHED' })
-      .resolves({ Status: 'FINISHED' }); // create views
+      .resolvesOnce({ Status: 'FINISHED' })
+      .resolvesOnce({ Status: 'STARTED' })
+      .resolvesOnce({ Status: 'FINISHED' })
+      .resolves({ Status: 'FINISHED' });
     const resp = await handler(createServerlessEvent, context, callback) as CdkCustomResourceResponse;
     expect(resp.Status).toEqual('SUCCESS');
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 2);
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 2);
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 5);
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, baseCount + appNewCount);
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, baseCount + appNewCount + 1);
   });
 
   test('Created database, bi user, schemas and views in Redshift serverless - check status multiple times to wait with failure', async () => {
@@ -448,18 +279,15 @@ describe('Custom resource - Create schemas for applications in Redshift database
       Tags: { tag_key: 'tag_value' },
     });
     redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
-    redshiftDataMock.on(BatchExecuteStatementCommand).resolves({ Id: 'Id-2' });
     redshiftDataMock.on(DescribeStatementCommand)
-      .resolvesOnce({ Status: 'FINISHED' }) // create db
-      .resolvesOnce({ Status: 'FINISHED' }) // create bi user
-      .resolvesOnce({ Status: 'STARTED' }) // create schemas
-      .resolvesOnce({ Status: 'FAILED' }); // for second describe call while creating schema
+      .resolvesOnce({ Status: 'FINISHED' })
+      .resolvesOnce({ Status: 'FINISHED' })
+      .resolvesOnce({ Status: 'STARTED' })
+      .resolvesOnce({ Status: 'FAILED' });
     try {
       await handler(createServerlessEvent, context, callback);
     } catch (e) {
-      expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 2);
-      expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 1);
-      expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 4);
+      expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 3);
       return;
     }
     fail('No exception happened when Redshift DescribeStatementCommand returns FAILED');
@@ -471,198 +299,60 @@ describe('Custom resource - Create schemas for applications in Redshift database
       Tags: { tag_key: 'tag_value' },
     });
     redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
-    redshiftDataMock.on(BatchExecuteStatementCommand).resolves({ Id: 'Id-2' });
     redshiftDataMock.on(DescribeStatementCommand)
-      .resolvesOnce({ Status: 'FINISHED' }) // create db
-      .resolvesOnce({ Status: 'FINISHED' }) // create bi user
-      .resolvesOnce({ Status: 'SUBMITTED' }) // create schemas
+      .resolvesOnce({ Status: 'FINISHED' })
+      .resolvesOnce({ Status: 'FINISHED' })
+      .resolvesOnce({ Status: 'SUBMITTED' })
       .resolves({ Status: 'PICKED' });
     try {
       await handler(createServerlessEvent, context, callback);
     } catch (e) {
-      expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 2);
-      expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 1);
-      expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 2 + 1 + 4);
+      expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 3);
       return;
     }
     fail('No exception happened when timeout happened in waiting for the status Redshift DescribeStatementCommand becoming FINISHED');
   });
 
-  test('Updated schemas and views only in Redshift serverless in update stack', async () => {
+  test('Update schemas and views in Redshift serverless should not create database and user', async () => {
     smMock.onAnyCommand().resolves({});
     lambdaMock.on(ListTagsCommand).resolves({
       Tags: { tag_key: 'tag_value' },
     });
-    redshiftDataMock.on(BatchExecuteStatementCommand).callsFakeOnce(input => {
-      const sqlStr = input.Sqls.join(';\n');
-      if (input as BatchExecuteStatementCommandInput) {
-        if (sqlStr.includes('CREATE SCHEMA IF NOT EXISTS app2')
-          && sqlStr.includes(`GRANT USAGE ON SCHEMA app2 TO ${biUserNamePrefix}abcde`)
-          && sqlStr.includes(`ALTER DEFAULT PRIVILEGES IN SCHEMA app2 GRANT SELECT ON TABLES TO ${biUserNamePrefix}abcde`)
-        ) {
-          return { Id: 'Id-1' };
-        }
-      }
-      throw new Error('Sql-3 are not expected');
-    }).resolves({ Id: 'Id-2' });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
     redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
-    const resp = await handler(updateServerlessEvent2, context, callback) as CdkCustomResourceResponse;
+
+    const resp = await handler(updateServerlessEvent, context, callback) as CdkCustomResourceResponse;
+
     expect(resp.Status).toEqual('SUCCESS');
-    expect(resp.Data?.RedshiftBIUsername).toEqual(`${biUserNamePrefix}abcde`);
-    expect(smMock).toHaveReceivedCommandTimes(CreateSecretCommand, 0);
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 2);
-    expect(redshiftDataMock).toHaveReceivedNthSpecificCommandWith(1, BatchExecuteStatementCommand, {
-      WorkgroupName: workgroupName,
-      Database: projectDBName,
-      ClusterIdentifier: undefined,
-      DbUser: undefined,
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, appNewCount);
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, appNewCount);
+
+    expect(redshiftDataMock).toHaveReceivedNthSpecificCommandWith(1, ExecuteStatementCommand, {
+      Sql: expect.stringContaining('CREATE SCHEMA IF NOT EXISTS app2'),
     });
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 2);
-  });
-
-
-  test('Validate sqls when update schema', async () => {
-    smMock.onAnyCommand().resolves({});
-    lambdaMock.on(ListTagsCommand).resolves({
-      Tags: { tag_key: 'tag_value' },
-    });
-    const schemaSQLForApp2Count = 1 + // create schema for new app
-      schemaDefs.length;
-
-    const schemaSQLForApp1Count = schemaDefs.filter((def) => def.updatable === 'true').length;
-
-    const reportingSQLForApp2Count = reportingViewsDef.length * 2 + // grant to bi user one by one
-      TABLES_VIEWS_FOR_REPORTING.length;
-
-    const reportingSQLForApp1Count = reportingViewsDef.filter((def) => def.updatable === 'true').length +
-      reportingViewsDef.length + // grant to bi user one by one
-      TABLES_VIEWS_FOR_REPORTING.length;
-
-    redshiftDataMock.on(BatchExecuteStatementCommand).callsFakeOnce(input => {
-      console.log('input.Sqls.length-1:' + input.Sqls.length);
-      const expectedSql = 'CREATE SCHEMA IF NOT EXISTS app2';
-      if (input.Sqls.length !== schemaSQLForApp2Count || input.Sqls[0] !== expectedSql) {
-        throw new Error('create schema sqls for app2 are not expected');
-      }
-      return { Id: 'Id-1' };
-    }).callsFakeOnce(input => {
-      console.log('input.Sqls.length-2:' + input.Sqls.length);
-      const expectedSql = 'CREATE TABLE IF NOT EXISTS app1.clickstream_log';
-      if (input.Sqls.length !== schemaSQLForApp1Count || !(input.Sqls[0] as string).startsWith(expectedSql)) {
-        throw new Error('update schema sqls for app1 are not expected');
-      }
-      return { Id: 'Id-1' };
-
-    }).callsFakeOnce(input => {
-      console.log('input.Sqls.length-3:' + input.Sqls.length);
-      const expectedSql = `CREATE MATERIALIZED VIEW app2.${CLICKSTREAM_EVENT_VIEW_NAME}`;
-      const expectedSql2 = `GRANT SELECT ON app2.${CLICKSTREAM_USER_ATTR_VIEW_NAME} TO clickstream_report_user_abcde;`;
-      const expectedSql3 = `GRANT SELECT ON app2.${TABLE_NAME_EVENT} TO clickstream_report_user_abcde;`;
-      const expectedSql4 = 'GRANT SELECT ON app2.item_m_view TO clickstream_report_user_abcde;';
-      if (input.Sqls.length !== reportingSQLForApp2Count
-        || !(input.Sqls[0] as string).startsWith(expectedSql)
-        || !(input.Sqls[reportingViewsDef.length * 2 - 1] as string).startsWith(expectedSql2)
-        || !(input.Sqls[reportingSQLForApp2Count - TABLES_VIEWS_FOR_REPORTING.length] as string).startsWith(expectedSql3)
-        || !(input.Sqls[reportingSQLForApp2Count - 1] as string).startsWith(expectedSql4)
-      ) {
-        throw new Error('create report view sqls for app2 are not expected');
-      }
-      return { Id: 'Id-1' };
-    }).callsFakeOnce(input => {
-      console.log('input.Sqls.length-4:' + input.Sqls.length);
-      const expectedSql1 = `GRANT SELECT ON app1.${CLICKSTREAM_USER_ATTR_VIEW_NAME} TO clickstream_report_user_abcde;`;
-      const expectedSql2 = `GRANT SELECT ON app1.${TABLE_NAME_EVENT} TO clickstream_report_user_abcde;`;
-      const expectedSql3 = 'GRANT SELECT ON app1.item_m_view TO clickstream_report_user_abcde;';
-      if (input.Sqls.length !== reportingSQLForApp1Count
-        || !(input.Sqls[reportingSQLForApp1Count - TABLES_VIEWS_FOR_REPORTING.length - 1] as string).startsWith(expectedSql1)
-        || !(input.Sqls[reportingSQLForApp1Count - TABLES_VIEWS_FOR_REPORTING.length] as string).startsWith(expectedSql2)
-        || !(input.Sqls[reportingSQLForApp1Count - 1] as string).startsWith(expectedSql3)
-      ) {
-        throw new Error('update report view sqls for app1 are not expected');
-      }
-      return { Id: 'Id-1' };
-    }).resolves({ Id: 'Id-2' });
-    redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
-    const resp = await handler(updateServerlessEvent3, context, callback) as CdkCustomResourceResponse;
-    expect(resp.Status).toEqual('SUCCESS');
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 4);
 
   });
 
-  test('Validate sqls when upgrade from 1.0.x to 1.1.x', async () => {
-    smMock.onAnyCommand().resolves({});
-    lambdaMock.on(ListTagsCommand).resolves({
-      Tags: { tag_key: 'tag_value' },
-    });
-
-    const schemaSQLForApp1Count = schemaDefs.filter((def) => def.updatable === 'true').length;
-    const reportingSQLForApp1Count = reportingViewsDef.length * 2 + TABLES_VIEWS_FOR_REPORTING.length; // grant to bi user one by one
-
-    redshiftDataMock.on(BatchExecuteStatementCommand).callsFakeOnce(input => {
-      console.log('input.Sqls.length-2:' + input.Sqls.length);
-      const expectedSql = 'CREATE TABLE IF NOT EXISTS app1.clickstream_log';
-      if (input.Sqls.length !== schemaSQLForApp1Count || !(input.Sqls[0] as string).startsWith(expectedSql)) {
-        throw new Error('update schema sqls for app1 are not expected');
-      }
-      const sqlStr = input.Sqls.join(';\n');
-
-      if (!sqlStr.includes('app1.ods_events')) {
-        throw new Error('should have app1.ods_events in sp-migrate-ods-events-1.0-to-1.1.sql');
-      }
-
-      return { Id: 'Id-1' };
-    }).callsFakeOnce(input => {
-      console.log('input.Sqls.length-4:' + input.Sqls.length);
-      const expectedSql1 = `GRANT SELECT ON app1.${CLICKSTREAM_EVENT_VIEW_NAME} TO clickstream_report_user_abcde;`;
-      const expectedSql2 = `GRANT SELECT ON app1.${TABLE_NAME_EVENT} TO clickstream_report_user_abcde;`;
-      const expectedSql3 = 'GRANT SELECT ON app1.item_m_view TO clickstream_report_user_abcde;';
-      if (input.Sqls.length !== reportingSQLForApp1Count
-        || !(input.Sqls[(reportingSQLForApp1Count - TABLES_VIEWS_FOR_REPORTING.length)/2] as string).startsWith(expectedSql1)
-        || !(input.Sqls[reportingSQLForApp1Count - TABLES_VIEWS_FOR_REPORTING.length] as string).startsWith(expectedSql2)
-        || !(input.Sqls[reportingSQLForApp1Count - 1] as string).startsWith(expectedSql3)
-      ) {
-        throw new Error('update report view sqls for app1 are not expected');
-      }
-
-      return { Id: 'Id-1' };
-    }).resolves({ Id: 'Id-2' });
-    redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
-    const resp = await handler(updateServerlessEvent4, context, callback) as CdkCustomResourceResponse;
-    expect(resp.Status).toEqual('SUCCESS');
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 2);
-
-  });
 
   test('Updated schemas and views only in Redshift serverless in update stack from empty appIds', async () => {
     smMock.onAnyCommand().resolves({});
     lambdaMock.on(ListTagsCommand).resolves({
       Tags: { tag_key: 'tag_value' },
     });
-    redshiftDataMock.on(BatchExecuteStatementCommand).callsFakeOnce(input => {
-      const sqlStr = input.Sqls.join(';\n');
-      if (input as BatchExecuteStatementCommandInput) {
-        if (sqlStr.includes('CREATE SCHEMA IF NOT EXISTS app2')
-          && sqlStr.includes(`GRANT USAGE ON SCHEMA app2 TO ${biUserNamePrefix}abcde`)
-          && sqlStr.includes(`ALTER DEFAULT PRIVILEGES IN SCHEMA app2 GRANT SELECT ON TABLES TO ${biUserNamePrefix}abcde`)
-        ) {
-          return { Id: 'Id-1' };
-        }
-      }
-      throw new Error('Updating sqls are not expected');
-    }).resolves({ Id: 'Id-2' });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-2' });
     redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
     const resp = await handler(updateServerlessEvent, context, callback) as CdkCustomResourceResponse;
     expect(resp.Status).toEqual('SUCCESS');
     expect(resp.Data?.RedshiftBIUsername).toEqual(`${biUserNamePrefix}abcde`);
     expect(smMock).toHaveReceivedCommandTimes(CreateSecretCommand, 0);
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 2);
-    expect(redshiftDataMock).toHaveReceivedNthSpecificCommandWith(1, BatchExecuteStatementCommand, {
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, appNewCount);
+    expect(redshiftDataMock).toHaveReceivedNthSpecificCommandWith(1, ExecuteStatementCommand, {
       WorkgroupName: workgroupName,
       Database: projectDBName,
       ClusterIdentifier: undefined,
       DbUser: undefined,
     });
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 2);
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, appNewCount);
   });
 
 
@@ -675,7 +365,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
     const resp = await handler(deleteEvent, context, callback) as CdkCustomResourceResponse;
     expect(resp.Status).toEqual('SUCCESS');
     expect(smMock).toHaveReceivedCommandTimes(CreateSecretCommand, 0);
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 0);
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 0);
     expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 0);
   });
 
@@ -684,15 +374,12 @@ describe('Custom resource - Create schemas for applications in Redshift database
     lambdaMock.on(ListTagsCommand).resolves({
       Tags: { tag_key: 'tag_value' },
     });
-    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
-    redshiftDataMock.on(BatchExecuteStatementCommand).rejects();
-    redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
+    redshiftDataMock.on(ExecuteStatementCommand).rejects();
     try {
       await handler(createServerlessEvent, context, callback);
     } catch (e) {
-      expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 1);
-      expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 2);
-      expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 2);
+      expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 1);
+      expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 0);
       return;
     }
     fail('No exception happened when Redshift ExecuteStatementCommand failed');
@@ -704,12 +391,12 @@ describe('Custom resource - Create schemas for applications in Redshift database
       Tags: { tag_key: 'tag_value' },
     });
     redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
-    redshiftDataMock.on(BatchExecuteStatementCommand).resolves({ Id: 'Id-2' });
     redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
     const resp = await handler(createProvisionedEvent, context, callback) as CdkCustomResourceResponse;
+
     expect(resp.Status).toEqual('SUCCESS');
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 2);
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 2);
+
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, baseCount + appNewCount);
     expect(redshiftDataMock).toHaveReceivedNthSpecificCommandWith(1, ExecuteStatementCommand, {
       Sql: `CREATE DATABASE ${projectDBName};`,
       WorkgroupName: undefined,
@@ -717,115 +404,25 @@ describe('Custom resource - Create schemas for applications in Redshift database
       ClusterIdentifier: clusterId,
       DbUser: dbUser,
     });
-    expect(redshiftDataMock).toHaveReceivedNthSpecificCommandWith(1, BatchExecuteStatementCommand, {
-      WorkgroupName: undefined,
-      Database: projectDBName,
-      ClusterIdentifier: clusterId,
-      DbUser: dbUser,
-    });
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 4);
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, baseCount + appNewCount);
   });
 
   test('Updated schemas and views in Redshift provisioned cluster', async () => {
-    redshiftDataMock
-      .callsFakeOnce(input => {
-        const sqlStr = input.Sqls.join(';\n');
-
-        if (input as BatchExecuteStatementCommandInput) {
-          if (!sqlStr.includes('app1.')
-            && sqlStr.includes('CREATE SCHEMA IF NOT EXISTS app2')
-            && sqlStr.includes(`CREATE TABLE IF NOT EXISTS app2.${TABLE_NAME_EVENT_PARAMETER}(`)
-            && sqlStr.includes('CREATE OR REPLACE PROCEDURE app2.sp_clickstream_log_non_atomic')
-
-          ) {
-            return { Id: 'Id-1-1' };
-          }
-        }
-        throw new Error('Sql-5-1 are not expected');
-      }).callsFakeOnce(input => {
-        const sqlStr = input.Sqls.join(';\n');
-
-        if (input as BatchExecuteStatementCommandInput) {
-          if (!sqlStr.includes('app2.')
-            && sqlStr.includes('CREATE SCHEMA IF NOT EXISTS app1')
-            && sqlStr.includes(`CREATE TABLE IF NOT EXISTS app1.${TABLE_NAME_EVENT_PARAMETER}`)
-            && sqlStr.includes('CREATE OR REPLACE PROCEDURE app1.sp_clickstream_log_non_atomic')
-          ) {
-            return { Id: 'Id-1-2' };
-          }
-        }
-        throw new Error('Sql-5-2 are not expected');
-      }).resolves({ Id: 'Id-2' });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
     redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
 
     const resp = await handler(updateAdditionalProvisionedEvent, context, callback) as CdkCustomResourceResponse;
 
     expect(resp.Status).toEqual('SUCCESS');
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 4);
-    expect(redshiftDataMock).toHaveReceivedNthSpecificCommandWith(1, BatchExecuteStatementCommand, {
+
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, appNewCount * 2);
+    expect(redshiftDataMock).toHaveReceivedNthSpecificCommandWith(1, ExecuteStatementCommand, {
       WorkgroupName: undefined,
       Database: projectDBName,
       ClusterIdentifier: clusterId,
       DbUser: dbUser,
     });
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 4);
-  });
-
-  test('Updated schemas and views in Redshift provisioned cluster with updatable/new added view/schema table', async () => {
-    redshiftDataMock
-      .callsFakeOnce(input => {
-        if (input as BatchExecuteStatementCommandInput) {
-          const sqlStr = input.Sqls.join(';\n');
-          if (sqlStr.includes('CREATE SCHEMA IF NOT EXISTS app2')
-            && sqlStr.includes('CREATE TABLE IF NOT EXISTS app2.clickstream_log')
-            && sqlStr.includes(`CREATE TABLE IF NOT EXISTS app2.${TABLE_NAME_EVENT_PARAMETER}`)
-            && sqlStr.includes('CREATE OR REPLACE PROCEDURE app2.sp_clickstream_log_non_atomic')
-            && !sqlStr.includes('app1.')
-
-          ) {
-            return { Id: 'Id-1-1' };
-          }
-        }
-        throw new Error('Sql-7 are not expected');
-      })
-      .callsFakeOnce(input => {
-        const sqlStr = input.Sqls.join(';\n');
-
-        if (input as BatchExecuteStatementCommandInput) {
-          if (sqlStr.includes('CREATE MATERIALIZED VIEW app2.user_m_view')
-            && sqlStr.includes('CREATE MATERIALIZED VIEW app2.item_m_view')
-            && !sqlStr.includes('app1.')
-          ) {
-            return { Id: 'Id-2-2' };
-          }
-        }
-        throw new Error('Sql-8 are not expected');
-      })
-      .callsFakeOnce(input => {
-        const sqlStr = input.Sqls.join(';\n');
-
-        if (input as BatchExecuteStatementCommandInput) {
-          if ( !sqlStr.includes('app2.')) {
-            return { Id: 'Id-2-3' };
-          }
-        }
-        throw new Error('Sql-9 are not expected');
-      })
-      .resolves({
-        Id: 'Id-2-4',
-      });
-
-    redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
-    const resp = await handler(updateAdditionalProvisionedEvent2, context, callback) as CdkCustomResourceResponse;
-    expect(resp.Status).toEqual('SUCCESS');
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 4);
-    expect(redshiftDataMock).toHaveReceivedNthSpecificCommandWith(1, BatchExecuteStatementCommand, {
-      WorkgroupName: undefined,
-      Database: projectDBName,
-      ClusterIdentifier: clusterId,
-      DbUser: dbUser,
-    });
-    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 4);
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, appNewCount * 2);
   });
 
   test('Data api exception in Redshift provisioned cluster', async () => {
@@ -833,22 +430,19 @@ describe('Custom resource - Create schemas for applications in Redshift database
     lambdaMock.on(ListTagsCommand).resolves({
       Tags: { tag_key: 'tag_value' },
     });
-    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
-    redshiftDataMock.on(BatchExecuteStatementCommand).rejects();
-    redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
+    redshiftDataMock.on(ExecuteStatementCommand).rejects();
     try {
       await handler(createProvisionedEvent, context, callback);
     } catch (e) {
-      expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 1);
-      expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 2);
-      expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 2);
+      expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 1);
+      expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 0);
       return;
     }
     fail('No exception happened when Redshift ExecuteStatementCommand failed');
   });
 
   test('No valid Redshift cluster is specified', async () => {
-    redshiftDataMock.on(BatchExecuteStatementCommand).resolves({ Id: 'Id-1' });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
     redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
 
     const invalidEvent = {
@@ -861,13 +455,85 @@ describe('Custom resource - Create schemas for applications in Redshift database
     try {
       await handler(invalidEvent, context, callback);
     } catch (e) {
-      expect(redshiftDataMock).toHaveReceivedCommandTimes(BatchExecuteStatementCommand, 0);
+      expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 0);
       expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 0);
       return;
     }
     fail('No exception happened when Redshift ExecuteStatementCommand failed');
   });
+
+
+  test('Created database, error with object already exists will be ignored', async () => {
+    smMock.onAnyCommand().resolves({});
+    lambdaMock.on(ListTagsCommand).resolves({
+      Tags: { tag_key: 'tag_value' },
+    });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
+    redshiftDataMock.on(DescribeStatementCommand)
+      .resolvesOnce({ Status: 'FINISHED' })
+      .resolvesOnce({ Status: 'FINISHED' })
+      .resolvesOnce({ Status: 'SUBMITTED' })
+      .resolves({ Status: 'FAILED', Error: 'Object xxxx already exists', QueryString: 'test SQL create' });
+
+    const resp = await handler(createServerlessEvent, context, callback);
+    expect(resp.Status).toEqual('SUCCESS');
+
+  });
+
+
+  test('Update database, error with object already exists will be ignored', async () => {
+    smMock.onAnyCommand().resolves({});
+    lambdaMock.on(ListTagsCommand).resolves({
+      Tags: { tag_key: 'tag_value' },
+    });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
+    redshiftDataMock.on(DescribeStatementCommand)
+      .resolvesOnce({ Status: 'FINISHED' })
+      .resolvesOnce({ Status: 'FINISHED' })
+      .resolvesOnce({ Status: 'SUBMITTED' })
+      .resolves({ Status: 'FAILED', Error: 'Object xxxx already exists', QueryString: 'test SQL update' });
+
+    const resp = await handler(updateServerlessEvent, context, callback);
+    expect(resp.Status).toEqual('SUCCESS');
+
+  });
+
+  test('Created database, DB error will be ignored when env.SUPPRESS_DB_ERROR=true', async () => {
+    process.env.SUPPRESS_DB_ERROR = 'true';
+    smMock.onAnyCommand().resolves({});
+    lambdaMock.on(ListTagsCommand).resolves({
+      Tags: { tag_key: 'tag_value' },
+    });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
+    redshiftDataMock.on(DescribeStatementCommand)
+      .resolvesOnce({ Status: 'FINISHED' })
+      .resolvesOnce({ Status: 'FINISHED' })
+      .resolvesOnce({ Status: 'SUBMITTED' })
+      .resolves({ Status: 'FAILED', Error: 'got DB error1', QueryString: 'test SQL create' });
+
+    const resp = await handler(createServerlessEvent, context, callback);
+    expect(resp.Status).toEqual('SUCCESS');
+  });
+
+  test('Created database, all errors will be ignored when env.SUPPRESS_ALL_ERROR=true', async () => {
+    process.env.SUPPRESS_ALL_ERROR = 'true';
+    smMock.onAnyCommand().rejects({});
+    lambdaMock.on(ListTagsCommand).resolves({
+      Tags: { tag_key: 'tag_value' },
+    });
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
+    redshiftDataMock.on(DescribeStatementCommand)
+      .resolvesOnce({ Status: 'FINISHED' })
+      .resolvesOnce({ Status: 'FINISHED' })
+      .resolvesOnce({ Status: 'SUBMITTED' })
+      .resolves({ Status: 'FAILED', Error: 'got DB error1', QueryString: 'test SQL create' });
+
+    const resp = await handler(createServerlessEvent, context, callback);
+    expect(resp.Status).toEqual('SUCCESS');
+  });
+
 });
+
 
 const testSqlContent = (filePath: string) => {
   const sqlTemplate = readFileSync(filePath, 'utf8');


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)
1. add doc how to handle upgrade  issue 'UPDATE_ROLLBACK_FAILED ' from v1.0.x to v1.1.x
2. remove `updatable` flag for sql file, simplify the update/upgrade logic
3. change exec SQL one by one, not batch
4. ignore SQL error: `xxxx already exists` when apply SQL
5. add env `SUPPRESS_DB_ERROR` and `SUPPRESS_ALL_ERROR` to lambda `CreateSchemaForApplicationsFn` to handle further upgrade issue

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend