### PR TITLE
fix: add IngestionServerStackV2 into main

### DIFF
--- a/src/ingestion-server/server/private/cfn-nag.ts
+++ b/src/ingestion-server/server/private/cfn-nag.ts
@@ -21,6 +21,7 @@ const cfnNagList = [
       'IngestionServer/clickstream-ingestion-service-ecs-asg/InstanceRole/DefaultPolicy/Resource',
       'IngestionServer/clickstream-ingestion-service-ecs-asg/DrainECSHook/Function/ServiceRole/DefaultPolicy/Resource',
       'IngestionServer/clickstream-ingestion-service-ecs-task-def/ExecutionRole/DefaultPolicy/Resource',
+      'IngestionServer/ECSFargateCluster/ecs-fargate-service/clickstream-ingestion-service-ecs-fargate-task-def/ExecutionRole/DefaultPolicy/Resource',
     ],
     rules_to_suppress: [
       ruleToSuppressRolePolicyWithWildcardResources('CDK built-in Lambda', ''),

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import { DataModelingAthenaStack } from './data-modeling-athena-stack';
 import { DataPipelineStack } from './data-pipeline-stack';
 import { DataReportingQuickSightStack } from './data-reporting-quicksight-stack';
 import { IngestionServerStack } from './ingestion-server-stack';
+import { IngestionServerStackV2 } from './ingestion-server-v2-stack';
 import { KafkaS3SinkConnectorStack } from './kafka-s3-connector-stack';
 import { MetricsStack } from './metrics-stack';
 import { SolutionNodejsFunction } from './private/function';
@@ -150,6 +151,11 @@ stackSuppressions([
     deliverToKinesis: false,
     deliverToS3: true,
   }),
+
+  // for Ingestion V2
+  new IngestionServerStackV2(app, 'ingestion-server-v2-stack', { //To Ingestion V2
+    synthesizer: synthesizer(),
+  }),  
 ], [
   ...commonCdkNagRules,
   {

--- a/src/main.ts
+++ b/src/main.ts
@@ -155,7 +155,7 @@ stackSuppressions([
   // for Ingestion V2
   new IngestionServerStackV2(app, 'ingestion-server-v2-stack', { //To Ingestion V2
     synthesizer: synthesizer(),
-  }),  
+  }),
 ], [
   ...commonCdkNagRules,
   {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Add IngestionServerStackV2 into main.ts file

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend