### PR TITLE
fix: datasource is not appearing on the Console Analyzes UI

### DIFF
--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -276,7 +276,7 @@ const createQuickSightDashboard = async (quickSight: QuickSight,
     schema,
   };
 
-  await grantDataSourcePermission(quickSight, dashboardDef.dataSourceArn, commonParams.awsAccountId, ownerPrincipalArn);
+  await grantDataSourcePermission(quickSight, dashboardDef.dataSourceArn, commonParams.awsAccountId, ownerPrincipalArn, sharePrincipalArn);
 
   for ( const dataSet of dataSets) {
     const createdDataset = await createDataSet(quickSight, commonParams, dashboardDef.dataSourceArn, dataSet);
@@ -376,7 +376,7 @@ const updateQuickSightDashboard = async (quickSight: QuickSight,
     schema,
   };
 
-  await grantDataSourcePermission(quickSight, dashboardDef.dataSourceArn, commonParams.awsAccountId, ownerPrincipalArn);
+  await grantDataSourcePermission(quickSight, dashboardDef.dataSourceArn, commonParams.awsAccountId, ownerPrincipalArn, sharePrincipalArn);
 
   const oldDataSetTableNames: string[] = [];
   const dataSetTableNames: string[] = [];
@@ -1003,7 +1003,8 @@ const updateDashboard = async (quickSight: QuickSight, commonParams: ResourceCom
   }
 };
 
-const grantDataSourcePermission = async (quickSight: QuickSight, dataSourceArn: string, awsAccountId: string, ownerPrincipalArn: string) => {
+const grantDataSourcePermission = async (quickSight: QuickSight, dataSourceArn: string, awsAccountId: string,
+  ownerPrincipalArn: string, sharePrincipalArn: string) => {
   const arnSplits = dataSourceArn.split('/');
   const dataSourceId = arnSplits[arnSplits.length - 1];
   await waitForDataSourceChangeCompleted(quickSight, awsAccountId, dataSourceId);
@@ -1013,6 +1014,17 @@ const grantDataSourcePermission = async (quickSight: QuickSight, dataSourceArn: 
     GrantPermissions: [
       {
         Principal: ownerPrincipalArn,
+        Actions: [
+          'quicksight:UpdateDataSourcePermissions',
+          'quicksight:DescribeDataSourcePermissions',
+          'quicksight:PassDataSource',
+          'quicksight:DescribeDataSource',
+          'quicksight:DeleteDataSource',
+          'quicksight:UpdateDataSource',
+        ],
+      },
+      {
+        Principal: sharePrincipalArn,
         Actions: [
           'quicksight:UpdateDataSourcePermissions',
           'quicksight:DescribeDataSourcePermissions',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

pick #801 to v1.1.2

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend