### PR TITLE
fix: update pipeline when QuickSight already existed

### DIFF
--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -359,7 +359,6 @@ export class CPipeline {
       status: ExecutionStatus.RUNNING,
     };
     this.pipeline.statusType = PipelineStatusType.UPDATING;
-    this.pipeline.tags = oldPipeline.tags;
     this.pipeline.workflow = this.stackManager.getWorkflow();
     await store.updatePipeline(this.pipeline, oldPipeline);
   }
@@ -469,7 +468,7 @@ export class CPipeline {
   private async _forceRefreshStatus(): Promise<void> {
     let executionDetail;
     if (this.pipeline.executionDetail?.executionArn) {
-      executionDetail = await getExecutionDetail(awsRegion!, this.pipeline.executionDetail?.executionArn);
+      executionDetail = await getExecutionDetail(awsRegion, this.pipeline.executionDetail?.executionArn);
       if (executionDetail) {
         this.pipeline.executionDetail = {
           executionArn: executionDetail.executionArn ?? '',

--- a/src/control-plane/backend/lambda/api/service/stack.ts
+++ b/src/control-plane/backend/lambda/api/service/stack.ts
@@ -182,7 +182,7 @@ export class StackManager {
     if (workflow === undefined) {
       throw new Error('Pipeline workflow is empty.');
     }
-    const executionArn = await startExecution(awsRegion!, stackWorkflowStateMachineArn!, executionName, JSON.stringify(workflow.Workflow));
+    const executionArn = await startExecution(awsRegion, stackWorkflowStateMachineArn!, executionName, JSON.stringify(workflow.Workflow));
     return executionArn ?? '';
   }
 

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -2681,6 +2681,91 @@ describe('Pipeline test', () => {
       error: 'Error',
     });
   });
+  it('Update pipeline when QuickSight user already existed', async () => {
+    tokenMock(ddbMock, false);
+    projectExistedMock(ddbMock, true);
+    dictionaryMock(ddbMock);
+    createPipelineMock(mockClients, {
+      publicAZContainPrivateAZ: true,
+      subnetsCross3AZ: true,
+      subnetsIsolated: true,
+      update: true,
+      quickSightUserExisted: true,
+      updatePipeline: {
+        ...MSK_DATA_PROCESSING_NEW_SERVERLESS_PIPELINE_WITH_WORKFLOW,
+      },
+    });
+    cloudFormationMock.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackName: 'xxx',
+          Outputs: [
+            {
+              OutputKey: 'IngestionServerC000IngestionServerURL',
+              OutputValue: 'http://xxx/xxx',
+            },
+            {
+              OutputKey: 'IngestionServerC000IngestionServerDNS',
+              OutputValue: 'yyy/yyy',
+            },
+            {
+              OutputKey: 'Dashboards',
+              OutputValue: '[{"appId":"app1","dashboardId":"clickstream_dashboard_v1_notepad_mtzfsocy_app1"},{"appId":"app2","dashboardId":"clickstream_dashboard_v1_notepad_mtzfsocy_app2"}]',
+            },
+            {
+              OutputKey: 'ObservabilityDashboardName',
+              OutputValue: 'clickstream_dashboard_notepad_mtzfsocy',
+            },
+          ],
+          StackStatus: StackStatus.CREATE_COMPLETE,
+          CreationTime: new Date(),
+        },
+      ],
+    });
+
+    ddbMock.on(TransactWriteItemsCommand).resolves({});
+    let res = await request(app)
+      .put(`/api/pipeline/${MOCK_PIPELINE_ID}`)
+      .send({
+        ...MSK_DATA_PROCESSING_NEW_SERVERLESS_PIPELINE_WITH_WORKFLOW,
+        ingestionServer: {
+          ...MSK_DATA_PROCESSING_NEW_SERVERLESS_PIPELINE_WITH_WORKFLOW.ingestionServer,
+          loadBalancer: {
+            ...MSK_DATA_PROCESSING_NEW_SERVERLESS_PIPELINE_WITH_WORKFLOW.ingestionServer.loadBalancer,
+            protocol: PipelineServerProtocol.HTTP,
+            enableApplicationLoadBalancerAccessLog: false,
+            notificationsTopicArn: 'arn:aws:sns:us-east-1:111122223333:test-modify',
+            enableGlobalAccelerator: false,
+            serverCorsOrigin: '*',
+            serverEndpointPath: '/collect-modify',
+          },
+        },
+      });
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 6);
+    expect(ddbMock).toHaveReceivedCommandTimes(TransactWriteItemsCommand, 1);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toEqual({
+      data: {
+        id: MOCK_PIPELINE_ID,
+      },
+      success: true,
+      message: 'Pipeline updated.',
+    });
+
+    // Mock DynamoDB error
+    ddbMock.on(TransactWriteItemsCommand).rejects(new Error('Mock DynamoDB error'));
+    res = await request(app)
+      .put(`/api/pipeline/${MOCK_PIPELINE_ID}`)
+      .send({ ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Unexpected error occurred at server.',
+      error: 'Error',
+    });
+  });
   it('Update pipeline not change pipeline version', async () => {
     tokenMock(ddbMock, false);
     projectExistedMock(ddbMock, true);


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend