### PR TITLE
fix: create app schema timeout when appId count more than 15

### DIFF
--- a/src/analytics/lambdas/custom-resource/create-schemas.ts
+++ b/src/analytics/lambdas/custom-resource/create-schemas.ts
@@ -352,7 +352,7 @@ const createDatabaseBIUser = async (redshiftClient: RedshiftDataClient, credenti
     await executeStatementsWithWait(redshiftClient, [
       `CREATE USER ${credential.username} PASSWORD '${credential.password}'`,
     ], props.serverlessRedshiftProps, props.provisionedRedshiftProps,
-      props.serverlessRedshiftProps?.databaseName ?? props.provisionedRedshiftProps?.databaseName, false);
+    props.serverlessRedshiftProps?.databaseName ?? props.provisionedRedshiftProps?.databaseName, false);
   } catch (err) {
     if (err instanceof Error) {
       if (err.message.includes('already exists')) {

--- a/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
@@ -407,9 +407,35 @@ describe('Custom resource - Create schemas for applications in Redshift database
     expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, baseCount + appNewCount);
   });
 
-  test('Updated schemas and views in Redshift provisioned cluster', async () => {
+  test('Updated schemas and views in Redshift provisioned cluster with same lastModifiedTime', async () => {
     redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
     redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
+
+    const lastModifiedTime = new Date().getTime();
+    updateAdditionalProvisionedEvent.OldResourceProperties.lastModifiedTime = lastModifiedTime;
+    updateAdditionalProvisionedEvent.ResourceProperties.lastModifiedTime = lastModifiedTime;
+
+    const resp = await handler(updateAdditionalProvisionedEvent, context, callback) as CdkCustomResourceResponse;
+
+    expect(resp.Status).toEqual('SUCCESS');
+
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, appNewCount);
+    expect(redshiftDataMock).toHaveReceivedNthSpecificCommandWith(1, ExecuteStatementCommand, {
+      WorkgroupName: undefined,
+      Database: projectDBName,
+      ClusterIdentifier: clusterId,
+      DbUser: dbUser,
+    });
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, appNewCount);
+  });
+
+  test('Updated schemas and views in Redshift provisioned cluster with lastModifiedTime changed', async () => {
+    redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
+    redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
+
+    const lastModifiedTime = new Date().getTime();
+    updateAdditionalProvisionedEvent.OldResourceProperties.lastModifiedTime = lastModifiedTime;
+    updateAdditionalProvisionedEvent.ResourceProperties.lastModifiedTime = lastModifiedTime + 1;
 
     const resp = await handler(updateAdditionalProvisionedEvent, context, callback) as CdkCustomResourceResponse;
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend