### PR TITLE
fix: prune node_modules to reduce api lambda size

### DIFF
--- a/src/control-plane/backend/Dockerfile
+++ b/src/control-plane/backend/Dockerfile
@@ -4,6 +4,9 @@ WORKDIR /home/node/app
 COPY ./src ./src
 RUN cd src/control-plane/backend/lambda/api && yarn install && yarn compile
 RUN cd src/control-plane/backend/lambda/api && rm -rf node_modules && yarn install --production
+RUN rm -rf /home/node/app/src/control-plane/backend/lambda/api/dist/test && \
+curl -sf https://gobinaries.com/tj/node-prune | sh && \
+node-prune /home/node/app/src/control-plane/backend/lambda/api/node_modules
 
 RUN mkdir -p /home/node/app/src/control-plane/backend/lambda/api/dist/service/quicksight/
 RUN cp -r /home/node/app/src/control-plane/backend/lambda/api/service/quicksight/templates /home/node/app/src/control-plane/backend/lambda/api/dist/service/quicksight/


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend