### PR TITLE
chore: refactor Redshift associate IAM roles as construct

### DIFF
--- a/src/analytics/lambdas/custom-resource/create-redshift-namespace.ts
+++ b/src/analytics/lambdas/custom-resource/create-redshift-namespace.ts
@@ -18,8 +18,8 @@ import { getRedshiftServerlessNamespace } from './redshift-serverless';
 import { getFunctionTags } from '../../../common/lambda/tags';
 import { logger } from '../../../common/powertools';
 import { aws_sdk_client_common_config } from '../../../common/sdk-client-config';
+import { sleep } from '../../../common/utils';
 import { NewNamespaceCustomProperties } from '../../private/model';
-import { Sleep } from '../redshift-data';
 
 type ResourcePropertiesType = NewNamespaceCustomProperties & {
   readonly ServiceToken: string;
@@ -134,7 +134,7 @@ async function waitForRedshiftServerlessNamespaceStatus(
     if (namespace.status === NamespaceStatus.AVAILABLE) {
       return namespace;
     }
-    await Sleep(3000);
+    await sleep(3000);
   }
   throw new Error(`Namespace ${namespaceName} is not available.`);
 }

--- a/src/analytics/lambdas/load-data-workflow/refresh-views.ts
+++ b/src/analytics/lambdas/load-data-workflow/refresh-views.ts
@@ -17,7 +17,8 @@ import { checkLoadStatus } from './check-load-status';
 import { CLICKSTREAM_DEVICE_VIEW_NAME, CLICKSTREAM_EVENT_PARAMETER_VIEW_NAME, CLICKSTREAM_EVENT_VIEW_NAME, CLICKSTREAM_LIFECYCLE_DAILY_VIEW_NAME, CLICKSTREAM_LIFECYCLE_WEEKLY_VIEW_NAME, CLICKSTREAM_RETENTION_VIEW_NAME, CLICKSTREAM_SESSION_VIEW_NAME, CLICKSTREAM_USER_FIRST_ATTR_VIEW_NAME } from '../../../common/constant';
 import { logger } from '../../../common/powertools';
 
-import { getRedshiftClient, executeStatements, getRedshiftProps, Sleep } from '../redshift-data';
+import { sleep } from '../../../common/utils';
+import { getRedshiftClient, executeStatements, getRedshiftProps } from '../redshift-data';
 
 const REDSHIFT_DATA_API_ROLE_ARN = process.env.REDSHIFT_DATA_API_ROLE!;
 const REDSHIFT_DATABASE = process.env.REDSHIFT_DATABASE!;
@@ -68,7 +69,7 @@ REFRESH MATERIALIZED VIEW ${schema}.${CLICKSTREAM_USER_FIRST_ATTR_VIEW_NAME};
   }
 
   const execInfo = [];
-  await Sleep(1000 * parseInt(SLEEP_SEC));
+  await sleep(1000 * parseInt(SLEEP_SEC));
 
   for (const queryId of queryIds) {
     const statusRes = await checkLoadStatus(queryId);

--- a/src/analytics/lambdas/redshift-data.ts
+++ b/src/analytics/lambdas/redshift-data.ts
@@ -16,6 +16,7 @@ import { NodeHttpHandler } from '@smithy/node-http-handler';
 import { REDSHIFT_MODE } from '../../common/model';
 import { logger } from '../../common/powertools';
 import { aws_sdk_client_common_config } from '../../common/sdk-client-config';
+import { sleep } from '../../common/utils';
 import { ExistingRedshiftServerlessCustomProps, ProvisionedRedshiftProps } from '../private/model';
 
 export function getRedshiftClient(roleArn: string) {
@@ -104,7 +105,7 @@ export const executeStatementsWithWait = async (client: RedshiftDataClient, sqlS
   logger.info(`Got statement query '${queryId}' with status: ${response.Status} after submitting it`);
   let count = 0;
   while (response.Status != StatusString.FINISHED && response.Status != StatusString.FAILED && count < GET_STATUS_TIMEOUT) {
-    await Sleep(waitMilliseconds);
+    await sleep(waitMilliseconds);
     count++;
     response = await client.send(checkParams);
     logger.info(`Got statement query '${queryId}' with status: ${response.Status} in ${count * waitMilliseconds} Milliseconds`);
@@ -164,10 +165,6 @@ export const describeStatement = async (client: RedshiftDataClient, queryId: str
     }
     throw err;
   }
-};
-
-export const Sleep = (ms: number) => {
-  return new Promise(resolve=>setTimeout(resolve, ms));
 };
 
 export function getRedshiftProps(

--- a/src/analytics/private/model.ts
+++ b/src/analytics/private/model.ts
@@ -112,6 +112,7 @@ export type CreateMappingRoleUser = Omit<CustomProperties, 'provisionedRedshiftP
 
 export type AssociateIAMRoleToRedshift = CustomProperties & {
   readonly roleArn: string;
+  readonly timeoutInSeconds: number;
 }
 
 export interface NewWorkgroupProperties {

--- a/src/analytics/private/redshift-associate-iam-role.ts
+++ b/src/analytics/private/redshift-associate-iam-role.ts
@@ -14,7 +14,7 @@
 import { join } from 'path';
 import { Duration, Arn, Stack, ArnFormat, Token, CfnCondition, CfnResource, CustomResource } from 'aws-cdk-lib';
 
-import { IRole, Policy, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { IRole, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
@@ -24,166 +24,177 @@ import { createLambdaRole } from '../../common/lambda';
 import { SolutionNodejsFunction } from '../../private/function';
 
 
-export interface RedshiftProps {
+export interface RedshiftAssociateIAMRoleProps {
   readonly serverlessRedshift?: ExistingRedshiftServerlessProps;
   readonly provisionedRedshift?: ProvisionedRedshiftProps;
+  readonly role: IRole;
+  /**
+   * default 50 seconds
+   */
+  readonly timeoutInSeconds?: number;
 }
 
-export interface AssociateIAMRoleResult {
-  readonly cr: CustomResource;
-  readonly redshiftRoleForCopyFromS3: Role;
-}
+export class RedshiftAssociateIAMRole extends Construct {
 
-export function createCustomResourceAssociateIAMRole(scope: Construct, props: RedshiftProps): AssociateIAMRoleResult {
-  // create IAM role for redshift to load data from S3
-  const redshiftRoleForCopyFromS3 = new Role(scope, 'CopyDataFromS3Role', {
-    assumedBy: new ServicePrincipal('redshift.amazonaws.com'),
-  });
+  public readonly cr: CustomResource;
 
-  const fn = new SolutionNodejsFunction(scope, 'AssociateIAMRoleToRedshiftFn', {
-    entry: join(
-      __dirname + '/../lambdas/custom-resource',
-      'redshift-associate-iam-role.ts',
-    ),
-    handler: 'handler',
-    memorySize: 256,
-    reservedConcurrentExecutions: 1,
-    timeout: Duration.minutes(5),
-    logRetention: RetentionDays.ONE_WEEK,
-    role: createLambdaRole(scope, 'AssociateIAMRoleFnRole', false, [
-      new PolicyStatement({
-        actions: [
-          'iam:PassRole',
+  constructor(scope: Construct, id: string, props: RedshiftAssociateIAMRoleProps) {
+    super(scope, id);
+
+    if (!props.provisionedRedshift && !props.serverlessRedshift) {
+      throw new Error('Must specify either provisioned Redshift or serverless Redshift.');
+    }
+
+    const fn = new SolutionNodejsFunction(scope, 'AssociateIAMRoleToRedshiftFn', {
+      entry: join(
+        __dirname + '/../lambdas/custom-resource',
+        'redshift-associate-iam-role.ts',
+      ),
+      handler: 'handler',
+      memorySize: 256,
+      reservedConcurrentExecutions: 1,
+      timeout: Duration.minutes(5),
+      logRetention: RetentionDays.ONE_WEEK,
+      role: createLambdaRole(scope, 'AssociateIAMRoleFnRole', false, [
+        new PolicyStatement({
+          actions: [
+            'iam:PassRole',
+          ],
+          resources: ['*'], //NOSONAR have to use wildcard for keeping existing associated roles
+          conditions: {
+            StringEquals: {
+              'iam:PassedToService': 'redshift.amazonaws.com',
+            },
+          },
+        }),
+      ]),
+    });
+
+    const provider = new Provider(
+      scope,
+      'RedshiftAssociateIAMRoleCustomResourceProvider',
+      {
+        onEventHandler: fn,
+        logRetention: RetentionDays.FIVE_DAYS,
+      },
+    );
+
+    const customProps: AssociateIAMRoleToRedshift = {
+      roleArn: props.role.roleArn,
+      timeoutInSeconds: props.timeoutInSeconds ?? 50,
+      serverlessRedshiftProps: props.serverlessRedshift,
+      provisionedRedshiftProps: props.provisionedRedshift,
+    };
+
+    this.cr = new CustomResource(scope, 'RedshiftAssociateIAMRoleCustomResource', {
+      serviceToken: provider.serviceToken,
+      properties: customProps,
+    });
+
+    if (props.serverlessRedshift) {
+      if (props.serverlessRedshift.workgroupId && Token.isUnresolved(props.serverlessRedshift.workgroupId) &&
+              !props.serverlessRedshift.createdInStack) {
+        const noWorkgroupIdCondition = getOrCreateNoWorkgroupIdCondition(scope, props.serverlessRedshift.workgroupId);
+        this.createRedshiftServerlessWorkgroupPolicy('RedshiftServerlessAllWorkgroupPolicy', '*',
+          fn.role!, noWorkgroupIdCondition);
+
+        const withWorkgroupIdCondition = getOrCreateWithWorkgroupIdCondition(scope, props.serverlessRedshift.workgroupId);
+        this.createRedshiftServerlessWorkgroupPolicy('RedshiftServerlessSingleWorkgroupPolicy', props.serverlessRedshift.workgroupId,
+          fn.role!, withWorkgroupIdCondition);
+      } else {
+        this.cr.node.addDependency(this.createRedshiftServerlessWorkgroupPolicy('RedshiftServerlessWorkgroupPolicy',
+          props.serverlessRedshift.workgroupId ?? '*', fn.role!));
+      }
+      if (props.serverlessRedshift.namespaceId && Token.isUnresolved(props.serverlessRedshift.namespaceId) &&
+              !props.serverlessRedshift.createdInStack) {
+        const noNamespaceIdCondition = getOrCreateNoNamespaceIdCondition(scope, props.serverlessRedshift.namespaceId);
+        this.createRedshiftServerlessNamespacePolicy('RedshiftServerlessAllNamespacePolicy', '*',
+          fn.role!, noNamespaceIdCondition);
+
+        const withNamespaceIdCondition = getOrCreateWithNamespaceIdCondition(scope, props.serverlessRedshift.namespaceId);
+        this.createRedshiftServerlessNamespacePolicy('RedshiftServerlessSingleNamespacePolicy',
+          props.serverlessRedshift.namespaceId, fn.role!, withNamespaceIdCondition);
+      } else {
+        this.cr.node.addDependency(this.createRedshiftServerlessNamespacePolicy('RedshiftServerlessNamespacePolicy',
+          props.serverlessRedshift.namespaceId ?? '*', fn.role!));
+      }
+    } else {
+      this.cr.node.addDependency(new Policy(scope, 'ProvisionedRedshiftIAMPolicy', {
+        roles: [fn.role!],
+        statements: [
+          new PolicyStatement({
+            actions: [
+              'redshift:DescribeClusters',
+            ],
+            resources: [
+              Arn.format({
+                service: 'redshift',
+                resource: '*',
+              }, Stack.of(scope)),
+            ],
+          }),
+          new PolicyStatement({
+            actions: [
+              'redshift:ModifyClusterIamRoles',
+            ],
+            resources: [
+              Arn.format({
+                service: 'redshift',
+                resource: 'cluster',
+                resourceName: props.provisionedRedshift!.clusterIdentifier,
+                arnFormat: ArnFormat.COLON_RESOURCE_NAME,
+              }, Stack.of(scope)),
+            ],
+          }),
         ],
-        resources: ['*'], // have to use wildcard for keeping existing associated roles
-      }),
-    ]),
-  });
-
-  const provider = new Provider(
-    scope,
-    'RedshiftAssociateIAMRoleCustomResourceProvider',
-    {
-      onEventHandler: fn,
-      logRetention: RetentionDays.FIVE_DAYS,
-    },
-  );
-
-  const customProps: AssociateIAMRoleToRedshift = {
-    roleArn: redshiftRoleForCopyFromS3.roleArn,
-    serverlessRedshiftProps: props.serverlessRedshift,
-    provisionedRedshiftProps: props.provisionedRedshift,
-  };
-
-  const cr = new CustomResource(scope, 'RedshiftAssociateIAMRoleCustomResource', {
-    serviceToken: provider.serviceToken,
-    properties: customProps,
-  });
-
-  if (props.serverlessRedshift) {
-    if (props.serverlessRedshift.workgroupId && Token.isUnresolved(props.serverlessRedshift.workgroupId) &&
-            !props.serverlessRedshift.createdInStack) {
-      const noWorkgroupIdCondition = getOrCreateNoWorkgroupIdCondition(scope, props.serverlessRedshift.workgroupId);
-      createRedshiftServerlessWorkgroupPolicy(scope, 'RedshiftServerlessAllWorkgroupPolicy', '*',
-        fn.role!, noWorkgroupIdCondition);
-
-      const withWorkgroupIdCondition = getOrCreateWithWorkgroupIdCondition(scope, props.serverlessRedshift.workgroupId);
-      createRedshiftServerlessWorkgroupPolicy(scope, 'RedshiftServerlessSingleWorkgroupPolicy', props.serverlessRedshift.workgroupId,
-        fn.role!, withWorkgroupIdCondition);
-    } else {
-      cr.node.addDependency(createRedshiftServerlessWorkgroupPolicy(scope, 'RedshiftServerlessWorkgroupPolicy',
-        props.serverlessRedshift.workgroupId ?? '*', fn.role!));
+      }));
     }
-    if (props.serverlessRedshift.namespaceId && Token.isUnresolved(props.serverlessRedshift.namespaceId) &&
-            !props.serverlessRedshift.createdInStack) {
-      const noNamespaceIdCondition = getOrCreateNoNamespaceIdCondition(scope, props.serverlessRedshift.namespaceId);
-      createRedshiftServerlessNamespacePolicy(scope, 'RedshiftServerlessAllNamespacePolicy', '*',
-        fn.role!, noNamespaceIdCondition);
+  }
 
-      const withNamespaceIdCondition = getOrCreateWithNamespaceIdCondition(scope, props.serverlessRedshift.namespaceId);
-      createRedshiftServerlessNamespacePolicy(scope, 'RedshiftServerlessSingleNamespacePolicy', props.serverlessRedshift.namespaceId,
-        fn.role!, withNamespaceIdCondition);
-    } else {
-      cr.node.addDependency(createRedshiftServerlessNamespacePolicy(scope, 'RedshiftServerlessNamespacePolicy',
-        props.serverlessRedshift.namespaceId ?? '*', fn.role!));
-    }
-  } else {
-    cr.node.addDependency(new Policy(scope, 'ProvisionedRedshiftIAMPolicy', {
-      roles: [fn.role!],
+  private createRedshiftServerlessWorkgroupPolicy(id: string, workgroupId: string, role: IRole, condition?: CfnCondition): Policy {
+    const policy = new Policy(this, id, {
+      roles: [role],
       statements: [
         new PolicyStatement({
           actions: [
-            'redshift:DescribeClusters',
+            'redshift-serverless:GetWorkgroup',
           ],
           resources: [
             Arn.format({
-              service: 'redshift',
-              resource: '*',
-            }, Stack.of(scope)),
-          ],
-        }),
-        new PolicyStatement({
-          actions: [
-            'redshift:ModifyClusterIamRoles',
-          ],
-          resources: [
-            Arn.format({
-              service: 'redshift',
-              resource: 'cluster',
-              resourceName: props.provisionedRedshift!.clusterIdentifier,
-              arnFormat: ArnFormat.COLON_RESOURCE_NAME,
-            }, Stack.of(scope)),
+              service: 'redshift-serverless',
+              resource: 'workgroup',
+              resourceName: workgroupId,
+              arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
+            }, Stack.of(this)),
           ],
         }),
       ],
-    }));
+    });
+    if (condition) { (policy.node.findChild('Resource') as CfnResource).cfnOptions.condition = condition; }
+    return policy;
   }
-  return { cr, redshiftRoleForCopyFromS3 };
-}
 
-function createRedshiftServerlessWorkgroupPolicy(scope: Construct, id: string, workgroupId: string, role: IRole, condition?: CfnCondition): Policy {
-  const policy = new Policy(scope, id, {
-    roles: [role],
-    statements: [
-      new PolicyStatement({
-        actions: [
-          'redshift-serverless:GetWorkgroup',
-        ],
-        resources: [
-          Arn.format({
-            service: 'redshift-serverless',
-            resource: 'workgroup',
-            resourceName: workgroupId,
-            arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
-          }, Stack.of(scope)),
-        ],
-      }),
-    ],
-  });
-  if (condition) { (policy.node.findChild('Resource') as CfnResource).cfnOptions.condition = condition; }
-  return policy;
-}
-
-function createRedshiftServerlessNamespacePolicy(scope: Construct, id: string, namespaceId: string, role: IRole, condition?: CfnCondition): Policy {
-  const policy = new Policy(scope, id, {
-    roles: [role],
-    statements: [
-      new PolicyStatement({
-        actions: [
-          'redshift-serverless:GetNamespace',
-          'redshift-serverless:UpdateNamespace',
-        ],
-        resources: [
-          Arn.format({
-            service: 'redshift-serverless',
-            resource: 'namespace',
-            resourceName: namespaceId,
-            arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
-          }, Stack.of(scope)),
-        ],
-      }),
-    ],
-  });
-  if (condition) { (policy.node.findChild('Resource') as CfnResource).cfnOptions.condition = condition; }
-  return policy;
+  private createRedshiftServerlessNamespacePolicy(id: string, namespaceId: string, role: IRole, condition?: CfnCondition): Policy {
+    const policy = new Policy(this, id, {
+      roles: [role],
+      statements: [
+        new PolicyStatement({
+          actions: [
+            'redshift-serverless:GetNamespace',
+            'redshift-serverless:UpdateNamespace',
+          ],
+          resources: [
+            Arn.format({
+              service: 'redshift-serverless',
+              resource: 'namespace',
+              resourceName: namespaceId,
+              arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
+            }, Stack.of(this)),
+          ],
+        }),
+      ],
+    });
+    if (condition) { (policy.node.findChild('Resource') as CfnResource).cfnOptions.condition = condition; }
+    return policy;
+  }
 }

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -45,3 +45,7 @@ export function generateRandomStr(length: number, charSet?: string): string {
   }
   return password;
 }
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve=>setTimeout(resolve, ms));
+};

--- a/src/control-plane/backend/lambda/api/service/quicksight/reporting-utils.ts
+++ b/src/control-plane/backend/lambda/api/service/quicksight/reporting-utils.ts
@@ -1007,10 +1007,6 @@ export function formatDatesInObject(inputObject: any): any {
   }
 }
 
-export function sleep(ms: number) {
-  return new Promise<void>(resolve => setTimeout(() => resolve(), ms));
-};
-
 export function getQuickSightUnitFromTimeUnit(timeUnit: string) : string {
   let unit = 'DAY';
   if (timeUnit == ExploreRelativeTimeUnit.WK) {

--- a/src/control-plane/backend/lambda/api/service/reporting.ts
+++ b/src/control-plane/backend/lambda/api/service/reporting.ts
@@ -23,7 +23,6 @@ import {
   applyChangeToDashboard,
   getDashboardDefinitionFromArn,
   CreateDashboardResult,
-  sleep,
   DashboardCreateParameters,
   getFunnelVisualDef,
   getVisualRelatedDefs,
@@ -54,6 +53,7 @@ import { logger } from '../common/powertools';
 import { SDKClient } from '../common/sdk-client';
 import { ApiFail, ApiSuccess, PipelineStackType } from '../common/types';
 import { getStackOutputFromPipelineStatus } from '../common/utils';
+import { sleep } from '../common/utils-ln';
 import { QuickSightUserArns, generateEmbedUrlForRegisteredUser, getClickstreamUserArn, waitDashboardSuccess } from '../store/aws/quicksight';
 import { ClickStreamStore } from '../store/click-stream-store';
 import { DynamoDbStore } from '../store/dynamodb/dynamodb-store';

--- a/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
@@ -49,9 +49,9 @@ import { QUICKSIGHT_ANALYSIS_INFIX, QUICKSIGHT_DASHBOARD_INFIX, QUICKSIGHT_DATAS
 import { logger } from '../../common/powertools';
 import { SDKClient } from '../../common/sdk-client';
 import { QuickSightAccountInfo } from '../../common/types';
+import { sleep } from '../../common/utils-ln';
 import { IDashboard } from '../../model/project';
 import { analysisAdminPermissionActions, dashboardAdminPermissionActions, dataSetAdminPermissionActions } from '../../service/quicksight/dashboard-ln';
-import { sleep } from '../../service/quicksight/reporting-utils';
 
 const QUICKSIGHT_NAMESPACE = 'default';
 const QUICKSIGHT_EXPLORE_USER_NAME = 'ClickstreamExploreUser';

--- a/src/ingestion-server/custom-resource/delete-ecs-cluster/index.ts
+++ b/src/ingestion-server/custom-resource/delete-ecs-cluster/index.ts
@@ -25,6 +25,7 @@ import {
 import { CloudFormationCustomResourceEvent, Context } from 'aws-lambda';
 import { logger } from '../../../common/powertools';
 import { aws_sdk_client_common_config } from '../../../common/sdk-client-config';
+import { sleep } from '../../../common/utils';
 
 const region = process.env.AWS_REGION!;
 
@@ -130,7 +131,7 @@ async function updateEcsService(ecsServiceName: string, ecsClusterName: string) 
       if (runningCount === 0) {
         break;
       } else {
-        await new Promise(resolve => setTimeout(resolve, 5000)); // Sleep for 10 seconds
+        await sleep(5000); // Sleep for 5 seconds
       }
     } else {
       break;

--- a/src/ingestion-server/kafka-s3-connector/custom-resource/kafka-s3-sink-connector/index.ts
+++ b/src/ingestion-server/kafka-s3-connector/custom-resource/kafka-s3-sink-connector/index.ts
@@ -37,6 +37,7 @@ import {
 import { CloudFormationCustomResourceEvent, Context } from 'aws-lambda';
 import { logger } from '../../../../common/powertools';
 import { aws_sdk_client_common_config } from '../../../../common/sdk-client-config';
+import { sleep } from '../../../../common/utils';
 
 const region = process.env.AWS_REGION;
 
@@ -209,7 +210,7 @@ async function createCustomPlugin(
   let n = 0;
   while (n < MAX_N) {
     n++;
-    await sleep(5);
+    await sleep(5000);
     let res = await kafkaConnectClient.send(
       new DescribeCustomPluginCommand({
         customPluginArn,
@@ -324,7 +325,7 @@ async function createConnector(event: ResourceEvent, customPluginArn: string) {
   let n = 0;
   while (n < MAX_N) {
     n++;
-    await sleep();
+    await sleep(SLEEP_SEC * 1000);
     let res = await kafkaConnectClient.send(
       new DescribeConnectorCommand({
         connectorArn,
@@ -446,7 +447,7 @@ async function updateConnector(event: ResourceEvent) {
     let n = 0;
     while (n < MAX_N) {
       n++;
-      await sleep();
+      await sleep(SLEEP_SEC * 1000);
       const res = await kafkaConnectClient.send(
         new DescribeConnectorCommand({
           connectorArn,
@@ -491,7 +492,7 @@ async function deletePlugin(event: ResourceEvent) {
     let n = 0;
     while (n < MAX_N) {
       n++;
-      await sleep();
+      await sleep(SLEEP_SEC * 1000);
       try {
         const res = await kafkaConnectClient.send(
           new DescribeCustomPluginCommand({
@@ -534,7 +535,7 @@ async function deleteConnector(event: ResourceEvent) {
     let n = 0;
     while (n < MAX_N) {
       n++;
-      await sleep();
+      await sleep(SLEEP_SEC * 1000);
       try {
         const res = await kafkaConnectClient.send(
           new DescribeConnectorCommand({
@@ -604,11 +605,5 @@ async function download(url: string, outPath: string) {
         reject(err);
       });
     });
-  });
-}
-
-async function sleep(seconds: number = SLEEP_SEC) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, seconds * 1000);
   });
 }

--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -41,6 +41,7 @@ import Mustache from 'mustache';
 import { v4 as uuidv4 } from 'uuid';
 import { logger } from '../../../../common/powertools';
 import { aws_sdk_client_common_config } from '../../../../common/sdk-client-config';
+import { sleep } from '../../../../common/utils';
 import {
   QuicksightCustomResourceLambdaProps,
   waitForAnalysisChangeCompleted,
@@ -56,7 +57,6 @@ import {
   dataSetAdminPermissionActions,
   analysisAdminPermissionActions,
   dataSetReaderPermissionActions,
-  sleep,
   waitForTemplateChangeCompleted,
   existDashboard,
   existAnalysis,

--- a/src/reporting/lambda/custom-resource/quicksight/network-interface-check.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/network-interface-check.ts
@@ -15,7 +15,8 @@ import { EC2, NetworkInterfaceStatus } from '@aws-sdk/client-ec2';
 import { Context, CloudFormationCustomResourceEvent, CdkCustomResourceResponse } from 'aws-lambda';
 import { logger } from '../../../../common/powertools';
 import { aws_sdk_client_common_config } from '../../../../common/sdk-client-config';
-import { NetworkInterfaceCheckCustomResourceLambdaProps, sleep } from '../../../private/dashboard';
+import { sleep } from '../../../../common/utils';
+import { NetworkInterfaceCheckCustomResourceLambdaProps } from '../../../private/dashboard';
 
 type ResourceEvent = CloudFormationCustomResourceEvent;
 

--- a/test/ingestion-server/kafka-s3-connector/custom-resource/kafka-s3-sink-connector.test.ts
+++ b/test/ingestion-server/kafka-s3-connector/custom-resource/kafka-s3-sink-connector.test.ts
@@ -182,7 +182,7 @@ process.env.LOG_LEVEL = 'WARN';
 
 import { handler as msk_sink_handler } from '../../../../src/ingestion-server/kafka-s3-connector/custom-resource/kafka-s3-sink-connector';
 
-test('Create connector, there is exsiting connector', async () => {
+test('Create connector, there is existing connector', async () => {
   KafkaConnectClientMock.send = jest.fn().mockImplementation((command: any) => {
     if (command.command == 'CreateConnectorCommand') {
       throw new Error(


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend