### PR TITLE
fix: error status when refresh force

### DIFF
--- a/frontend/public/locales/en-US/pipeline.json
+++ b/frontend/public/locales/en-US/pipeline.json
@@ -49,7 +49,8 @@
     "redshiftProvisionedDBUserFormatError": "Database user format error",
     "emailInvalid": "Email invalid.",
     "stackRollbackFailed": "Some stacks are ROLLBACK_FAILED and can not be updated.",
-    "transformPluginEmptyError": "Please select transform plugin when use Third-party SDK."
+    "transformPluginEmptyError": "Please select transform plugin when use Third-party SDK.",
+    "tagsKeyValueEmpty": "Please input key and value."
   },
   "create": {
     "basicInfo": "Basic configuration",

--- a/frontend/public/locales/zh-CN/pipeline.json
+++ b/frontend/public/locales/zh-CN/pipeline.json
@@ -49,7 +49,8 @@
     "redshiftProvisionedDBUserFormatError": "数据库用户格式错误",
     "emailInvalid": "电子邮件无效。",
     "stackRollbackFailed": "某些堆栈处于 ROLLBACK_FAILED 状态，无法更新。",
-    "transformPluginEmptyError": "使用第三方 SDK 时需选择转换插件。"
+    "transformPluginEmptyError": "使用第三方 SDK 时需选择转换插件。",
+    "tagsKeyValueEmpty": "标签键和值不能为空。"
   },
   "create": {
     "basicInfo": "基本配置",

--- a/frontend/src/pages/pipelines/comps/BasicInfo.tsx
+++ b/frontend/src/pages/pipelines/comps/BasicInfo.tsx
@@ -170,7 +170,8 @@ const BasicInfo: React.FC<BasicInfoProps> = (props: BasicInfoProps) => {
                   </Button>
                 )}
                 {(pipelineInfo?.statusType === EPipelineStatus.Active ||
-                  pipelineInfo?.statusType === EPipelineStatus.Failed) && (
+                  pipelineInfo?.statusType === EPipelineStatus.Failed ||
+                  pipelineInfo?.statusType === EPipelineStatus.Warning) && (
                   <Button
                     href={`/project/${pipelineInfo.projectId}/pipeline/${pipelineInfo.pipelineId}/update`}
                     iconName="edit"

--- a/frontend/src/pages/pipelines/create/CreatePipeline.tsx
+++ b/frontend/src/pages/pipelines/create/CreatePipeline.tsx
@@ -112,6 +112,7 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
   const [regionEmptyError, setRegionEmptyError] = useState(false);
   const [vpcEmptyError, setVPCEmptyError] = useState(false);
   const [sdkEmptyError, setSDKEmptyError] = useState(false);
+  const [tagsKeyValueEmptyError, setTagsKeyValueEmptyError] = useState(false);
   const [assetsBucketEmptyError, setAssetsBucketEmptyError] = useState(false);
 
   const [publicSubnetError, setPublicSubnetError] = useState(false);
@@ -232,6 +233,14 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
     }
     if (!pipelineInfo.ingestionServer.loadBalancer.logS3Bucket.name) {
       setAssetsBucketEmptyError(true);
+      return false;
+    }
+    if (
+      pipelineInfo.tags.some(
+        (tag) => !tag.key || tag.key === '' || !tag.value || tag.value === ''
+      )
+    ) {
+      setTagsKeyValueEmptyError(true);
       return false;
     }
     return true;
@@ -1106,6 +1115,7 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
               regionEmptyError={regionEmptyError}
               vpcEmptyError={vpcEmptyError}
               sdkEmptyError={sdkEmptyError}
+              tagsKeyValueEmptyError={tagsKeyValueEmptyError}
               pipelineInfo={pipelineInfo}
               assetsS3BucketEmptyError={assetsBucketEmptyError}
               loadingServiceAvailable={loadingServiceAvailable}
@@ -1213,6 +1223,7 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
                 });
               }}
               changeTags={(tags) => {
+                setTagsKeyValueEmptyError(false);
                 setPipelineInfo((prev) => {
                   return {
                     ...prev,

--- a/frontend/src/pages/pipelines/create/steps/BasicInformation.tsx
+++ b/frontend/src/pages/pipelines/create/steps/BasicInformation.tsx
@@ -42,6 +42,7 @@ interface BasicInformationProps {
   regionEmptyError: boolean;
   vpcEmptyError: boolean;
   sdkEmptyError: boolean;
+  tagsKeyValueEmptyError: boolean;
   assetsS3BucketEmptyError: boolean;
   loadingServiceAvailable: boolean;
   unSupportedServices: string;
@@ -62,6 +63,7 @@ const BasicInformation: React.FC<BasicInformationProps> = (
     regionEmptyError,
     vpcEmptyError,
     sdkEmptyError,
+    tagsKeyValueEmptyError,
     assetsS3BucketEmptyError,
     loadingServiceAvailable,
     unSupportedServices,
@@ -298,6 +300,15 @@ const BasicInformation: React.FC<BasicInformationProps> = (
             changeTags(tags);
           }}
         />
+        <div>
+          {tagsKeyValueEmptyError ? (
+            <StatusIndicator type="error">
+              {t('pipeline:valid.tagsKeyValueEmpty')}
+            </StatusIndicator>
+          ) : (
+            ''
+          )}
+        </div>
       </SpaceBetween>
     </Container>
   );

--- a/src/control-plane/backend/lambda/api/service/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/service/pipeline.ts
@@ -15,7 +15,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { OUTPUT_INGESTION_SERVER_DNS_SUFFIX, OUTPUT_INGESTION_SERVER_URL_SUFFIX, OUTPUT_METRICS_OBSERVABILITY_DASHBOARD_NAME, OUTPUT_REPORT_DASHBOARDS_SUFFIX } from '../common/constants-ln';
 import { PipelineStackType, PipelineStatusType } from '../common/model-ln';
 import { ApiFail, ApiSuccess } from '../common/types';
-import { getStackOutputFromPipelineStatus, getReportingDashboardsUrl, paginateData, pipelineAnalysisStudioEnabled, getPipelineStatusType } from '../common/utils';
+import { getStackOutputFromPipelineStatus, getReportingDashboardsUrl, paginateData, pipelineAnalysisStudioEnabled, getPipelineStatusType, isEmpty } from '../common/utils';
 import { IPipeline, CPipeline } from '../model/pipeline';
 import { ClickStreamStore } from '../store/click-stream-store';
 import { DynamoDbStore } from '../store/dynamodb/dynamodb-store';
@@ -79,11 +79,11 @@ export class PipelineServ {
       return res.json(new ApiSuccess({
         ...latestPipeline,
         statusType: getPipelineStatusType(latestPipeline),
-        dataProcessing: {
+        dataProcessing: !isEmpty(latestPipeline.dataProcessing) ? {
           ...latestPipeline.dataProcessing,
           transformPlugin: pluginsInfo.transformPlugin,
           enrichPlugin: pluginsInfo.enrichPlugin,
-        },
+        } : {},
         endpoint: getStackOutputFromPipelineStatus(latestPipeline.stackDetails ?? latestPipeline.status?.stackDetails,
           PipelineStackType.INGESTION, OUTPUT_INGESTION_SERVER_URL_SUFFIX),
         dns: getStackOutputFromPipelineStatus(latestPipeline.stackDetails ?? latestPipeline.status?.stackDetails,

--- a/src/control-plane/backend/lambda/api/store/aws/cloudformation.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/cloudformation.ts
@@ -41,7 +41,7 @@ export const getStacksDetailsByNames = async (region: string, stackNames: string
     const stackDetails: PipelineStatusDetail[] = [];
     for (let stackName of stackNames) {
       const stack = await describeStack(region, stackName);
-      const name = stack?.StackName ?? '';
+      const name = stack?.StackName ?? stackName;
       stackDetails.push({
         stackId: stack?.StackId ?? '',
         stackName: name,

--- a/src/control-plane/backend/lambda/api/test/api/pipeline-status.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline-status.test.ts
@@ -197,6 +197,45 @@ describe('Pipeline status test', () => {
       ],
     };
     expect(getPipelineStatusType(pipeline7)).toEqual(PipelineStatusType.FAILED);
+    // execution SUCCEEDED
+    // stacks [CREATE_IN_PROGRESS, CREATE_IN_PROGRESS, CREATE_COMPLETE]
+    const pipeline8: IPipeline = {
+      ...BASE_STATUS_PIPELINE,
+      lastAction: 'Create',
+      executionDetail: {
+        executionArn: 'arn:aws:states:us-east-1:123456789012:execution:EXAMPLE',
+        name: 'EXAMPLE',
+        status: ExecutionStatus.SUCCEEDED,
+      },
+      stackDetails: [
+        {
+          ...BASE_STACK_DETAIL,
+          stackStatus: StackStatus.CREATE_IN_PROGRESS,
+        },
+        {
+          ...BASE_STACK_DETAIL,
+          stackStatus: StackStatus.CREATE_IN_PROGRESS,
+        },
+        {
+          ...BASE_STACK_DETAIL,
+          stackStatus: StackStatus.CREATE_COMPLETE,
+        },
+      ],
+    };
+    expect(getPipelineStatusType(pipeline8)).toEqual(PipelineStatusType.CREATING);
+    // execution SUCCEEDED
+    // stacks []
+    const pipeline9: IPipeline = {
+      ...BASE_STATUS_PIPELINE,
+      lastAction: 'Create',
+      executionDetail: {
+        executionArn: 'arn:aws:states:us-east-1:123456789012:execution:EXAMPLE',
+        name: 'EXAMPLE',
+        status: ExecutionStatus.SUCCEEDED,
+      },
+      stackDetails: [],
+    };
+    expect(getPipelineStatusType(pipeline9)).toEqual(PipelineStatusType.ACTIVE);
   });
   it('update status', async () => {
     // execution RUNNING
@@ -371,6 +410,45 @@ describe('Pipeline status test', () => {
       ],
     };
     expect(getPipelineStatusType(pipeline8)).toEqual(PipelineStatusType.WARNING);
+    // execution SUCCEEDED
+    // stacks [UPDATE_COMPLETE, UPDATE_IN_PROGRESS, UPDATE_IN_PROGRESS]
+    const pipeline9: IPipeline = {
+      ...BASE_STATUS_PIPELINE,
+      lastAction: 'Update',
+      executionDetail: {
+        executionArn: 'arn:aws:states:us-east-1:123456789012:execution:EXAMPLE',
+        name: 'EXAMPLE',
+        status: ExecutionStatus.SUCCEEDED,
+      },
+      stackDetails: [
+        {
+          ...BASE_STACK_DETAIL,
+          stackStatus: StackStatus.UPDATE_COMPLETE,
+        },
+        {
+          ...BASE_STACK_DETAIL,
+          stackStatus: StackStatus.UPDATE_IN_PROGRESS,
+        },
+        {
+          ...BASE_STACK_DETAIL,
+          stackStatus: StackStatus.UPDATE_IN_PROGRESS,
+        },
+      ],
+    };
+    expect(getPipelineStatusType(pipeline9)).toEqual(PipelineStatusType.UPDATING);
+    // execution SUCCEEDED
+    // stacks []
+    const pipeline10: IPipeline = {
+      ...BASE_STATUS_PIPELINE,
+      lastAction: 'Update',
+      executionDetail: {
+        executionArn: 'arn:aws:states:us-east-1:123456789012:execution:EXAMPLE',
+        name: 'EXAMPLE',
+        status: ExecutionStatus.SUCCEEDED,
+      },
+      stackDetails: [],
+    };
+    expect(getPipelineStatusType(pipeline10)).toEqual(PipelineStatusType.ACTIVE);
   });
   it('upgrade status', async () => {
     // execution RUNNING

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -1213,7 +1213,7 @@ describe('Pipeline test', () => {
           status: PipelineStatusType.ACTIVE,
         },
         stackDetails: stackDetails,
-        statusType: PipelineStatusType.WARNING,
+        statusType: PipelineStatusType.ACTIVE,
         dataProcessing: {
           ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW.dataProcessing,
           enrichPlugin: [
@@ -1302,6 +1302,87 @@ describe('Pipeline test', () => {
         metricsDashboardName: 'clickstream_dashboard_notepad_mtzfsocy',
         analysisStudioEnabled: false,
       },
+    });
+  });
+  it('Get pipeline by ID and refresh force', async () => {
+    projectExistedMock(ddbMock, true);
+    const stackDetails = [
+      stackDetailsWithOutputs[0],
+      stackDetailsWithOutputs[1],
+      stackDetailsWithOutputs[2],
+      stackDetailsWithOutputs[3],
+      stackDetailsWithOutputs[4],
+      {
+        ...stackDetailsWithOutputs[5],
+        stackTemplateVersion: FULL_SOLUTION_VERSION,
+      },
+    ];
+
+    ddbMock.on(QueryCommand).resolves({
+      Items: [{
+        ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW,
+        stackDetails: stackDetails,
+      }],
+    });
+    dictionaryMock(ddbMock);
+    ddbMock.on(QueryCommand, {
+      ExclusiveStartKey: undefined,
+      ExpressionAttributeNames:
+        { '#prefix': 'prefix' },
+      ExpressionAttributeValues: {
+        ':d': false,
+        ':prefix': 'PLUGIN',
+      },
+      FilterExpression: 'deleted = :d',
+      KeyConditionExpression:
+    '#prefix= :prefix',
+      Limit: undefined,
+      ScanIndexForward: true,
+      TableName: clickStreamTableName,
+      IndexName: prefixTimeGSIName,
+    }).resolves({
+      Items: [
+        { id: `${MOCK_PLUGIN_ID}_2`, name: `${MOCK_PLUGIN_ID}_2` },
+      ],
+    });
+
+    sfnMock.on(DescribeExecutionCommand).resolves({
+      executionArn: 'arn:aws:states:ap-southeast-1:123456789012:execution:ForceExecutionName:12345678-1234-1234-1234-123456789012',
+      name: MOCK_EXECUTION_ID,
+      status: ExecutionStatus.FAILED,
+      startDate: new Date(),
+    });
+    cloudFormationMock.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackName: 'ForceStackName',
+          StackId: 'arn:aws:cloudformation:ap-southeast-1:123456789012:stack/ForceStackName/12345678-1234-1234-1234-123456789012',
+          Tags: [{ Key: BuiltInTagKeys.AWS_SOLUTION_VERSION, Value: MOCK_SOLUTION_VERSION }],
+          StackStatus: StackStatus.CREATE_FAILED,
+          StackStatusReason: 'MockForceStackStatusReason',
+          CreationTime: new Date(),
+        },
+      ],
+    });
+    let res = await request(app)
+      .get(`/api/pipeline/${MOCK_PIPELINE_ID}?pid=${MOCK_PROJECT_ID}&refresh=force`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.statusType).toEqual(PipelineStatusType.FAILED);
+    expect(res.body.data.stackDetails).toContainEqual(
+      {
+        outputs: [],
+        stackId: 'arn:aws:cloudformation:ap-southeast-1:123456789012:stack/ForceStackName/12345678-1234-1234-1234-123456789012',
+        stackName: 'ForceStackName',
+        stackStatus: StackStatus.CREATE_FAILED,
+        stackStatusReason: 'MockForceStackStatusReason',
+        stackTemplateVersion: MOCK_SOLUTION_VERSION,
+      },
+    );
+    expect(res.body.data.executionDetail).toEqual({
+      executionArn: 'arn:aws:states:ap-southeast-1:123456789012:execution:ForceExecutionName:12345678-1234-1234-1234-123456789012',
+      name: MOCK_EXECUTION_ID,
+      status: ExecutionStatus.FAILED,
     });
   });
   it('Get pipeline when no found Execution history and stack details', async () => {
@@ -1682,7 +1763,7 @@ describe('Pipeline test', () => {
       data: {
         ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW,
         stackDetails: BASE_STATUS.stackDetails,
-        statusType: 'Warning',
+        statusType: PipelineStatusType.ACTIVE,
         dataProcessing: {
           ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW.dataProcessing,
           enrichPlugin: [

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -1850,11 +1850,7 @@ describe('Pipeline test', () => {
         ...S3_INGESTION_PIPELINE,
         stackDetails: [],
         statusType: 'Active',
-        dataProcessing: {
-          ...S3_INGESTION_PIPELINE.dataProcessing,
-          enrichPlugin: [],
-          transformPlugin: null,
-        },
+        dataProcessing: {},
         dns: '',
         endpoint: '',
         dashboards: [],


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. creating pipeline error status when refresh force

## Implementation highlights

Reorganize the status pseudocode：
  
Algorithm get-pipeline-status is:
&nbsp;&nbsp;&nbsp;&nbsp;Retrieve `latestAction`: Create, Update, Delete
&nbsp;&nbsp;&nbsp;&nbsp;Retrieve `stackStatus`
&nbsp;&nbsp;&nbsp;&nbsp;Retrieve `executionStatus`
&nbsp;&nbsp;&nbsp;&nbsp;**If** executionStatus **failed**:
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**return** FAILED
&nbsp;&nbsp;&nbsp;&nbsp;**ElseIf** executionStatus is **running**:
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**return** pipeline status is Updating, Creating or Deleting depending on latestAction
&nbsp;&nbsp;&nbsp;&nbsp;**ElseIf** executionStatus is **succeeded**:
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**return** pipeline status depending on stack status
&nbsp;&nbsp;&nbsp;&nbsp;Handling special situations: Warning

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend