### PR TITLE
fix: can' t delete app when QuickSight folder contains customer resources

### DIFF
--- a/test/reporting/quicksight/lambda/quicksight-resource.test.ts
+++ b/test/reporting/quicksight/lambda/quicksight-resource.test.ts
@@ -2474,7 +2474,7 @@ describe('QuickSight Lambda function', () => {
   });
 
 
-  test('Delete QuickSight dashboard - folder', async () => {
+  test('Delete QuickSight dashboard - folder contains custom resources', async () => {
 
     quickSightClientMock.on(DescribeDataSetCommand).rejects(notExistError);
     quickSightClientMock.on(DeleteDataSetCommand).resolves({});


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend