### PR TITLE
chore: optimize metadata query performance

### DIFF
--- a/src/analytics/lambdas/scan-metadata-workflow/metadata-post-processing.ts
+++ b/src/analytics/lambdas/scan-metadata-workflow/metadata-post-processing.ts
@@ -1,0 +1,196 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, QueryCommandInput, paginateQuery, UpdateCommand, UpdateCommandInput } from '@aws-sdk/lib-dynamodb';
+import { NativeAttributeValue } from '@aws-sdk/util-dynamodb';
+import { logger } from '../../../common/powertools';
+import { aws_sdk_client_common_config } from '../../../common/sdk-client-config';
+import { MetadataPostProcessingBody } from '../../private/model';
+
+const analyticsMetadataTable = process.env.METADATA_DDB_TABLE_ARN!;
+const prefixMonthGSIName = process.env.PREFIX_MONTH_GSI_NAME!;
+const { ddbRegion, ddbTableName } = parseDynamoDBTableARN(analyticsMetadataTable);
+const projectId = process.env.PROJECT_ID!;
+
+// Create an Amazon DynamoDB service client object.
+const ddbClient = new DynamoDBClient({
+  ...aws_sdk_client_common_config,
+  region: ddbRegion,
+});
+
+const ddbDocClient = DynamoDBDocumentClient.from(ddbClient);
+
+export interface MetadataPostProcessingEvent {
+  detail: MetadataPostProcessingBody;
+}
+
+export const handler = async (event: MetadataPostProcessingEvent) => {
+  const appId = event.detail.appId;
+  logger.info('Metadata post processing for appId: ', { appId });
+  try {
+    // get all metadata from DDB according to appId
+    const records = await getAllMetadataFromDDB(appId);
+
+    // group records by id
+    const groupedRecords = await groupRecordsById(records);
+
+    // order group record by month
+    const orderedGroupedRecords = await orderGroupRecordByMonth(groupedRecords);
+
+    await updateIsLastMonth(orderedGroupedRecords);
+
+    return {
+      detail: {
+        appId: appId,
+        status: 'SUCCEED',
+        message: 'Metadata post processing succeed.',
+      },
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      logger.error('Error when post processing metadata.', { error });
+    }
+    return {
+      detail: {
+        appId: appId,
+        status: 'FAILED',
+        message: 'failed to post processing metadata.',
+      },
+    };
+  }
+};
+
+/*
+  Get all metadata from DDB according to appId
+  @param appId
+  @returns records
+*/
+async function getAllMetadataFromDDB(appId: string) {
+  logger.info('Get all metadata from DDB according to appId: ', { appId });
+  const queryCommandInput: QueryCommandInput = {
+    TableName: ddbTableName,
+    IndexName: prefixMonthGSIName,
+    KeyConditionExpression: '#prefix= :prefix',
+    ProjectionExpression: '#id, #month, #prefix, isLastMonth',
+    ExpressionAttributeNames: {
+      '#prefix': 'prefix',
+      '#id': 'id',
+      '#month': 'month',
+    },
+    ExpressionAttributeValues: {
+      ':prefix': `EVENT_PARAMETER#${projectId}#${appId}`,
+    },
+    ScanIndexForward: false,
+  };
+
+  const records: Record<string, NativeAttributeValue>[] = [];
+  for await (const page of paginateQuery({ client: ddbDocClient }, queryCommandInput)) {
+    records.push(...page.Items as Record<string, NativeAttributeValue>[]);
+  }
+  return records;
+}
+
+/*
+  Group records by id
+  @param records
+  @returns groupedRecords
+*/
+async function groupRecordsById(records: Record<string, NativeAttributeValue>[]) {
+  logger.info('Group records by id started.');
+  const groupedRecords: Record<string, Record<string, NativeAttributeValue>[]> = {};
+  for (const record of records) {
+    const id = record.id;
+    if (!groupedRecords[id]) {
+      groupedRecords[id] = [];
+    }
+    groupedRecords[id].push(record);
+  }
+  return groupedRecords;
+}
+
+/*
+  Order group record by month
+  @param groupedRecords
+  @returns orderedGroupedRecords
+*/
+async function orderGroupRecordByMonth(groupedRecords: Record<string, Record<string, NativeAttributeValue>[]>) {
+  logger.info('Order group record by month started.');
+  const orderedGroupedRecords: Record<string, Record<string, NativeAttributeValue>[]> = {};
+  for (const id in groupedRecords) {
+    const records = groupedRecords[id];
+    records.sort((a, b) => {
+      const aMonth = a.month;
+      const bMonth = b.month;
+      return aMonth.localeCompare(bMonth);
+    });
+    orderedGroupedRecords[id] = records;
+  }
+  return orderedGroupedRecords;
+}
+
+/*
+  Update isLastMonth to DDB table
+  @param orderedGroupedRecords
+*/
+async function updateIsLastMonth(orderedGroupedRecords: Record<string, Record<string, NativeAttributeValue>[]>) {
+  logger.info('Update isLastMonth to DDB table started.');
+  const shouldUpdateRecords: Record<string, NativeAttributeValue>[] = [];
+  for (const id in orderedGroupedRecords) {
+    const records = orderedGroupedRecords[id];
+    for (let i = 0; i < records.length; i++) {
+      const record = records[i];
+      let shouldIsLastMonth = false;
+      if (i === records.length - 1) {
+        shouldIsLastMonth = true;
+      }
+      if (record.isLastMonth === shouldIsLastMonth) {
+        continue;
+      }
+      record.isLastMonth = shouldIsLastMonth;
+      shouldUpdateRecords.push(record);
+    }
+  }
+  // update orderedGroupedRecords to DDB table
+  await updateIsLastMonthToDDB(shouldUpdateRecords);
+
+}
+
+async function updateIsLastMonthToDDB(updateRecords: Record<string, NativeAttributeValue>[]) {
+  for (const record of updateRecords) {
+    const updateCommandInput: UpdateCommandInput = {
+      TableName: ddbTableName,
+      Key: {
+        id: record.id,
+        month: record.month,
+      },
+      UpdateExpression: 'SET isLastMonth = :isLastMonth',
+      ExpressionAttributeValues: {
+        ':isLastMonth': record.isLastMonth,
+      },
+    };
+    await ddbDocClient.send(new UpdateCommand(updateCommandInput));
+  }
+}
+
+function parseDynamoDBTableARN(ddbArn: string) {
+  const arnComponents = ddbArn.split(':');
+  const region = arnComponents[3];
+  const tableName = arnComponents[5].split('/')[1];
+
+  return {
+    ddbRegion: region,
+    ddbTableName: tableName,
+  };
+}

--- a/src/analytics/lambdas/scan-metadata-workflow/store-metadata-into-ddb.ts
+++ b/src/analytics/lambdas/scan-metadata-workflow/store-metadata-into-ddb.ts
@@ -67,7 +67,7 @@ export const handler = async (event: StoreMetadataEvent) => {
     };
   } catch (err) {
     if (err instanceof Error) {
-      logger.error('Error when query metadata.', err);
+      logger.error('Error when store metadata into ddb.', err);
     }
     return {
       detail: {

--- a/src/analytics/private/model.ts
+++ b/src/analytics/private/model.ts
@@ -160,6 +160,10 @@ export interface StoreMetadataBody {
   readonly appId: string;
 }
 
+export interface MetadataPostProcessingBody {
+  readonly appId: string;
+}
+
 export type CheckUpsertStatusEventDetail = {
   id: string;
   appId: string;

--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -392,3 +392,4 @@ export const QUICKSIGHT_TEMP_RESOURCE_NAME_PREFIX = '_tmp_';
 export const QUICKSIGHT_DASHBOARD_INFIX= '-dashboard-';
 export const QUICKSIGHT_ANALYSIS_INFIX= '-analysis-';
 export const QUICKSIGHT_DATASET_INFIX= '-dataset-';
+export const PREFIX_MONTH_GSI_NAME = 'prefix-month-index';

--- a/src/control-plane/backend/click-stream-api.ts
+++ b/src/control-plane/backend/click-stream-api.ts
@@ -49,7 +49,7 @@ import { LambdaAdapterLayer } from './layer/lambda-web-adapter/layer';
 import { StackActionStateMachine } from './stack-action-state-machine-construct';
 import { StackWorkflowStateMachine } from './stack-workflow-state-machine-construct';
 import { addCfnNagSuppressRules, addCfnNagToSecurityGroup } from '../../common/cfn-nag';
-import { QUICKSIGHT_RESOURCE_NAME_PREFIX, QUICKSIGHT_TEMP_RESOURCE_NAME_PREFIX } from '../../common/constant';
+import { QUICKSIGHT_RESOURCE_NAME_PREFIX, QUICKSIGHT_TEMP_RESOURCE_NAME_PREFIX, PREFIX_MONTH_GSI_NAME } from '../../common/constant';
 import { cloudWatchSendLogs, createENI } from '../../common/lambda';
 import { createLogGroup } from '../../common/logs';
 import { POWERTOOLS_ENVS } from '../../common/powertools';
@@ -143,7 +143,7 @@ export class ClickStreamApiConstruct extends Construct {
       pointInTimeRecovery: true,
       encryption: TableEncryption.AWS_MANAGED,
     });
-    const prefixMonthGSIName = 'prefix-month-index';
+    const prefixMonthGSIName = PREFIX_MONTH_GSI_NAME;
     analyticsMetadataTable.addGlobalSecondaryIndex({
       indexName: prefixMonthGSIName,
       partitionKey: {

--- a/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/metadata-post-processing.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/metadata-post-processing.test.ts
@@ -1,0 +1,293 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { DynamoDBDocumentClient, QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { mockClient } from 'aws-sdk-client-mock';
+import { handler, MetadataPostProcessingEvent } from '../../../../../src/analytics/lambdas/scan-metadata-workflow/metadata-post-processing';
+import { MetadataPostProcessingBody } from '../../../../../src/analytics/private/model';
+import 'aws-sdk-client-mock-jest';
+
+
+const metadataPostProcessingBody: MetadataPostProcessingBody = {
+  appId: 'app1',
+};
+
+const metadataPostProcessingEvent: MetadataPostProcessingEvent = {
+  detail: metadataPostProcessingBody,
+};
+
+describe('Lambda - Metadata Post Processing', () => {
+  const dynamoDBMock = mockClient(DynamoDBDocumentClient);
+
+  beforeEach(() => {
+    dynamoDBMock.reset();
+  });
+
+  const mockRecords = [
+    {
+      id: 'project1#app1#eventName#propertyName#valueType',
+      month: '#202301',
+      prefix: 'EVENT_PARAMETER#project1#app1',
+      isLastMonth: false,
+    },
+    {
+      id: 'project1#app1#eventName#propertyName#valueType',
+      month: '#202302',
+      prefix: 'EVENT_PARAMETER#project1#app1',
+      isLastMonth: true,
+    },
+    {
+      id: 'project1#app1#eventName#propertyName#valueType',
+      month: '#202303',
+      prefix: 'EVENT_PARAMETER#project1#app1',
+      isLastMonth: true,
+    },
+    {
+      id: 'project1#app1#eventName#propertyName1#valueType',
+      month: '#202301',
+      prefix: 'EVENT_PARAMETER#project1#app1',
+      isLastMonth: true,
+    },
+    {
+      id: 'project1#app1#eventName#propertyName1#valueType',
+      month: '#202302',
+      prefix: 'EVENT_PARAMETER#project1#app1',
+      isLastMonth: false,
+    },
+    {
+      id: 'project1#app1#eventName#propertyName1#valueType',
+      month: '#202303',
+      prefix: 'EVENT_PARAMETER#project1#app1',
+      isLastMonth: false,
+    },
+    {
+      id: 'project1#app1#eventName#propertyName2#valueType',
+      month: '#202301',
+      prefix: 'EVENT_PARAMETER#project1#app1',
+      isLastMonth: false,
+    },
+    {
+      id: 'project1#app1#eventName#propertyName2#valueType',
+      month: '#202302',
+      prefix: 'EVENT_PARAMETER#project1#app1',
+      isLastMonth: true,
+    },
+    {
+      id: 'project1#app1#eventName#propertyName2#valueType',
+      month: '#202303',
+      prefix: 'EVENT_PARAMETER#project1#app1',
+      isLastMonth: false,
+    },
+    {
+      id: 'project1#app1#eventName#propertyName3#valueType',
+      month: '#202301',
+      prefix: 'EVENT_PARAMETER#project1#app1',
+    },
+    {
+      id: 'project1#app1#eventName#propertyName3#valueType',
+      month: '#202302',
+      prefix: 'EVENT_PARAMETER#project1#app1',
+    },
+    {
+      id: 'project1#app1#eventName#propertyName3#valueType',
+      month: '#202303',
+      prefix: 'EVENT_PARAMETER#project1#app1',
+    },
+    {
+      id: 'project1#app1#eventName#propertyName4#valueType',
+      month: '#202301',
+      prefix: 'EVENT_PARAMETER#project1#app1',
+      isLastMonth: true,
+    },
+    {
+      id: 'project1#app1#eventName#propertyName4#valueType',
+      month: '#202303',
+      prefix: 'EVENT_PARAMETER#project1#app1',
+    },
+  ];
+
+  test('should handle metadata post processing', async () => {
+    // Mock DynamoDBDocumentClient query
+    dynamoDBMock.on(QueryCommand).resolves({
+      Items: mockRecords,
+    });
+
+    // Mock DynamoDBDocumentClient update
+    dynamoDBMock.on(UpdateCommand).resolves({});
+
+    await handler(metadataPostProcessingEvent);
+
+    expect(dynamoDBMock).toHaveReceivedNthCommandWith(1,
+      QueryCommand,
+      {
+        TableName: 'ClickstreamAnalyticsMetadata',
+        IndexName: 'prefix-month-gsi-name',
+        KeyConditionExpression: '#prefix= :prefix',
+        ProjectionExpression: '#id, #month, #prefix, isLastMonth',
+        Limit: undefined,
+        ExclusiveStartKey: undefined,
+        ExpressionAttributeNames: {
+          '#prefix': 'prefix',
+          '#id': 'id',
+          '#month': 'month',
+        },
+        ExpressionAttributeValues: {
+          ':prefix': 'EVENT_PARAMETER#project1#app1',
+        },
+        ScanIndexForward: false,
+      },
+    );
+
+    expect(dynamoDBMock).toHaveReceivedNthCommandWith(2, UpdateCommand,
+      {
+        TableName: 'ClickstreamAnalyticsMetadata',
+        Key: {
+          id: 'project1#app1#eventName#propertyName#valueType',
+          month: '#202302',
+        },
+        UpdateExpression: 'SET isLastMonth = :isLastMonth',
+        ExpressionAttributeValues: {
+          ':isLastMonth': false,
+        },
+      },
+    );
+
+    expect(dynamoDBMock).toHaveReceivedNthCommandWith(3, UpdateCommand,
+      {
+        TableName: 'ClickstreamAnalyticsMetadata',
+        Key: {
+          id: 'project1#app1#eventName#propertyName1#valueType',
+          month: '#202301',
+        },
+        UpdateExpression: 'SET isLastMonth = :isLastMonth',
+        ExpressionAttributeValues: {
+          ':isLastMonth': false,
+        },
+      },
+    );
+
+    expect(dynamoDBMock).toHaveReceivedNthCommandWith(4, UpdateCommand,
+      {
+        TableName: 'ClickstreamAnalyticsMetadata',
+        Key: {
+          id: 'project1#app1#eventName#propertyName1#valueType',
+          month: '#202303',
+        },
+        UpdateExpression: 'SET isLastMonth = :isLastMonth',
+        ExpressionAttributeValues: {
+          ':isLastMonth': true,
+        },
+      },
+    );
+
+    expect(dynamoDBMock).toHaveReceivedNthCommandWith(5, UpdateCommand,
+      {
+        TableName: 'ClickstreamAnalyticsMetadata',
+        Key: {
+          id: 'project1#app1#eventName#propertyName2#valueType',
+          month: '#202302',
+        },
+        UpdateExpression: 'SET isLastMonth = :isLastMonth',
+        ExpressionAttributeValues: {
+          ':isLastMonth': false,
+        },
+      },
+    );
+
+    expect(dynamoDBMock).toHaveReceivedNthCommandWith(6, UpdateCommand,
+      {
+        TableName: 'ClickstreamAnalyticsMetadata',
+        Key: {
+          id: 'project1#app1#eventName#propertyName2#valueType',
+          month: '#202303',
+        },
+        UpdateExpression: 'SET isLastMonth = :isLastMonth',
+        ExpressionAttributeValues: {
+          ':isLastMonth': true,
+        },
+      },
+    );
+
+    expect(dynamoDBMock).toHaveReceivedNthCommandWith(7, UpdateCommand,
+      {
+        TableName: 'ClickstreamAnalyticsMetadata',
+        Key: {
+          id: 'project1#app1#eventName#propertyName3#valueType',
+          month: '#202301',
+        },
+        UpdateExpression: 'SET isLastMonth = :isLastMonth',
+        ExpressionAttributeValues: {
+          ':isLastMonth': false,
+        },
+      },
+    );
+
+    expect(dynamoDBMock).toHaveReceivedNthCommandWith(8, UpdateCommand,
+      {
+        TableName: 'ClickstreamAnalyticsMetadata',
+        Key: {
+          id: 'project1#app1#eventName#propertyName3#valueType',
+          month: '#202302',
+        },
+        UpdateExpression: 'SET isLastMonth = :isLastMonth',
+        ExpressionAttributeValues: {
+          ':isLastMonth': false,
+        },
+      },
+    );
+
+    expect(dynamoDBMock).toHaveReceivedNthCommandWith(9, UpdateCommand,
+      {
+        TableName: 'ClickstreamAnalyticsMetadata',
+        Key: {
+          id: 'project1#app1#eventName#propertyName3#valueType',
+          month: '#202303',
+        },
+        UpdateExpression: 'SET isLastMonth = :isLastMonth',
+        ExpressionAttributeValues: {
+          ':isLastMonth': true,
+        },
+      },
+    );
+
+    expect(dynamoDBMock).toHaveReceivedNthCommandWith(10, UpdateCommand,
+      {
+        TableName: 'ClickstreamAnalyticsMetadata',
+        Key: {
+          id: 'project1#app1#eventName#propertyName4#valueType',
+          month: '#202301',
+        },
+        UpdateExpression: 'SET isLastMonth = :isLastMonth',
+        ExpressionAttributeValues: {
+          ':isLastMonth': false,
+        },
+      },
+    );
+
+    expect(dynamoDBMock).toHaveReceivedNthCommandWith(11, UpdateCommand,
+      {
+        TableName: 'ClickstreamAnalyticsMetadata',
+        Key: {
+          id: 'project1#app1#eventName#propertyName4#valueType',
+          month: '#202303',
+        },
+        UpdateExpression: 'SET isLastMonth = :isLastMonth',
+        ExpressionAttributeValues: {
+          ':isLastMonth': true,
+        },
+      },
+    );
+
+    expect(dynamoDBMock).toHaveReceivedCommandTimes(UpdateCommand, 10);
+  });
+});


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

optimize metadata performance

## Implementation highlights

Optimize metadata performance
Detail: 
1, Add a job in ScanMetadataWorkflow to scan metadata in DDB
2, In the job, find the last month data with the same id and mark them field "isLastMonth" as true, and mark other data's isLastMonth as false. 
3, Compatible with existing versions which data do not contains isLastMonth field. The isLastMonth field will be added in the new job.
4. Add UT to cover the cases.

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend