### PR TITLE
fix: validate tags empty key and value

### DIFF
--- a/frontend/public/locales/en-US/pipeline.json
+++ b/frontend/public/locales/en-US/pipeline.json
@@ -49,7 +49,8 @@
     "redshiftProvisionedDBUserFormatError": "Database user format error",
     "emailInvalid": "Email invalid.",
     "stackRollbackFailed": "Some stacks are ROLLBACK_FAILED and can not be updated.",
-    "transformPluginEmptyError": "Please select transform plugin when use Third-party SDK."
+    "transformPluginEmptyError": "Please select transform plugin when use Third-party SDK.",
+    "tagsKeyValueEmpty": "Please input key and value."
   },
   "create": {
     "basicInfo": "Basic configuration",

--- a/frontend/public/locales/zh-CN/pipeline.json
+++ b/frontend/public/locales/zh-CN/pipeline.json
@@ -49,7 +49,8 @@
     "redshiftProvisionedDBUserFormatError": "数据库用户格式错误",
     "emailInvalid": "电子邮件无效。",
     "stackRollbackFailed": "某些堆栈处于 ROLLBACK_FAILED 状态，无法更新。",
-    "transformPluginEmptyError": "使用第三方 SDK 时需选择转换插件。"
+    "transformPluginEmptyError": "使用第三方 SDK 时需选择转换插件。",
+    "tagsKeyValueEmpty": "标签键和值不能为空。"
   },
   "create": {
     "basicInfo": "基本配置",

--- a/frontend/src/pages/pipelines/comps/BasicInfo.tsx
+++ b/frontend/src/pages/pipelines/comps/BasicInfo.tsx
@@ -170,7 +170,8 @@ const BasicInfo: React.FC<BasicInfoProps> = (props: BasicInfoProps) => {
                   </Button>
                 )}
                 {(pipelineInfo?.statusType === EPipelineStatus.Active ||
-                  pipelineInfo?.statusType === EPipelineStatus.Failed) && (
+                  pipelineInfo?.statusType === EPipelineStatus.Failed ||
+                  pipelineInfo?.statusType === EPipelineStatus.Warning) && (
                   <Button
                     href={`/project/${pipelineInfo.projectId}/pipeline/${pipelineInfo.pipelineId}/update`}
                     iconName="edit"

--- a/frontend/src/pages/pipelines/create/CreatePipeline.tsx
+++ b/frontend/src/pages/pipelines/create/CreatePipeline.tsx
@@ -112,6 +112,7 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
   const [regionEmptyError, setRegionEmptyError] = useState(false);
   const [vpcEmptyError, setVPCEmptyError] = useState(false);
   const [sdkEmptyError, setSDKEmptyError] = useState(false);
+  const [tagsKeyValueEmptyError, setTagsKeyValueEmptyError] = useState(false);
   const [assetsBucketEmptyError, setAssetsBucketEmptyError] = useState(false);
 
   const [publicSubnetError, setPublicSubnetError] = useState(false);
@@ -232,6 +233,14 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
     }
     if (!pipelineInfo.ingestionServer.loadBalancer.logS3Bucket.name) {
       setAssetsBucketEmptyError(true);
+      return false;
+    }
+    if (
+      pipelineInfo.tags.some(
+        (tag) => !tag.key || tag.key === '' || !tag.value || tag.value === ''
+      )
+    ) {
+      setTagsKeyValueEmptyError(true);
       return false;
     }
     return true;
@@ -1100,6 +1109,7 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
               regionEmptyError={regionEmptyError}
               vpcEmptyError={vpcEmptyError}
               sdkEmptyError={sdkEmptyError}
+              tagsKeyValueEmptyError={tagsKeyValueEmptyError}
               pipelineInfo={pipelineInfo}
               assetsS3BucketEmptyError={assetsBucketEmptyError}
               loadingServiceAvailable={loadingServiceAvailable}
@@ -1207,6 +1217,7 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
                 });
               }}
               changeTags={(tags) => {
+                setTagsKeyValueEmptyError(false);
                 setPipelineInfo((prev) => {
                   return {
                     ...prev,

--- a/frontend/src/pages/pipelines/create/CreatePipeline.tsx
+++ b/frontend/src/pages/pipelines/create/CreatePipeline.tsx
@@ -237,7 +237,11 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
     }
     if (
       pipelineInfo.tags.some(
-        (tag) => !tag.key || tag.key === '' || !tag.value || tag.value === ''
+        (tag) =>
+          !tag.key ||
+          tag.key.trim() === '' ||
+          !tag.value ||
+          tag.value.trim() === ''
       )
     ) {
       setTagsKeyValueEmptyError(true);

--- a/frontend/src/pages/pipelines/create/steps/BasicInformation.tsx
+++ b/frontend/src/pages/pipelines/create/steps/BasicInformation.tsx
@@ -42,6 +42,7 @@ interface BasicInformationProps {
   regionEmptyError: boolean;
   vpcEmptyError: boolean;
   sdkEmptyError: boolean;
+  tagsKeyValueEmptyError: boolean;
   assetsS3BucketEmptyError: boolean;
   loadingServiceAvailable: boolean;
   unSupportedServices: string;
@@ -62,6 +63,7 @@ const BasicInformation: React.FC<BasicInformationProps> = (
     regionEmptyError,
     vpcEmptyError,
     sdkEmptyError,
+    tagsKeyValueEmptyError,
     assetsS3BucketEmptyError,
     loadingServiceAvailable,
     unSupportedServices,
@@ -298,6 +300,15 @@ const BasicInformation: React.FC<BasicInformationProps> = (
             changeTags(tags);
           }}
         />
+        <div>
+          {tagsKeyValueEmptyError ? (
+            <StatusIndicator type="error">
+              {t('pipeline:valid.tagsKeyValueEmpty')}
+            </StatusIndicator>
+          ) : (
+            ''
+          )}
+        </div>
       </SpaceBetween>
     </Container>
   );

--- a/src/control-plane/backend/lambda/api/service/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/service/pipeline.ts
@@ -15,7 +15,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { OUTPUT_INGESTION_SERVER_DNS_SUFFIX, OUTPUT_INGESTION_SERVER_URL_SUFFIX, OUTPUT_METRICS_OBSERVABILITY_DASHBOARD_NAME, OUTPUT_REPORT_DASHBOARDS_SUFFIX } from '../common/constants-ln';
 import { PipelineStackType, PipelineStatusType } from '../common/model-ln';
 import { ApiFail, ApiSuccess } from '../common/types';
-import { getStackOutputFromPipelineStatus, getReportingDashboardsUrl, paginateData, pipelineAnalysisStudioEnabled, getPipelineStatusType } from '../common/utils';
+import { getStackOutputFromPipelineStatus, getReportingDashboardsUrl, paginateData, pipelineAnalysisStudioEnabled, getPipelineStatusType, isEmpty } from '../common/utils';
 import { IPipeline, CPipeline } from '../model/pipeline';
 import { ClickStreamStore } from '../store/click-stream-store';
 import { DynamoDbStore } from '../store/dynamodb/dynamodb-store';
@@ -79,11 +79,11 @@ export class PipelineServ {
       return res.json(new ApiSuccess({
         ...latestPipeline,
         statusType: getPipelineStatusType(latestPipeline),
-        dataProcessing: {
+        dataProcessing: !isEmpty(latestPipeline.dataProcessing) ? {
           ...latestPipeline.dataProcessing,
           transformPlugin: pluginsInfo.transformPlugin,
           enrichPlugin: pluginsInfo.enrichPlugin,
-        },
+        } : {},
         endpoint: getStackOutputFromPipelineStatus(latestPipeline.stackDetails ?? latestPipeline.status?.stackDetails,
           PipelineStackType.INGESTION, OUTPUT_INGESTION_SERVER_URL_SUFFIX),
         dns: getStackOutputFromPipelineStatus(latestPipeline.stackDetails ?? latestPipeline.status?.stackDetails,

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -1858,11 +1858,7 @@ describe('Pipeline test', () => {
         ...S3_INGESTION_PIPELINE,
         stackDetails: [],
         statusType: 'Active',
-        dataProcessing: {
-          ...S3_INGESTION_PIPELINE.dataProcessing,
-          enrichPlugin: [],
-          transformPlugin: null,
-        },
+        dataProcessing: {},
         dns: '',
         endpoint: '',
         dashboards: [],


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. validate tags empty key and value
2. return empty object if dataProcessing disable 

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend