### PR TITLE
fix: do not create QuickSight user in China region

### DIFF
--- a/src/control-plane/backend/lambda/api/common/stack-params-valid.ts
+++ b/src/control-plane/backend/lambda/api/common/stack-params-valid.ts
@@ -86,7 +86,6 @@ export const validatePipelineNetwork = async (pipeline: IPipeline, resources: CP
 
   await _checkForDataModelingAndReporting(pipeline, allSubnets, resources);
 
-  console.log(pipeline.ingestionServer.loadBalancer);
   if (pipeline.ingestionServer.loadBalancer.enableApplicationLoadBalancerAccessLog) {
     const enableAccessLogs = await validateEnableAccessLogsForALB(pipeline.region, pipeline.bucket.name);
     if (!enableAccessLogs) {

--- a/src/control-plane/backend/lambda/api/common/stack-params-valid.ts
+++ b/src/control-plane/backend/lambda/api/common/stack-params-valid.ts
@@ -86,6 +86,7 @@ export const validatePipelineNetwork = async (pipeline: IPipeline, resources: CP
 
   await _checkForDataModelingAndReporting(pipeline, allSubnets, resources);
 
+  console.log(pipeline.ingestionServer.loadBalancer);
   if (pipeline.ingestionServer.loadBalancer.enableApplicationLoadBalancerAccessLog) {
     const enableAccessLogs = await validateEnableAccessLogsForALB(pipeline.region, pipeline.bucket.name);
     if (!enableAccessLogs) {

--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -487,7 +487,7 @@ export class CPipeline {
         this.pipeline.ingestionServer.loadBalancer.authenticationSecretArn, SECRETS_MANAGER_ARN_PATTERN);
     }
 
-    if (this.pipeline.reporting) {
+    if (this.pipeline.reporting?.quickSight?.accountName && !this.pipeline.region.startsWith('cn')) {
       const quickSightUser = await registerClickstreamUser();
       this.resources = {
         ...this.resources,


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend