### PR TITLE
fix: incorrectly choose or input s3 bucket in another region

### DIFF
--- a/frontend/src/pages/pipelines/create/CreatePipeline.tsx
+++ b/frontend/src/pages/pipelines/create/CreatePipeline.tsx
@@ -784,67 +784,19 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
             data,
             'quicksight'
           );
-          if (update) {
-            setPipelineInfo((prev) => {
-              return {
-                ...prev,
-                serviceStatus: {
-                  AGA: agaAvailable,
-                  EMR_SERVERLESS: emrAvailable,
-                  REDSHIFT_SERVERLESS: redshiftServerlessAvailable,
-                  MSK: mskAvailable,
-                  QUICK_SIGHT: quickSightAvailable,
-                },
-              };
-            });
-          } else {
-            setPipelineInfo((prev) => {
-              return {
-                ...prev,
-                serviceStatus: {
-                  AGA: agaAvailable,
-                  EMR_SERVERLESS: emrAvailable,
-                  REDSHIFT_SERVERLESS: redshiftServerlessAvailable,
-                  MSK: mskAvailable,
-                  QUICK_SIGHT: quickSightAvailable,
-                },
-                // Below to set resources to empty by regions
-                selectedVPC: null,
-                selectedPublicSubnet: [],
-                selectedPrivateSubnet: [],
-                selectedSecret: null, // clear secret
-                selectedCertificate: null, // clear certificates
-                showServiceStatus: false,
-                redshiftBaseCapacity: null,
-                redshiftServerlessSG: [],
-                redshiftServerlessVPC: null,
-                redshiftServerlessSubnets: [],
-                ingestionServer: {
-                  ...prev.ingestionServer,
-                  sinkS3: {
-                    // set sink s3 to null
-                    ...prev.ingestionServer.sinkS3,
-                    sinkBucket: {
-                      name: '',
-                      prefix: '',
-                    },
-                  },
-                  domain: {
-                    ...prev.ingestionServer.domain,
-                    certificateArn: '', // set certificate arn to empty
-                  },
-                  loadBalancer: {
-                    ...prev.ingestionServer.loadBalancer,
-                    authenticationSecretArn: '', // set secret value to null
-                    logS3Bucket: {
-                      ...prev.ingestionServer.loadBalancer.logS3Bucket,
-                      name: '',
-                    },
-                  },
-                },
-              };
-            });
-
+          setPipelineInfo((prev) => {
+            return {
+              ...prev,
+              serviceStatus: {
+                AGA: agaAvailable,
+                EMR_SERVERLESS: emrAvailable,
+                REDSHIFT_SERVERLESS: redshiftServerlessAvailable,
+                MSK: mskAvailable,
+                QUICK_SIGHT: quickSightAvailable,
+              },
+            };
+          });
+          if (!update) {
             // Set show alert information when has unsupported services
             const unSupportedServiceList = data.filter(
               (service) => !service.available
@@ -1041,6 +993,48 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
   // Monitor Region Changed and validate Service Available
   useEffect(() => {
     if (pipelineInfo.region) {
+      if (!update) {
+        setPipelineInfo((prev) => {
+          return {
+            ...prev,
+            // Below to set resources to empty by regions
+            selectedVPC: null,
+            selectedS3Bucket: null,
+            selectedPublicSubnet: [],
+            selectedPrivateSubnet: [],
+            selectedSecret: null, // clear secret
+            selectedCertificate: null, // clear certificates
+            showServiceStatus: false,
+            redshiftBaseCapacity: null,
+            redshiftServerlessSG: [],
+            redshiftServerlessVPC: null,
+            redshiftServerlessSubnets: [],
+            ingestionServer: {
+              ...prev.ingestionServer,
+              sinkS3: {
+                // set sink s3 to null
+                ...prev.ingestionServer.sinkS3,
+                sinkBucket: {
+                  name: '',
+                  prefix: '',
+                },
+              },
+              domain: {
+                ...prev.ingestionServer.domain,
+                certificateArn: '', // set certificate arn to empty
+              },
+              loadBalancer: {
+                ...prev.ingestionServer.loadBalancer,
+                authenticationSecretArn: '', // set secret value to null
+                logS3Bucket: {
+                  ...prev.ingestionServer.loadBalancer.logS3Bucket,
+                  name: '',
+                },
+              },
+            },
+          };
+        });
+      }
       validServiceAvailable(pipelineInfo.region);
     }
   }, [pipelineInfo.region]);

--- a/src/control-plane/backend/lambda/api/store/aws/s3.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/s3.ts
@@ -117,8 +117,9 @@ export const isBucketExist = async (region: string, bucket: string) => {
       Bucket: bucket,
       ExpectedBucketOwner: awsAccountId,
     });
-    await s3Client.send(params);
-    return true;
+    const res = await s3Client.send(params);
+    const location = res.LocationConstraint ?? 'us-east-1';
+    return location === region;
   } catch (error) {
     logger.warn('get S3 bucket location error ', { error });
     return false;

--- a/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
@@ -449,7 +449,10 @@ function createPipelineMock(
     twoAZsInRegion?: boolean;
     quickSightStandard?: boolean;
     albPolicyDisable?: boolean;
-    bucketNotExist?: boolean;
+    bucket?: {
+      notExist?: boolean;
+      location?: BucketLocationConstraint;
+    };
   }): any {
   iamMock.on(SimulateCustomPolicyCommand).resolves({
     EvaluationResults: [
@@ -998,13 +1001,13 @@ function createPipelineMock(
     Policy: props?.albPolicyDisable ? AllowIAMUserPutObejectPolicyWithErrorService
       :AllowIAMUserPutObejectPolicyInApSouthEast1,
   });
-  if (props?.bucketNotExist) {
+  if (props?.bucket?.notExist) {
     const mockNoSuchBucketError = new Error('NoSuchBucket');
     mockNoSuchBucketError.name = 'NoSuchBucket';
     s3Mock.on(GetBucketLocationCommand).rejects(mockNoSuchBucketError);
   } else {
     s3Mock.on(GetBucketLocationCommand).resolves({
-      LocationConstraint: BucketLocationConstraint.ap_southeast_1,
+      LocationConstraint: props?.bucket?.location ?? BucketLocationConstraint.ap_southeast_1,
     });
   }
 }

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -35,6 +35,7 @@ import {
   RedshiftServerlessClient,
 } from '@aws-sdk/client-redshift-serverless';
 import {
+  BucketLocationConstraint,
   GetBucketPolicyCommand,
   S3Client,
 } from '@aws-sdk/client-s3';
@@ -145,7 +146,9 @@ describe('Pipeline test', () => {
         publicAZContainPrivateAZ: true,
         subnetsCross3AZ: true,
         subnetsIsolated: true,
-        bucketNotExist: true,
+        bucket: {
+          notExist: true,
+        },
       });
 
     ddbMock.on(PutCommand).resolves({});
@@ -250,6 +253,9 @@ describe('Pipeline test', () => {
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
         noVpcEndpoint: true,
+        bucket: {
+          location: BucketLocationConstraint.cn_north_1,
+        },
       });
     ddbMock.on(PutCommand).resolves({});
     createPipelineMockForBJSRegion(s3Mock);
@@ -298,6 +304,9 @@ describe('Pipeline test', () => {
         publicAZContainPrivateAZ: true,
         subnetsCross3AZ: true,
         noVpcEndpoint: true,
+        bucket: {
+          location: BucketLocationConstraint.us_west_1,
+        },
       });
     ddbMock.on(PutCommand).resolves({});
     const res = await request(app)

--- a/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
@@ -26,6 +26,7 @@ import {
   RedshiftServerlessClient,
 } from '@aws-sdk/client-redshift-serverless';
 import {
+  BucketLocationConstraint,
   S3Client,
 } from '@aws-sdk/client-s3';
 import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
@@ -258,6 +259,9 @@ describe('Workflow test', () => {
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
         noVpcEndpoint: true,
+        bucket: {
+          location: BucketLocationConstraint.cn_north_1,
+        },
       });
     createPipelineMockForBJSRegion(s3Mock);
     const pipeline: CPipeline = new CPipeline({
@@ -602,6 +606,9 @@ describe('Workflow test', () => {
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
         noVpcEndpoint: true,
+        bucket: {
+          location: BucketLocationConstraint.cn_north_1,
+        },
       });
     createPipelineMockForBJSRegion(s3Mock);
     const pipeline: CPipeline = new CPipeline({
@@ -840,6 +847,9 @@ describe('Workflow test', () => {
       ec2Mock, sfnMock, secretsManagerMock, quickSightMock, s3Mock, iamMock, {
         publicAZContainPrivateAZ: true,
         noVpcEndpoint: true,
+        bucket: {
+          location: BucketLocationConstraint.cn_north_1,
+        },
       });
     createPipelineMockForBJSRegion(s3Mock);
     const pipeline: CPipeline = new CPipeline({


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend