### PR TITLE
fix: enable scan metadata alarm actions

### DIFF
--- a/src/analytics/private/metrics-common-workflow.ts
+++ b/src/analytics/private/metrics-common-workflow.ts
@@ -112,6 +112,7 @@ export function buildMetricsWidgetForWorkflows(scope: Construct, id: string, pro
         alarms: [
           loadDataWorkflowAlarm.alarmArn,
           newFilesCountAlarm.alarmArn,
+          scanMetadataWorkflowAlarm.alarmArn,
         ],
         title: 'Data Modeling Alarms',
       },

--- a/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
+++ b/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
@@ -3185,7 +3185,19 @@ describe('Should set metrics widgets', () => {
         description: {
           markdown: Match.anyValue(),
         },
-        widgets: Match.anyValue(),
+        widgets: Match.arrayWith([
+          Match.objectLike({
+            type: 'alarm',
+            properties: {
+              alarms: Match.arrayWith([
+                Match.objectLike({ 'Fn::GetAtt': Match.anyValue() }),
+                Match.objectLike({ 'Fn::GetAtt': Match.anyValue() }),
+                Match.objectLike({ 'Fn::GetAtt': Match.anyValue() }),
+              ]),
+              title: Match.anyValue(),
+            },
+          }),
+        ]),
       },
     });
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

enable scan metadata alarm actions

## Implementation highlights

enable scan metadata alarm actions

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend