### PR TITLE
fix: dictionary data not updated when Custom Resource parameters unchanged

### DIFF
--- a/src/control-plane/backend/batch-insert-ddb-custom-resource-construct.ts
+++ b/src/control-plane/backend/batch-insert-ddb-custom-resource-construct.ts
@@ -39,7 +39,6 @@ export class BatchInsertDDBCustomResource extends Construct {
       handler: 'handler',
       timeout: Duration.seconds(30),
       memorySize: 256,
-      reservedConcurrentExecutions: 1,
       role: createLambdaRole(this, 'DicInitCustomResourceRole', false, []),
     });
 
@@ -68,6 +67,7 @@ export class BatchInsertDDBCustomResource extends Construct {
         serviceToken: customResourceProvider.serviceToken,
         properties: {
           tableName: props.table.tableName,
+          lastModifiedTime: new Date().toISOString(),
         },
       },
     );

--- a/src/control-plane/backend/batch-insert-ddb-custom-resource-construct.ts
+++ b/src/control-plane/backend/batch-insert-ddb-custom-resource-construct.ts
@@ -11,7 +11,9 @@
  *  and limitations under the License.
  */
 
-import path from 'path';
+
+import { statSync } from 'fs';
+import { join, resolve } from 'path';
 import { Duration, CustomResource, Stack } from 'aws-cdk-lib';
 import { Table } from 'aws-cdk-lib/aws-dynamodb';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
@@ -35,7 +37,7 @@ export class BatchInsertDDBCustomResource extends Construct {
 
     const customResourceLambda = new SolutionNodejsFunction(this, 'DicInitCustomResourceFunction', {
       description: 'Lambda function for dictionary init of solution Click Stream Analytics on AWS',
-      entry: path.join(__dirname, './lambda/batch-insert-ddb/index.ts'),
+      entry: join(__dirname, './lambda/batch-insert-ddb/index.ts'),
       handler: 'handler',
       timeout: Duration.seconds(30),
       memorySize: 256,
@@ -67,10 +69,20 @@ export class BatchInsertDDBCustomResource extends Construct {
         serviceToken: customResourceProvider.serviceToken,
         properties: {
           tableName: props.table.tableName,
-          lastModifiedTime: new Date().toISOString(),
+          lastModifiedTime: this.getLatestTimestampFromDictionary(),
         },
       },
     );
+  }
+
+  private getLatestTimestampFromDictionary(): number {
+    let latestTimestamp = 0;
+    const filePath = resolve(__dirname, 'lambda/api/config/dictionary.json');
+    const stats = statSync(filePath);
+    if (stats.isFile()) {
+      latestTimestamp = Math.max(stats.mtime.getTime(), latestTimestamp);
+    }
+    return latestTimestamp;
   }
 
 }

--- a/test/control-plane/lambda/batch-insert-ddb.test.ts
+++ b/test/control-plane/lambda/batch-insert-ddb.test.ts
@@ -37,6 +37,7 @@ describe('Dictionary Data', () => {
     ResourceProperties: {
       ...basicCloudFormationEvent.ResourceProperties,
       tableName: 'Dictionary',
+      lastModifiedTime: '2021-01-01T00:00:00.000Z',
     },
   };
 
@@ -52,6 +53,7 @@ describe('Dictionary Data', () => {
     OldResourceProperties: createDictionaryEvent.ResourceProperties,
     ResourceProperties: {
       ...createDictionaryEvent.ResourceProperties,
+      lastModifiedTime: '2021-01-02T00:00:00.000Z',
     },
     PhysicalResourceId: 'physical-resource-id',
     RequestType: 'Update',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend