### PR TITLE
fix: update pipeline status with optimistic locking

### DIFF
--- a/src/control-plane/backend/lambda/listen-stack-status/index.ts
+++ b/src/control-plane/backend/lambda/listen-stack-status/index.ts
@@ -46,5 +46,5 @@ export const handler = async (event: SQSEvent): Promise<void> => {
   const projectId = pipeline.projectId;
   const stackNames = getWorkflowStacks(pipeline.workflow.Workflow);
   const newStackDetails = getNewStackDetails(stackDetail, pipeline.stackDetails ?? [], stackNames);
-  await updatePipelineStackStatus(projectId, pipelineId, newStackDetails);
+  await updatePipelineStackStatus(projectId, pipelineId, newStackDetails, pipeline.updateAt);
 };

--- a/src/control-plane/backend/lambda/listen-state-status/index.ts
+++ b/src/control-plane/backend/lambda/listen-state-status/index.ts
@@ -36,7 +36,7 @@ export const handler = async (
 
   const projectId = pipeline.projectId;
 
-  await updatePipelineStateStatus(projectId, pipelineId, eventDetail);
+  await updatePipelineStateStatus(projectId, pipelineId, eventDetail, pipeline.updateAt);
 
   if (eventDetail.status === ExecutionStatus.SUCCEEDED && pipeline.lastAction === 'Delete') {
     const ruleName = `${CFN_RULE_PREFIX}-${projectId}`;


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend