### PR TITLE
fix: specify wrong bi user parameter for custom resource parameter

### DIFF
--- a/src/analytics/private/app-schema.ts
+++ b/src/analytics/private/app-schema.ts
@@ -165,17 +165,20 @@ export interface ApplicationSchemasAndReportingProps extends RedshiftSQLExecutio
 
 export class ApplicationSchemasAndReporting extends RedshiftSQLExecution {
 
-  readonly redshiftBIUserParameter: string;
   readonly redshiftBIUserName: string;
 
   constructor(scope: Construct, id: string, props: ApplicationSchemasAndReportingProps) {
     super(scope, id, props);
 
-    this.redshiftBIUserParameter = `/clickstream/reporting/user/${props.projectId}`;
     this.redshiftBIUserName = this.crForSQLExecution.getAttString(CUSTOM_RESOURCE_RESPONSE_REDSHIFT_BI_USER_NAME);
   }
 
+  public getRedshiftBIUserParameter(): string {
+    return `/clickstream/reporting/user/${(this.props as ApplicationSchemasAndReportingProps).projectId}`;
+  }
+
   protected additionalPolicies(): PolicyStatement[] {
+
     const writeSecretPolicy: PolicyStatement = new PolicyStatement({
       effect: Effect.ALLOW,
       resources: [
@@ -183,7 +186,7 @@ export class ApplicationSchemasAndReporting extends RedshiftSQLExecution {
           {
             resource: 'secret',
             service: 'secretsmanager',
-            resourceName: `${this.redshiftBIUserParameter}*`,
+            resourceName: `${this.getRedshiftBIUserParameter()}*`,
             arnFormat: ArnFormat.COLON_RESOURCE_NAME,
           }, Stack.of(this),
         ),
@@ -208,7 +211,7 @@ export class ApplicationSchemasAndReporting extends RedshiftSQLExecution {
       appIds: properties.appIds,
       odsTableNames: properties.odsTableNames,
       databaseName: properties.databaseName,
-      redshiftBIUserParameter: `${this.redshiftBIUserParameter}`,
+      redshiftBIUserParameter: this.getRedshiftBIUserParameter(),
       redshiftBIUsernamePrefix: 'clickstream_bi_',
       reportingViewsDef,
       schemaDefs,

--- a/src/data-analytics-redshift-stack.ts
+++ b/src/data-analytics-redshift-stack.ts
@@ -237,17 +237,17 @@ export function createRedshiftAnalyticsStack(
     condition: isNewRedshiftServerless,
   }).overrideLogicalId(OUTPUT_DATA_MODELING_REDSHIFT_SERVERLESS_NAMESPACE_NAME);
   new CfnOutput(scope, `NewRedshiftServerless${OUTPUT_DATA_MODELING_REDSHIFT_BI_USER_CREDENTIAL_PARAMETER_SUFFIX}`, {
-    value: newRedshiftServerlessStack.applicationSchema.redshiftBIUserParameter,
+    value: newRedshiftServerlessStack.applicationSchema.getRedshiftBIUserParameter(),
     description: 'Credential SSM parameter for BI user in Redshift',
     condition: isNewRedshiftServerless,
   }).overrideLogicalId(`NewRedshiftServerless${OUTPUT_DATA_MODELING_REDSHIFT_BI_USER_CREDENTIAL_PARAMETER_SUFFIX}`);
   new CfnOutput(scope, `ExistingRedshiftServerless${OUTPUT_DATA_MODELING_REDSHIFT_BI_USER_CREDENTIAL_PARAMETER_SUFFIX}`, {
-    value: redshiftExistingServerlessStack.applicationSchema.redshiftBIUserParameter,
+    value: redshiftExistingServerlessStack.applicationSchema.getRedshiftBIUserParameter(),
     description: 'Credential SSM parameter for BI user in Redshift',
     condition: isExistingRedshiftServerless,
   }).overrideLogicalId(`ExistingRedshiftServerless${OUTPUT_DATA_MODELING_REDSHIFT_BI_USER_CREDENTIAL_PARAMETER_SUFFIX}`);
   new CfnOutput(scope, `ProvisionedRedshift${OUTPUT_DATA_MODELING_REDSHIFT_BI_USER_CREDENTIAL_PARAMETER_SUFFIX}`, {
-    value: redshiftProvisionedStack.applicationSchema.redshiftBIUserParameter,
+    value: redshiftProvisionedStack.applicationSchema.getRedshiftBIUserParameter(),
     description: 'Credential SSM parameter for BI user in Redshift',
     condition: isRedshiftProvisioned,
   }).overrideLogicalId(`ProvisionedRedshift${OUTPUT_DATA_MODELING_REDSHIFT_BI_USER_CREDENTIAL_PARAMETER_SUFFIX}`);

--- a/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
+++ b/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
@@ -3777,35 +3777,47 @@ describe('DataAnalyticsRedshiftStack serverless custom resource test', () => {
   });
 
   test('redshiftServerlessStack has CreateApplicationSchemasRedshiftSchemasCustomResource', () => {
-    if (stack.nestedStacks.redshiftServerlessStack) {
-      const nestedTemplate = Template.fromStack(stack.nestedStacks.redshiftServerlessStack);
-      nestedTemplate.hasResourceProperties('AWS::CloudFormation::CustomResource', {
-        ServiceToken: {
-          'Fn::GetAtt': [
-            Match.anyValue(),
-            'Arn',
-          ],
-        },
-        projectId: RefAnyValue,
-        appIds: RefAnyValue,
-        odsTableNames: {
-          event: 'event',
-          event_parameter: 'event_parameter',
-          user: 'user',
-          item: 'item',
-        },
+    const nestedTemplate = Template.fromStack(stack.nestedStacks.redshiftServerlessStack);
+    nestedTemplate.hasResourceProperties('AWS::CloudFormation::CustomResource', {
+      ServiceToken: {
+        'Fn::GetAtt': [
+          Match.anyValue(),
+          'Arn',
+        ],
+      },
+      projectId: RefAnyValue,
+      appIds: RefAnyValue,
+      odsTableNames: {
+        event: 'event',
+        event_parameter: 'event_parameter',
+        user: 'user',
+        item: 'item',
+      },
+      databaseName: RefAnyValue,
+      dataAPIRole: RefAnyValue,
+      lastModifiedTime: Match.anyValue(),
+      serverlessRedshiftProps: {
         databaseName: RefAnyValue,
-        dataAPIRole: RefAnyValue,
-        lastModifiedTime: Match.anyValue(),
-        serverlessRedshiftProps: {
-          databaseName: RefAnyValue,
-          namespaceId: RefAnyValue,
-          workgroupName: RefAnyValue,
-          workgroupId: RefAnyValue,
-          dataAPIRoleArn: RefAnyValue,
-        },
-      });
-    }
+        namespaceId: RefAnyValue,
+        workgroupName: RefAnyValue,
+        workgroupId: RefAnyValue,
+        dataAPIRoleArn: RefAnyValue,
+      },
+      redshiftBIUserParameter: {
+        'Fn::Join': [
+          '',
+          [
+            '/clickstream/reporting/user/',
+            {
+              Ref: Match.anyValue(),
+            },
+          ],
+        ],
+      },
+      redshiftBIUsernamePrefix: 'clickstream_bi_',
+      reportingViewsDef: Match.not(Match.absent()),
+      schemaDefs: Match.not(Match.absent()),
+    });
   });
 
   test('Should has lambda CreateApplicationSchemasCreateSchemaForApplicationsFn', () => {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend