### PR TITLE
fix: creating pipeline error status when refresh force

### DIFF
--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -1083,13 +1083,12 @@ function _getPipelineStatus(pipeline: IPipeline) {
 function _getStatusWhenExecutionSuccess(stackStatus: string) {
   switch (stackStatus) {
     case 'FAILED':
-      return PipelineStatusType.FAILED;
     case 'ROLLBACK_COMPLETE':
-      return PipelineStatusType.WARNING;
-    case 'COMPLETE':
-      return PipelineStatusType.ACTIVE;
+      return PipelineStatusType.FAILED;
     case 'DELETE_COMPLETE':
       return PipelineStatusType.DELETED;
+    case 'WRONG_VERSION':
+      return PipelineStatusType.WARNING;
     default:
       return PipelineStatusType.ACTIVE;
   }
@@ -1117,6 +1116,13 @@ function _getPipelineStatusFromStacks(pipeline: IPipeline) {
     status = 'IN_PROGRESS';
   } else if (stackStatusArray.every(s => s === StackStatus.DELETE_COMPLETE)) {
     status = 'DELETE_COMPLETE';
+  }
+  // Error Template Version
+  if (stackDetails.some(
+    s => s.stackTemplateVersion !== '' &&
+    pipeline.templateVersion &&
+    pipeline.templateVersion !== s.stackTemplateVersion)) {
+    status = 'WRONG_VERSION';
   }
   return status;
 }

--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -1118,7 +1118,7 @@ function _getPipelineStatusFromStacks(pipeline: IPipeline) {
     status = 'DELETE_COMPLETE';
   }
   // Error Template Version
-  if (stackDetails.some(
+  if (status === 'COMPLETE' && stackDetails.some(
     s => s.stackTemplateVersion !== '' &&
     pipeline.templateVersion &&
     pipeline.templateVersion !== s.stackTemplateVersion)) {

--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -1087,7 +1087,7 @@ function _getStatusWhenExecutionSuccess(stackStatus: string) {
       return PipelineStatusType.FAILED;
     case 'DELETE_COMPLETE':
       return PipelineStatusType.DELETED;
-    case 'WRONG_VERSION':
+    case 'INCONSISTENT_VERSION':
       return PipelineStatusType.WARNING;
     default:
       return PipelineStatusType.ACTIVE;
@@ -1122,7 +1122,7 @@ function _getPipelineStatusFromStacks(pipeline: IPipeline) {
     s => s.stackTemplateVersion !== '' &&
     pipeline.templateVersion &&
     pipeline.templateVersion !== s.stackTemplateVersion)) {
-    status = 'WRONG_VERSION';
+    status = 'INCONSISTENT_VERSION';
   }
   return status;
 }

--- a/src/control-plane/backend/lambda/api/store/aws/cloudformation.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/cloudformation.ts
@@ -41,7 +41,7 @@ export const getStacksDetailsByNames = async (region: string, stackNames: string
     const stackDetails: PipelineStatusDetail[] = [];
     for (let stackName of stackNames) {
       const stack = await describeStack(region, stackName);
-      const name = stack?.StackName ?? '';
+      const name = stack?.StackName ?? stackName;
       stackDetails.push({
         stackId: stack?.StackId ?? '',
         stackName: name,

--- a/src/control-plane/backend/lambda/api/test/api/pipeline-status.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline-status.test.ts
@@ -197,6 +197,45 @@ describe('Pipeline status test', () => {
       ],
     };
     expect(getPipelineStatusType(pipeline7)).toEqual(PipelineStatusType.FAILED);
+    // execution SUCCEEDED
+    // stacks [CREATE_IN_PROGRESS, CREATE_IN_PROGRESS, CREATE_COMPLETE]
+    const pipeline8: IPipeline = {
+      ...BASE_STATUS_PIPELINE,
+      lastAction: 'Create',
+      executionDetail: {
+        executionArn: 'arn:aws:states:us-east-1:123456789012:execution:EXAMPLE',
+        name: 'EXAMPLE',
+        status: ExecutionStatus.SUCCEEDED,
+      },
+      stackDetails: [
+        {
+          ...BASE_STACK_DETAIL,
+          stackStatus: StackStatus.CREATE_IN_PROGRESS,
+        },
+        {
+          ...BASE_STACK_DETAIL,
+          stackStatus: StackStatus.CREATE_IN_PROGRESS,
+        },
+        {
+          ...BASE_STACK_DETAIL,
+          stackStatus: StackStatus.CREATE_COMPLETE,
+        },
+      ],
+    };
+    expect(getPipelineStatusType(pipeline8)).toEqual(PipelineStatusType.CREATING);
+    // execution SUCCEEDED
+    // stacks []
+    const pipeline9: IPipeline = {
+      ...BASE_STATUS_PIPELINE,
+      lastAction: 'Create',
+      executionDetail: {
+        executionArn: 'arn:aws:states:us-east-1:123456789012:execution:EXAMPLE',
+        name: 'EXAMPLE',
+        status: ExecutionStatus.SUCCEEDED,
+      },
+      stackDetails: [],
+    };
+    expect(getPipelineStatusType(pipeline9)).toEqual(PipelineStatusType.ACTIVE);
   });
   it('update status', async () => {
     // execution RUNNING
@@ -371,6 +410,45 @@ describe('Pipeline status test', () => {
       ],
     };
     expect(getPipelineStatusType(pipeline8)).toEqual(PipelineStatusType.WARNING);
+    // execution SUCCEEDED
+    // stacks [UPDATE_COMPLETE, UPDATE_IN_PROGRESS, UPDATE_IN_PROGRESS]
+    const pipeline9: IPipeline = {
+      ...BASE_STATUS_PIPELINE,
+      lastAction: 'Update',
+      executionDetail: {
+        executionArn: 'arn:aws:states:us-east-1:123456789012:execution:EXAMPLE',
+        name: 'EXAMPLE',
+        status: ExecutionStatus.SUCCEEDED,
+      },
+      stackDetails: [
+        {
+          ...BASE_STACK_DETAIL,
+          stackStatus: StackStatus.UPDATE_COMPLETE,
+        },
+        {
+          ...BASE_STACK_DETAIL,
+          stackStatus: StackStatus.UPDATE_IN_PROGRESS,
+        },
+        {
+          ...BASE_STACK_DETAIL,
+          stackStatus: StackStatus.UPDATE_IN_PROGRESS,
+        },
+      ],
+    };
+    expect(getPipelineStatusType(pipeline9)).toEqual(PipelineStatusType.UPDATING);
+    // execution SUCCEEDED
+    // stacks []
+    const pipeline10: IPipeline = {
+      ...BASE_STATUS_PIPELINE,
+      lastAction: 'Update',
+      executionDetail: {
+        executionArn: 'arn:aws:states:us-east-1:123456789012:execution:EXAMPLE',
+        name: 'EXAMPLE',
+        status: ExecutionStatus.SUCCEEDED,
+      },
+      stackDetails: [],
+    };
+    expect(getPipelineStatusType(pipeline10)).toEqual(PipelineStatusType.ACTIVE);
   });
   it('upgrade status', async () => {
     // execution RUNNING

--- a/src/control-plane/backend/lambda/api/test/api/pipeline-status.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline-status.test.ts
@@ -688,6 +688,35 @@ describe('Pipeline status test', () => {
     };
     expect(getPipelineStatusType(pipeline5)).toEqual(PipelineStatusType.DELETING);
   });
+  it('wrong version status', async () => {
+    // execution SUCCEEDED
+    // stacks [UPDATE_COMPLETE, UPDATE_COMPLETE, UPDATE_COMPLETE]
+    const pipeline4: IPipeline = {
+      ...BASE_STATUS_PIPELINE,
+      lastAction: 'Upgrade',
+      executionDetail: {
+        executionArn: 'arn:aws:states:us-east-1:123456789012:execution:EXAMPLE',
+        name: 'EXAMPLE',
+        status: ExecutionStatus.SUCCEEDED,
+      },
+      stackDetails: [
+        {
+          ...BASE_STACK_DETAIL,
+          stackTemplateVersion: 'wrong version',
+          stackStatus: StackStatus.UPDATE_COMPLETE,
+        },
+        {
+          ...BASE_STACK_DETAIL,
+          stackStatus: StackStatus.UPDATE_COMPLETE,
+        },
+        {
+          ...BASE_STACK_DETAIL,
+          stackStatus: StackStatus.UPDATE_COMPLETE,
+        },
+      ],
+    };
+    expect(getPipelineStatusType(pipeline4)).toEqual(PipelineStatusType.WARNING);
+  });
   afterAll((done) => {
     done();
   });

--- a/src/control-plane/backend/lambda/api/test/api/pipeline-status.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline-status.test.ts
@@ -691,7 +691,7 @@ describe('Pipeline status test', () => {
   it('wrong version status', async () => {
     // execution SUCCEEDED
     // stacks [UPDATE_COMPLETE, UPDATE_COMPLETE, UPDATE_COMPLETE]
-    const pipeline4: IPipeline = {
+    const pipeline1: IPipeline = {
       ...BASE_STATUS_PIPELINE,
       lastAction: 'Upgrade',
       executionDetail: {
@@ -715,7 +715,34 @@ describe('Pipeline status test', () => {
         },
       ],
     };
-    expect(getPipelineStatusType(pipeline4)).toEqual(PipelineStatusType.WARNING);
+    expect(getPipelineStatusType(pipeline1)).toEqual(PipelineStatusType.WARNING);
+    // execution RUNNING
+    // stacks [UPDATE_COMPLETE, UPDATE_IN_PROGRESS, UPDATE_COMPLETE]
+    const pipeline2: IPipeline = {
+      ...BASE_STATUS_PIPELINE,
+      lastAction: 'Upgrade',
+      executionDetail: {
+        executionArn: 'arn:aws:states:us-east-1:123456789012:execution:EXAMPLE',
+        name: 'EXAMPLE',
+        status: ExecutionStatus.RUNNING,
+      },
+      stackDetails: [
+        {
+          ...BASE_STACK_DETAIL,
+          stackTemplateVersion: 'wrong version',
+          stackStatus: StackStatus.UPDATE_COMPLETE,
+        },
+        {
+          ...BASE_STACK_DETAIL,
+          stackStatus: StackStatus.UPDATE_IN_PROGRESS,
+        },
+        {
+          ...BASE_STACK_DETAIL,
+          stackStatus: StackStatus.UPDATE_COMPLETE,
+        },
+      ],
+    };
+    expect(getPipelineStatusType(pipeline2)).toEqual(PipelineStatusType.UPDATING);
   });
   afterAll((done) => {
     done();

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -1221,7 +1221,7 @@ describe('Pipeline test', () => {
           status: PipelineStatusType.ACTIVE,
         },
         stackDetails: stackDetails,
-        statusType: PipelineStatusType.ACTIVE,
+        statusType: PipelineStatusType.WARNING,
         dataProcessing: {
           ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW.dataProcessing,
           enrichPlugin: [
@@ -1771,7 +1771,7 @@ describe('Pipeline test', () => {
       data: {
         ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW,
         stackDetails: BASE_STATUS.stackDetails,
-        statusType: PipelineStatusType.ACTIVE,
+        statusType: PipelineStatusType.WARNING,
         dataProcessing: {
           ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW.dataProcessing,
           enrichPlugin: [


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. creating pipeline error status when refresh force

## Implementation highlights

Reorganize the status pseudocode：
  
Algorithm get-pipeline-status is:
&nbsp;&nbsp;&nbsp;&nbsp;Retrieve `latestAction`: Create, Update, Delete
&nbsp;&nbsp;&nbsp;&nbsp;Retrieve `stackStatus`
&nbsp;&nbsp;&nbsp;&nbsp;Retrieve `executionStatus`
&nbsp;&nbsp;&nbsp;&nbsp;**If** executionStatus **failed**:
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**return** FAILED
&nbsp;&nbsp;&nbsp;&nbsp;**ElseIf** executionStatus is **running**:
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**return** pipeline status is Updating, Creating or Deleting depending on latestAction
&nbsp;&nbsp;&nbsp;&nbsp;**ElseIf** executionStatus is **succeeded**:
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**return** pipeline status depending on stack status
&nbsp;&nbsp;&nbsp;&nbsp;Handling special situations: Warning

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend