### PR TITLE
chore: upgrade vector to 0.34.1

### DIFF
--- a/src/ingestion-server/server/images/vector/Dockerfile
+++ b/src/ingestion-server/server/images/vector/Dockerfile
@@ -1,5 +1,5 @@
 ARG PLATFORM_ARG
-FROM --platform=$PLATFORM_ARG timberio/vector:0.31.0-debian
+FROM --platform=$PLATFORM_ARG timberio/vector:0.34.1-debian
 
 ENV AWS_REGION='__NOT_SET__'
 ENV AWS_MSK_BROKERS='__NOT_SET__'


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

upgrade vector to 0.34.1 version

## Implementation highlights

upgrade vector to 0.34.1 version
Test below cases:
1, Ingestion => S3
2, Ingestion => KDS on demand
3, Ingestion => MSK

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [x] deploy ingestion server
    - [x] with MSK sink
    - [x] with KDS sink
    - [x] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend