### PR TITLE
fix: make ETL compatible with Java 8

### DIFF
--- a/src/data-pipeline/spark-etl/build.gradle
+++ b/src/data-pipeline/spark-etl/build.gradle
@@ -75,7 +75,6 @@ var sparkJavaCompatibleJvmArgs = [
 ]
 
 tasks.named('test') {
-    jvmArgs += sparkJavaCompatibleJvmArgs
     useJUnitPlatform()
 }
 

--- a/src/data-pipeline/spark-etl/src/main/java/software/aws/solution/clickstream/MaxLengthTransformer.java
+++ b/src/data-pipeline/spark-etl/src/main/java/software/aws/solution/clickstream/MaxLengthTransformer.java
@@ -121,7 +121,7 @@ public class MaxLengthTransformer {
     }
 
     public static Dataset<Row> runMaxLengthTransformerForItem(final Dataset<Row> newItemsDataset1) {
-        Dataset<Row> newItemsDataset2 = new MaxLengthTransformer().transform(newItemsDataset1, List.of(ID), MAX_STRING_VALUE_LEN);
+        Dataset<Row> newItemsDataset2 = new MaxLengthTransformer().transform(newItemsDataset1, Arrays.asList(ID), MAX_STRING_VALUE_LEN);
         Dataset<Row> newItemsDataset3 = newItemsDataset2.select(
                 APP_ID,
                 EVENT_DATE,
@@ -179,8 +179,8 @@ public class MaxLengthTransformer {
 
     public static Dataset<Row> runMaxLengthTransformerForEventParameter(final Dataset<Row> dataset3) {
         MaxLengthTransformer maxLengthTransformer = new MaxLengthTransformer();
-        Dataset<Row> dataset4 = maxLengthTransformer.transform(dataset3, List.of(EVENT_ID, EVENT_NAME, EVENT_PARAM_KEY), MAX_STRING_VALUE_LEN);
-        Dataset<Row> dataset5 = maxLengthTransformer.transform(dataset4, List.of(EVENT_PARAM_STRING_VALUE), MAX_PARAM_STRING_VALUE_LEN);
+        Dataset<Row> dataset4 = maxLengthTransformer.transform(dataset3, Arrays.asList(EVENT_ID, EVENT_NAME, EVENT_PARAM_KEY), MAX_STRING_VALUE_LEN);
+        Dataset<Row> dataset5 = maxLengthTransformer.transform(dataset4, Arrays.asList(EVENT_PARAM_STRING_VALUE), MAX_PARAM_STRING_VALUE_LEN);
 
         Dataset<Row> eventPrameterTruncatedDataset = dataset5.filter(
                         col(EVENT_PARAM_KEY + TRUNCATED).equalTo(true)
@@ -203,7 +203,7 @@ public class MaxLengthTransformer {
     public static Dataset<Row> runMaxLengthTransformerForEvent(final Dataset<Row> datasetFinal2) {
         MaxLengthTransformer maxLengthTransformer = new MaxLengthTransformer();
         Dataset<Row> datasetFinal3 = maxLengthTransformer.transform(datasetFinal2,
-                List.of(EVENT_ID, EVENT_NAME, USER_PSEUDO_ID, USER_ID, PLATFORM),
+                Arrays.asList(EVENT_ID, EVENT_NAME, USER_PSEUDO_ID, USER_ID, PLATFORM),
                 MAX_STRING_VALUE_LEN);
 
         Dataset<Row> eventTruncatedDataset = datasetFinal3.filter(

--- a/src/data-pipeline/spark-etl/src/main/java/software/aws/solution/clickstream/gtm/ServerDataConverter.java
+++ b/src/data-pipeline/spark-etl/src/main/java/software/aws/solution/clickstream/gtm/ServerDataConverter.java
@@ -761,7 +761,7 @@ public class ServerDataConverter {
     public static String deCodeUri(final String uri) {
         String result = "";
         try {
-            result = URLDecoder.decode(uri, StandardCharsets.UTF_8);
+            result = URLDecoder.decode(uri, StandardCharsets.UTF_8.toString());
         } catch (Exception e) {
             log.warn(e.getMessage() + ", uri:" + uri);
         }

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/MaxLengthTransformerTest.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/MaxLengthTransformerTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
-import java.util.List;
+import java.util.*;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.spark.sql.functions.col;
@@ -42,7 +42,7 @@ public class MaxLengthTransformerTest extends BaseSparkTest {
 
         MaxLengthTransformer maxLengthTransformer = new MaxLengthTransformer();
 
-        Dataset<Row> dataset1 = maxLengthTransformer.transform(dataset, List.of( "name", "address"), 10);
+        Dataset<Row> dataset1 = maxLengthTransformer.transform(dataset, Arrays.asList("name", "address"), 10);
 
         Assertions.assertEquals("{\"address\":\"北京市\",\"age\":18,\"name\":\"刘先生\",\"phone\":\"13888888888\",\"sex\":\"M\",\"name_truncated\":false,\"address_truncated\":true}",
                 dataset1.filter(col("name").equalTo("刘先生")).first().json());


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend