### PR TITLE
fix: specify wrong bi user parameter for custom resource

### DIFF
--- a/src/analytics/private/app-schema.ts
+++ b/src/analytics/private/app-schema.ts
@@ -40,10 +40,12 @@ export abstract class RedshiftSQLExecution extends Construct {
   readonly crForSQLExecution: CustomResource;
   readonly crFunction: IFunction;
   readonly crProvider: Provider;
+  protected readonly props: RedshiftSQLExecutionProps;
 
   constructor(scope: Construct, id: string, props: RedshiftSQLExecutionProps) {
     super(scope, id);
 
+    this.props = props;
     /**
      * Create custom resource to execute SQLs in Redshift using Redshift-Data API.
      */
@@ -130,17 +132,20 @@ export interface ApplicationSchemasAndReportingProps extends RedshiftSQLExecutio
 
 export class ApplicationSchemasAndReporting extends RedshiftSQLExecution {
 
-  readonly redshiftBIUserParameter: string;
   readonly redshiftBIUserName: string;
 
   constructor(scope: Construct, id: string, props: ApplicationSchemasAndReportingProps) {
     super(scope, id, props);
 
-    this.redshiftBIUserParameter = `/clickstream/reporting/user/${props.projectId}`;
     this.redshiftBIUserName = this.crForSQLExecution.getAttString(CUSTOM_RESOURCE_RESPONSE_REDSHIFT_BI_USER_NAME);
   }
 
+  public getRedshiftBIUserParameter(): string {
+    return `/clickstream/reporting/user/${(this.props as ApplicationSchemasAndReportingProps).projectId}`;
+  }
+
   protected additionalPolicies(): PolicyStatement[] {
+
     const writeSecretPolicy: PolicyStatement = new PolicyStatement({
       effect: Effect.ALLOW,
       resources: [
@@ -148,7 +153,7 @@ export class ApplicationSchemasAndReporting extends RedshiftSQLExecution {
           {
             resource: 'secret',
             service: 'secretsmanager',
-            resourceName: `${this.redshiftBIUserParameter}*`,
+            resourceName: `${this.getRedshiftBIUserParameter()}*`,
             arnFormat: ArnFormat.COLON_RESOURCE_NAME,
           }, Stack.of(this),
         ),
@@ -173,7 +178,7 @@ export class ApplicationSchemasAndReporting extends RedshiftSQLExecution {
       appIds: properties.appIds,
       odsTableNames: properties.odsTableNames,
       databaseName: properties.databaseName,
-      redshiftBIUserParameter: `${this.redshiftBIUserParameter}`,
+      redshiftBIUserParameter: this.getRedshiftBIUserParameter(),
       redshiftBIUsernamePrefix: 'clickstream_bi_',
       reportingViewsDef,
       schemaDefs,

--- a/src/data-analytics-redshift-stack.ts
+++ b/src/data-analytics-redshift-stack.ts
@@ -236,17 +236,17 @@ export function createRedshiftAnalyticsStack(
     condition: isNewRedshiftServerless,
   }).overrideLogicalId(OUTPUT_DATA_MODELING_REDSHIFT_SERVERLESS_NAMESPACE_NAME);
   new CfnOutput(scope, `NewRedshiftServerless${OUTPUT_DATA_MODELING_REDSHIFT_BI_USER_CREDENTIAL_PARAMETER_SUFFIX}`, {
-    value: newRedshiftServerlessStack.applicationSchema.redshiftBIUserParameter,
+    value: newRedshiftServerlessStack.applicationSchema.getRedshiftBIUserParameter(),
     description: 'Credential SSM parameter for BI user in Redshift',
     condition: isNewRedshiftServerless,
   }).overrideLogicalId(`NewRedshiftServerless${OUTPUT_DATA_MODELING_REDSHIFT_BI_USER_CREDENTIAL_PARAMETER_SUFFIX}`);
   new CfnOutput(scope, `ExistingRedshiftServerless${OUTPUT_DATA_MODELING_REDSHIFT_BI_USER_CREDENTIAL_PARAMETER_SUFFIX}`, {
-    value: redshiftExistingServerlessStack.applicationSchema.redshiftBIUserParameter,
+    value: redshiftExistingServerlessStack.applicationSchema.getRedshiftBIUserParameter(),
     description: 'Credential SSM parameter for BI user in Redshift',
     condition: isExistingRedshiftServerless,
   }).overrideLogicalId(`ExistingRedshiftServerless${OUTPUT_DATA_MODELING_REDSHIFT_BI_USER_CREDENTIAL_PARAMETER_SUFFIX}`);
   new CfnOutput(scope, `ProvisionedRedshift${OUTPUT_DATA_MODELING_REDSHIFT_BI_USER_CREDENTIAL_PARAMETER_SUFFIX}`, {
-    value: redshiftProvisionedStack.applicationSchema.redshiftBIUserParameter,
+    value: redshiftProvisionedStack.applicationSchema.getRedshiftBIUserParameter(),
     description: 'Credential SSM parameter for BI user in Redshift',
     condition: isRedshiftProvisioned,
   }).overrideLogicalId(`ProvisionedRedshift${OUTPUT_DATA_MODELING_REDSHIFT_BI_USER_CREDENTIAL_PARAMETER_SUFFIX}`);

--- a/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
+++ b/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
@@ -2594,6 +2594,20 @@ describe('DataAnalyticsRedshiftStack serverless custom resource test', () => {
         workgroupId: RefAnyValue,
         dataAPIRoleArn: RefAnyValue,
       },
+      redshiftBIUserParameter: {
+        'Fn::Join': [
+          '',
+          [
+            '/clickstream/reporting/user/',
+            {
+              Ref: Match.anyValue(),
+            },
+          ],
+        ],
+      },
+      redshiftBIUsernamePrefix: 'clickstream_bi_',
+      reportingViewsDef: Match.not(Match.absent()),
+      schemaDefs: Match.not(Match.absent()),
     });
   });
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [x] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend