### PR TITLE
fix: upgrade pipeline failed because create topic and rule 

### DIFF
--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -17,7 +17,7 @@ import { ExecutionStatus } from '@aws-sdk/client-sfn';
 import { ipv4 as ip } from 'cidr-block';
 import { JSONPath } from 'jsonpath-plus';
 import jwt, { JwtPayload } from 'jsonwebtoken';
-import { amznRequestContextHeader } from './constants';
+import { FULL_SOLUTION_VERSION, amznRequestContextHeader } from './constants';
 import {
   ALBLogServiceAccountMapping,
   CORS_ORIGIN_DOMAIN_PATTERN,
@@ -1116,6 +1116,10 @@ function getDefaultTags(projectId: string) {
     {
       Key: BuiltInTagKeys.AWS_SOLUTION,
       Value: SolutionInfo.SOLUTION_SHORT_NAME,
+    },
+    {
+      Key: BuiltInTagKeys.AWS_SOLUTION_VERSION,
+      Value: FULL_SOLUTION_VERSION,
     },
     {
       Key: BuiltInTagKeys.CLICKSTREAM_PROJECT,

--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -17,7 +17,7 @@ import { ExecutionStatus } from '@aws-sdk/client-sfn';
 import { ipv4 as ip } from 'cidr-block';
 import { JSONPath } from 'jsonpath-plus';
 import jwt, { JwtPayload } from 'jsonwebtoken';
-import { FULL_SOLUTION_VERSION, amznRequestContextHeader } from './constants';
+import { amznRequestContextHeader } from './constants';
 import {
   ALBLogServiceAccountMapping,
   CORS_ORIGIN_DOMAIN_PATTERN,
@@ -1116,10 +1116,6 @@ function getDefaultTags(projectId: string) {
     {
       Key: BuiltInTagKeys.AWS_SOLUTION,
       Value: SolutionInfo.SOLUTION_SHORT_NAME,
-    },
-    {
-      Key: BuiltInTagKeys.AWS_SOLUTION_VERSION,
-      Value: FULL_SOLUTION_VERSION,
     },
     {
       Key: BuiltInTagKeys.CLICKSTREAM_PROJECT,

--- a/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-import { DeleteRuleCommand, ListTargetsByRuleCommand, PutRuleCommand, PutTargetsCommand, RemoveTargetsCommand } from '@aws-sdk/client-cloudwatch-events';
+import { DeleteRuleCommand, ListTargetsByRuleCommand, PutRuleCommand, PutTargetsCommand, RemoveTargetsCommand, TagResourceCommand as EventTagResourceCommand } from '@aws-sdk/client-cloudwatch-events';
 import { ConditionalCheckFailedException, TransactWriteItemsCommand } from '@aws-sdk/client-dynamodb';
 import {
   ConnectivityType,
@@ -30,7 +30,7 @@ import { GetNamespaceCommand, GetWorkgroupCommand } from '@aws-sdk/client-redshi
 import { BucketLocationConstraint, GetBucketLocationCommand, GetBucketPolicyCommand } from '@aws-sdk/client-s3';
 import { GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
 import { StartExecutionCommand } from '@aws-sdk/client-sfn';
-import { CreateTopicCommand, SetTopicAttributesCommand, SubscribeCommand } from '@aws-sdk/client-sns';
+import { CreateTopicCommand, SetTopicAttributesCommand, SubscribeCommand, TagResourceCommand as SNSTagResourceCommand } from '@aws-sdk/client-sns';
 import { DynamoDBDocumentClient, GetCommand, GetCommandInput, PutCommand, PutCommandOutput, QueryCommand, QueryCommandInput } from '@aws-sdk/lib-dynamodb';
 import { AwsClientStub } from 'aws-sdk-client-mock';
 import { analyticsMetadataTable, clickStreamTableName, dictionaryTableName, prefixTimeGSIName } from '../../common/constants';
@@ -941,6 +941,7 @@ function createEventRuleMock(cloudWatchEventsMock: any): any {
   cloudWatchEventsMock.on(PutRuleCommand).resolves({
     RuleArn: 'arn:aws:events:ap-southeast-1:111122223333:rule/ck-clickstream-branch-main',
   });
+  cloudWatchEventsMock.on(EventTagResourceCommand).resolves({});
   cloudWatchEventsMock.on(PutTargetsCommand).resolves({});
 }
 
@@ -959,6 +960,7 @@ function createSNSTopicMock(snsMock: any): any {
   snsMock.on(CreateTopicCommand).resolves({
     TopicArn: 'arn:aws:sns:ap-southeast-1:111122223333:ck-clickstream-branch-main',
   });
+  snsMock.on(SNSTagResourceCommand).resolves({});
   snsMock.on(SetTopicAttributesCommand).resolves({});
   snsMock.on(SubscribeCommand).resolves({});
 }

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { DescribeStacksCommand, CloudFormationClient, StackStatus } from '@aws-sdk/client-cloudformation';
-import { CloudWatchEventsClient, PutRuleCommand } from '@aws-sdk/client-cloudwatch-events';
+import { CloudWatchEventsClient, PutRuleCommand, TagResourceCommand as EventTagResourceCommand } from '@aws-sdk/client-cloudwatch-events';
 import { TransactWriteItemsCommand } from '@aws-sdk/client-dynamodb';
 import {
   EC2Client,
@@ -43,7 +43,7 @@ import {
 
 import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 import { DescribeExecutionCommand, ExecutionStatus, SFNClient, StartExecutionCommand } from '@aws-sdk/client-sfn';
-import { CreateTopicCommand, SNSClient } from '@aws-sdk/client-sns';
+import { CreateTopicCommand, SNSClient, TagResourceCommand as SNSTagResourceCommand } from '@aws-sdk/client-sns';
 import { DynamoDBDocumentClient, GetCommand, PutCommand, QueryCommand, ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import { mockClient } from 'aws-sdk-client-mock';
 import request from 'supertest';
@@ -85,9 +85,9 @@ import {
 import { FULL_SOLUTION_VERSION, clickStreamTableName, dictionaryTableName, prefixTimeGSIName } from '../../common/constants';
 import { BuiltInTagKeys, PipelineStatusType } from '../../common/model-ln';
 import { PipelineServerProtocol } from '../../common/types';
+import { getDefaultTags } from '../../common/utils';
 import { app, server } from '../../index';
 import 'aws-sdk-client-mock-jest';
-import { getDefaultTags } from '../../common/utils';
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 const sfnMock = mockClient(SFNClient);
@@ -3185,14 +3185,22 @@ describe('Pipeline test', () => {
       message: 'Pipeline upgraded.',
     });
     expect(snsMock).toHaveReceivedCommandTimes(CreateTopicCommand, 1);
+    expect(snsMock).toHaveReceivedCommandTimes(SNSTagResourceCommand, 1);
     expect(cloudWatchEventsMock).toHaveReceivedCommandTimes(PutRuleCommand, 1);
+    expect(cloudWatchEventsMock).toHaveReceivedCommandTimes(EventTagResourceCommand, 1);
     expect(snsMock).toHaveReceivedCommandWith(CreateTopicCommand, {
       Name: `ClickstreamTopicForCFN-${MOCK_PIPELINE_ID}`,
+    });
+    expect(snsMock).toHaveReceivedCommandWith(SNSTagResourceCommand, {
+      ResourceArn: 'arn:aws:sns:ap-southeast-1:111122223333:ck-clickstream-branch-main',
       Tags: getDefaultTags(MOCK_PROJECT_ID),
     });
     expect(cloudWatchEventsMock).toHaveReceivedCommandWith(PutRuleCommand, {
       Name: `ClickstreamRuleForCFN-${MOCK_PROJECT_ID}`,
       EventPattern: '{"source":["aws.cloudformation"],"resources":[{"wildcard":"arn:undefined:cloudformation:ap-southeast-1:555555555555:stack/Clickstream*6666-6666/*"}],"detail-type":["CloudFormation Stack Status Change"]}',
+    });
+    expect(cloudWatchEventsMock).toHaveReceivedCommandWith(EventTagResourceCommand, {
+      ResourceARN: 'arn:aws:events:ap-southeast-1:111122223333:rule/ck-clickstream-branch-main',
       Tags: getDefaultTags(MOCK_PROJECT_ID),
     });
   });


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

When creating duplicate resources with the same name, they cannot have different tags.

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend