### PR TITLE
fix: use wrong store procedure name when cleaning logs of scanning metadata

### DIFF
--- a/src/analytics/lambdas/scan-metadata-workflow/scan-metadata.ts
+++ b/src/analytics/lambdas/scan-metadata-workflow/scan-metadata.ts
@@ -12,6 +12,7 @@
  */
 
 import { logger } from '../../../common/powertools';
+import { SP_SCAN_METADATA } from '../../private/constant';
 import { getRedshiftClient, executeStatements, getRedshiftProps } from '../redshift-data';
 
 const REDSHIFT_DATA_API_ROLE_ARN = process.env.REDSHIFT_DATA_API_ROLE!;
@@ -54,9 +55,9 @@ export const handler = async (event: ScanMetadataEvent) => {
     const scanEndDate = event.scanEndDate;
     const scanStartDate = event.scanStartDate;
     if (scanStartDate) {
-      sqlStatements.push(`CALL ${schema}.sp_scan_metadata(${topFrequentPropertiesLimit}, '${scanEndDate}', '${scanStartDate}')`);
+      sqlStatements.push(`CALL ${schema}.${SP_SCAN_METADATA}(${topFrequentPropertiesLimit}, '${scanEndDate}', '${scanStartDate}')`);
     } else {
-      sqlStatements.push(`CALL ${schema}.sp_scan_metadata(${topFrequentPropertiesLimit}, '${scanEndDate}', NULL)`);
+      sqlStatements.push(`CALL ${schema}.${SP_SCAN_METADATA}(${topFrequentPropertiesLimit}, '${scanEndDate}', NULL)`);
     }
 
     const queryId = await executeStatements(

--- a/src/analytics/private/constant.ts
+++ b/src/analytics/private/constant.ts
@@ -42,7 +42,7 @@ export const REDSHIFT_TABLE_NAMES = [
 
 export const REDSHIFT_DUPLICATE_DATE_INTERVAL = 3; // Days
 
-export const SP_SCAN_METADATA = 'scan_metadata';
+export const SP_SCAN_METADATA = 'sp_scan_metadata';
 export const SP_CLEAR_EXPIRED_EVENTS = 'sp_clear_expired_events';
 
 export const SQL_TEMPLATE_PARAMETER = {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

fix the issue of delete scan metadata data log](fix: fix the issue that the clickstream_log of scan metadata cannot be deleted

## Implementation highlights

fix the issue of delete scan metadata data log](fix: fix the issue that the clickstream_log of scan metadata cannot be deleted

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend