### PR TITLE
chore: don't sink OPTIONS request in ingestion server

### DIFF
--- a/src/ingestion-server/server/images/nginx/config/nginx.conf
+++ b/src/ingestion-server/server/images/nginx/config/nginx.conf
@@ -33,6 +33,9 @@ http {
         server_name  _;
 
         include /etc/nginx/default.d/*.conf;
+
+        set $cosrCondition 0;
+        set $corsOptions 0;
       
         location %%SERVER_ENDPOINT_PATH%% {
             access_log off;
@@ -45,7 +48,21 @@ http {
                 add_header 'Access-Control-Allow-Credentials' 'true';
                 add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
                 add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+                set $cosrCondition 1;
             }
+
+            if ($request_method = OPTIONS) {
+                set $corsOptions "${cosrCondition}1";
+            }
+
+            if ($corsOptions = 11) {
+                add_header 'Access-Control-Allow-Origin' "$http_origin";
+                add_header 'Access-Control-Allow-Credentials' 'true';
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+                add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+                return 204;
+            }
+
             add_header 'X-Request-ID' $request_id;
 
             proxy_set_header 'X_Uri'                   $request_uri;
@@ -55,7 +72,7 @@ http {
             proxy_set_header 'X_Request_ID'            $request_id;
             proxy_set_header 'X_Method'                $request_method;
             
-            proxy_pass http://127.0.0.1:8685;   
+            proxy_pass http://127.0.0.1:8685;
         }
 
         location = /health {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

drop OPTIONS request in ingestion server

## Implementation highlights

drop OPTIONS request in ingestion server

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [x] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [x] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend