### PR TITLE
fix: set scan metadata data workflow alarm period with stack parameter

### DIFF
--- a/src/analytics/analytics-on-redshift.ts
+++ b/src/analytics/analytics-on-redshift.ts
@@ -317,6 +317,7 @@ export class RedshiftAnalyticsStack extends NestedStack {
         redshiftServerlessWorkgroupName: this.redshiftServerlessWorkgroup.workgroup.workgroupName,
         loadDataWorkflow: loadRedshiftTablesWorkflow.loadDataWorkflow,
         scanMetadataWorkflow: scanMetadataWorkflow.scanMetadataWorkflow,
+        scanWorkflowMinInterval: props.scanMetadataWorkflowData.scanWorkflowMinInterval,
         clearExpiredEventsWorkflow: clearExpiredEventsWorkflow.clearExpiredEventsWorkflow,
         sqlExecutionWorkflow: this.sqlExecutionWorkflow,
 
@@ -331,6 +332,7 @@ export class RedshiftAnalyticsStack extends NestedStack {
         redshiftServerlessWorkgroupName: props.existingRedshiftServerlessProps.workgroupName,
         loadDataWorkflow: loadRedshiftTablesWorkflow.loadDataWorkflow,
         scanMetadataWorkflow: scanMetadataWorkflow.scanMetadataWorkflow,
+        scanWorkflowMinInterval: props.scanMetadataWorkflowData.scanWorkflowMinInterval,
         clearExpiredEventsWorkflow: clearExpiredEventsWorkflow.clearExpiredEventsWorkflow,
         sqlExecutionWorkflow: this.sqlExecutionWorkflow,
       });
@@ -343,6 +345,7 @@ export class RedshiftAnalyticsStack extends NestedStack {
         redshiftClusterIdentifier: props.provisionedRedshiftProps.clusterIdentifier,
         loadDataWorkflow: loadRedshiftTablesWorkflow.loadDataWorkflow,
         scanMetadataWorkflow: scanMetadataWorkflow.scanMetadataWorkflow,
+        scanWorkflowMinInterval: props.scanMetadataWorkflowData.scanWorkflowMinInterval,
         clearExpiredEventsWorkflow: clearExpiredEventsWorkflow.clearExpiredEventsWorkflow,
         sqlExecutionWorkflow: this.sqlExecutionWorkflow,
       });

--- a/src/analytics/private/metrics-common-workflow.ts
+++ b/src/analytics/private/metrics-common-workflow.ts
@@ -26,12 +26,14 @@ export function buildMetricsWidgetForWorkflows(scope: Construct, id: string, pro
   dataProcessingCronOrRateExpression: string;
   loadDataWorkflow: IStateMachine;
   scanMetadataWorkflow: IStateMachine;
+  scanWorkflowMinInterval: string;
   clearExpiredEventsWorkflow: IStateMachine;
   sqlExecutionWorkflow: IStateMachine;
 }) {
 
   const processingJobInterval = new GetInterval(scope, 'dataProcess', {
     expression: props.dataProcessingCronOrRateExpression,
+    scanWorkflowMinInterval: props.scanWorkflowMinInterval,
   });
 
   const statesNamespace = 'AWS/States';
@@ -78,7 +80,7 @@ export function buildMetricsWidgetForWorkflows(scope: Construct, id: string, pro
     alarmDescription: `Scan metadata workflow failed, projectId: ${props.projectId}`,
     alarmName: getAlarmName(scope, props.projectId, 'Scan Metadata Workflow'),
   });
-  (scanMetadataWorkflowAlarm.node.defaultChild as CfnResource).addPropertyOverride('Period', processingJobInterval.getIntervalSeconds());
+  (scanMetadataWorkflowAlarm.node.defaultChild as CfnResource).addPropertyOverride('Period', processingJobInterval.getScanWorkflowMinIntervalSeconds());
 
   const newFilesCountAlarm = new Alarm(scope, id + 'MaxFileAgeAlarm', {
     comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,

--- a/src/analytics/private/metrics-redshift-cluster.ts
+++ b/src/analytics/private/metrics-redshift-cluster.ts
@@ -25,6 +25,7 @@ export function createMetricsWidgetForRedshiftCluster(scope: Construct, props: {
   redshiftClusterIdentifier: string;
   loadDataWorkflow: IStateMachine;
   scanMetadataWorkflow: IStateMachine;
+  scanWorkflowMinInterval: string;
   clearExpiredEventsWorkflow: IStateMachine;
   sqlExecutionWorkflow: IStateMachine;
 }) {

--- a/src/analytics/private/metrics-redshift-serverless.ts
+++ b/src/analytics/private/metrics-redshift-serverless.ts
@@ -26,6 +26,7 @@ export function createMetricsWidgetForRedshiftServerless(scope: Construct, id: s
   redshiftServerlessWorkgroupName: string;
   loadDataWorkflow: IStateMachine;
   scanMetadataWorkflow: IStateMachine;
+  scanWorkflowMinInterval: string;
   clearExpiredEventsWorkflow: IStateMachine;
   sqlExecutionWorkflow: IStateMachine;
 }) {

--- a/src/metrics/custom-resource/get-interval/index.ts
+++ b/src/metrics/custom-resource/get-interval/index.ts
@@ -51,9 +51,18 @@ async function _handler(event: CdkCustomResourceEvent) {
   intervalSeconds = Math.max(60, intervalSeconds);
   intervalSeconds = Math.floor(intervalSeconds / 60) * 60;
 
+  let scanWorkflowMinIntervalSeconds = 86400;
+  if (event.ResourceProperties.scanWorkflowMinInterval) {
+    const parsedValue = parseInt(event.ResourceProperties.scanWorkflowMinInterval, 10);
+    if (!isNaN(parsedValue)) {
+      scanWorkflowMinIntervalSeconds = Math.min(86400, parsedValue * 60);
+    }
+  }
+
   return {
     Data: {
       intervalSeconds,
+      scanWorkflowMinIntervalSeconds: scanWorkflowMinIntervalSeconds,
     },
   };
 }

--- a/src/metrics/get-interval-custom-resource.ts
+++ b/src/metrics/get-interval-custom-resource.ts
@@ -25,6 +25,7 @@ import { SolutionNodejsFunction } from '../private/function';
 
 export interface GetIntervalProps {
   readonly expression: string;
+  readonly scanWorkflowMinInterval?: string;
   readonly evaluationPeriods?: number;
 }
 
@@ -37,6 +38,10 @@ export class GetInterval extends Construct {
 
   public getIntervalSeconds(): string {
     return this.intervalCustomResource.getAttString('intervalSeconds');
+  }
+
+  public getScanWorkflowMinIntervalSeconds(): string {
+    return this.intervalCustomResource.getAttString('scanWorkflowMinIntervalSeconds');
   }
 }
 
@@ -58,6 +63,7 @@ function createGetIntervalCustomResource(
     serviceToken: provider.serviceToken,
     properties: {
       expression: props.expression,
+      scanWorkflowMinInterval: props.scanWorkflowMinInterval,
       evaluationPeriods: props.evaluationPeriods || '1',
       version: new Date().getTime(),
     },

--- a/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
+++ b/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
@@ -4227,7 +4227,7 @@ describe('Should set metrics widgets', () => {
       Period: {
         'Fn::GetAtt': [
           Match.anyValue(),
-          'intervalSeconds',
+          'scanWorkflowMinIntervalSeconds',
         ],
       },
     });
@@ -4313,7 +4313,7 @@ describe('Should set metrics widgets', () => {
       Period: {
         'Fn::GetAtt': [
           Match.anyValue(),
-          'intervalSeconds',
+          'scanWorkflowMinIntervalSeconds',
         ],
       },
     });
@@ -4397,7 +4397,7 @@ describe('Should set metrics widgets', () => {
       Period: {
         'Fn::GetAtt': [
           Match.anyValue(),
-          'intervalSeconds',
+          'scanWorkflowMinIntervalSeconds',
         ],
       },
     });

--- a/test/metrics/get-interval.test.ts
+++ b/test/metrics/get-interval.test.ts
@@ -43,7 +43,12 @@ test('should get interval seconds for rate expression - hours', async () => {
 
   //@ts-ignore
   const data = await handler(event, c);
-  expect(data).toEqual({ Data: { intervalSeconds: 7200 } });
+  expect(data).toEqual({
+    Data: {
+      intervalSeconds: 7200,
+      scanWorkflowMinIntervalSeconds: 86400,
+    },
+  });
 });
 
 
@@ -58,7 +63,12 @@ test('should get interval seconds for rate expression - days', async () => {
 
   //@ts-ignore
   const data = await handler(event, c);
-  expect(data).toEqual({ Data: { intervalSeconds: 86400 } });
+  expect(data).toEqual({
+    Data: {
+      intervalSeconds: 86400,
+      scanWorkflowMinIntervalSeconds: 86400,
+    },
+  });
 });
 
 
@@ -73,7 +83,12 @@ test('should get interval seconds for rate expression - minutes', async () => {
 
   //@ts-ignore
   const data = await handler(event, c);
-  expect(data).toEqual({ Data: { intervalSeconds: 120 } });
+  expect(data).toEqual({
+    Data: {
+      intervalSeconds: 120,
+      scanWorkflowMinIntervalSeconds: 86400,
+    },
+  });
 });
 
 
@@ -88,7 +103,12 @@ test('should get interval seconds for rate expression - seconds', async () => {
 
   //@ts-ignore
   const data = await handler(event, c);
-  expect(data).toEqual({ Data: { intervalSeconds: 60 } });
+  expect(data).toEqual({
+    Data: {
+      intervalSeconds: 60,
+      scanWorkflowMinIntervalSeconds: 86400,
+    },
+  });
 });
 
 
@@ -104,7 +124,12 @@ test('should get interval seconds for rate expression - evaluationPeriods', asyn
 
   //@ts-ignore
   const data = await handler(event, c);
-  expect(data).toEqual({ Data: { intervalSeconds: 28800 } });
+  expect(data).toEqual({
+    Data: {
+      intervalSeconds: 28800,
+      scanWorkflowMinIntervalSeconds: 86400,
+    },
+  });
 });
 
 
@@ -120,7 +145,12 @@ test('should get interval seconds for rate expression - evaluationPeriods 2', as
 
   //@ts-ignore
   const data = await handler(event, c);
-  expect(data).toEqual({ Data: { intervalSeconds: 28800 } });
+  expect(data).toEqual({
+    Data: {
+      intervalSeconds: 28800,
+      scanWorkflowMinIntervalSeconds: 86400,
+    },
+  });
 });
 
 
@@ -135,7 +165,12 @@ test('should get interval seconds for rate expression - intervalSeconds must N *
 
   //@ts-ignore
   const data = await handler(event, c);
-  expect(data).toEqual({ Data: { intervalSeconds: 60 } });
+  expect(data).toEqual({
+    Data: {
+      intervalSeconds: 60,
+      scanWorkflowMinIntervalSeconds: 86400,
+    },
+  });
 });
 
 
@@ -150,7 +185,12 @@ test('should get interval seconds for rate expression - intervalSeconds must N *
 
   //@ts-ignore
   const data = await handler(event, c);
-  expect(data).toEqual({ Data: { intervalSeconds: 60 } });
+  expect(data).toEqual({
+    Data: {
+      intervalSeconds: 60,
+      scanWorkflowMinIntervalSeconds: 86400,
+    },
+  });
 });
 
 
@@ -165,7 +205,12 @@ test('should get interval seconds for rate expression - weeks', async () => {
 
   //@ts-ignore
   const data = await handler(event, c);
-  expect(data).toEqual({ Data: { intervalSeconds: 3600 * 24 } });
+  expect(data).toEqual({
+    Data: {
+      intervalSeconds: 3600 * 24,
+      scanWorkflowMinIntervalSeconds: 86400,
+    },
+  });
 });
 
 
@@ -180,7 +225,12 @@ test('should get interval seconds for rate expression - month', async () => {
 
   //@ts-ignore
   const data = await handler(event, c);
-  expect(data).toEqual({ Data: { intervalSeconds: 3600 * 24 } });
+  expect(data).toEqual({
+    Data: {
+      intervalSeconds: 3600 * 24,
+      scanWorkflowMinIntervalSeconds: 86400,
+    },
+  });
 });
 
 
@@ -195,7 +245,12 @@ test('should get interval seconds for cron expression', async () => {
 
   //@ts-ignore
   const data = await handler(event, c);
-  expect(data).toEqual({ Data: { intervalSeconds: 120 } });
+  expect(data).toEqual({
+    Data: {
+      intervalSeconds: 120,
+      scanWorkflowMinIntervalSeconds: 86400,
+    },
+  });
 });
 
 
@@ -210,7 +265,12 @@ test('should get interval seconds for cron expression 2', async () => {
 
   //@ts-ignore
   const data = await handler(event, c);
-  expect(data).toEqual({ Data: { intervalSeconds: 120 } });
+  expect(data).toEqual({
+    Data: {
+      intervalSeconds: 120,
+      scanWorkflowMinIntervalSeconds: 86400,
+    },
+  });
 });
 
 
@@ -225,7 +285,12 @@ test('should get interval seconds for cron expression 3', async () => {
 
   //@ts-ignore
   const data = await handler(event, c);
-  expect(data).toEqual({ Data: { intervalSeconds: 3600 } });
+  expect(data).toEqual({
+    Data: {
+      intervalSeconds: 3600,
+      scanWorkflowMinIntervalSeconds: 86400,
+    },
+  });
 });
 
 
@@ -240,7 +305,12 @@ test('should get interval seconds for cron expression 4', async () => {
 
   //@ts-ignore
   const data = await handler(event, c);
-  expect(data).toEqual({ Data: { intervalSeconds: 3600 } });
+  expect(data).toEqual({
+    Data: {
+      intervalSeconds: 3600,
+      scanWorkflowMinIntervalSeconds: 86400,
+    },
+  });
 });
 
 
@@ -255,7 +325,52 @@ test('should get interval seconds for cron expression 5', async () => {
 
   //@ts-ignore
   const data = await handler(event, c);
-  expect(data).toEqual({ Data: { intervalSeconds: 3600 * 24 } });
+  expect(data).toEqual({
+    Data: {
+      intervalSeconds: 3600 * 24,
+      scanWorkflowMinIntervalSeconds: 86400,
+    },
+  });
+});
+
+test('should get scanWorkflowMinIntervalSeconds as 1 day if scanWorkflowMinInterval is more than 1 day', async () => {
+  const event = {
+    ...commonEventProps,
+    ResourceProperties: {
+      ServiceToken: 'arn:aws:lambda:us-east-1:11111111111:function:testFn',
+      expression: 'cron (0 1 1 * ? * )',
+      scanWorkflowMinInterval: '5000', // minutes
+    },
+  };
+
+  //@ts-ignore
+  const data = await handler(event, c);
+  expect(data).toEqual({
+    Data: {
+      intervalSeconds: 3600 * 24,
+      scanWorkflowMinIntervalSeconds: 86400,
+    },
+  });
+});
+
+test('should get scanWorkflowMinIntervalSeconds from scanWorkflowMinInterval', async () => {
+  const event = {
+    ...commonEventProps,
+    ResourceProperties: {
+      ServiceToken: 'arn:aws:lambda:us-east-1:11111111111:function:testFn',
+      expression: 'cron (0 1 1 * ? * )',
+      scanWorkflowMinInterval: '1000', // minutes
+    },
+  };
+
+  //@ts-ignore
+  const data = await handler(event, c);
+  expect(data).toEqual({
+    Data: {
+      intervalSeconds: 3600 * 24,
+      scanWorkflowMinIntervalSeconds: 60000,
+    },
+  });
 });
 
 
@@ -308,5 +423,10 @@ test('should get interval seconds for expression update', async () => {
 
   //@ts-ignore
   const data = await handler(event, c);
-  expect(data).toEqual({ Data: { intervalSeconds: 120 } });
+  expect(data).toEqual({
+    Data: {
+      intervalSeconds: 120,
+      scanWorkflowMinIntervalSeconds: 86400,
+    },
+  });
 });


### PR DESCRIPTION
…r (#762)


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

set scan metadata data workflow alarm period with stack parameter

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend