### PR TITLE
fix: scan metadata when status is undefined

### DIFF
--- a/src/control-plane/backend/lambda/api/service/metadata.ts
+++ b/src/control-plane/backend/lambda/api/service/metadata.ts
@@ -132,7 +132,7 @@ export class MetadataEventServ {
         return res.status(404).json(new ApiFail('Pipeline not found'));
       }
       const scanMetadataWorkflowArn = getStackOutputFromPipelineStatus(
-        pipeline.status?.stackDetails,
+        pipeline.stackDetails ?? pipeline.status?.stackDetails,
         PipelineStackType.DATA_MODELING_REDSHIFT,
         OUTPUT_SCAN_METADATA_WORKFLOW_ARN_SUFFIX,
       );


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend