### PR TITLE
fix: only specify the pass role condition for provisioned redshift

### DIFF
--- a/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
+++ b/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
@@ -2668,6 +2668,7 @@ describe('DataAnalyticsRedshiftStack serverless custom resource test', () => {
             Action: 'iam:PassRole',
             Effect: 'Allow',
             Resource: '*',
+            Condition: Match.absent(),
           },
         ],
         Version: '2012-10-17',
@@ -2676,6 +2677,33 @@ describe('DataAnalyticsRedshiftStack serverless custom resource test', () => {
       Roles: [
         RefAnyValue,
       ],
+    });
+
+    const nestedTemplate2 = Template.fromStack(stack.nestedStacks.redshiftProvisionedStack);
+    nestedTemplate2.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: [
+          {
+            Action: [
+              'logs:CreateLogStream',
+              'logs:PutLogEvents',
+              'logs:CreateLogGroup',
+            ],
+            Effect: 'Allow',
+            Resource: '*',
+          },
+          {
+            Action: 'iam:PassRole',
+            Effect: 'Allow',
+            Resource: '*',
+            Condition: {
+              StringEquals: {
+                'iam:PassedToService': 'redshift.amazonaws.com',
+              },
+            },
+          },
+        ],
+      },
     });
   });
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Redshift Serverless does not have a service-link role, we can not pass the roles with a conditional service name. Only specify the condition when associating roles to a Redshift provisioned cluster.

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [x] new Redshift Serverless
    - [x] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend