### PR TITLE
chore: remove QuickSight explore user

### DIFF
--- a/frontend/src/pages/analytics/analyzes/AnalyticsAnalyzes.tsx
+++ b/frontend/src/pages/analytics/analyzes/AnalyticsAnalyzes.tsx
@@ -18,7 +18,7 @@ import {
   Header,
   SpaceBetween,
 } from '@cloudscape-design/components';
-import { embedAnalyzesUrl, getPipelineDetailByProjectId } from 'apis/analytics';
+import { clean, embedAnalyzesUrl, getPipelineDetailByProjectId } from 'apis/analytics';
 import InfoLink from 'components/common/InfoLink';
 import Loading from 'components/common/Loading';
 import AnalyticsNavigation from 'components/layouts/AnalyticsNavigation';
@@ -62,7 +62,10 @@ const AnalyticsAnalyzes: React.FC = () => {
       const { success, data }: ApiResponse<IPipeline> =
         await getPipelineDetailByProjectId(defaultStr(projectId));
       if (success && data.analysisStudioEnabled) {
-        await getAnalyzes();
+        await Promise.all([
+          getAnalyzes(),
+          clean(data.region),
+        ]);
       }
       setLoadingData(false);
     } catch (error) {
@@ -70,6 +73,7 @@ const AnalyticsAnalyzes: React.FC = () => {
       console.log(error);
     }
   };
+
 
   useEffect(() => {
     if (projectId && appId) {

--- a/frontend/src/pages/analytics/analyzes/AnalyticsAnalyzes.tsx
+++ b/frontend/src/pages/analytics/analyzes/AnalyticsAnalyzes.tsx
@@ -18,7 +18,11 @@ import {
   Header,
   SpaceBetween,
 } from '@cloudscape-design/components';
-import { clean, embedAnalyzesUrl, getPipelineDetailByProjectId } from 'apis/analytics';
+import {
+  clean,
+  embedAnalyzesUrl,
+  getPipelineDetailByProjectId,
+} from 'apis/analytics';
 import InfoLink from 'components/common/InfoLink';
 import Loading from 'components/common/Loading';
 import AnalyticsNavigation from 'components/layouts/AnalyticsNavigation';
@@ -62,10 +66,7 @@ const AnalyticsAnalyzes: React.FC = () => {
       const { success, data }: ApiResponse<IPipeline> =
         await getPipelineDetailByProjectId(defaultStr(projectId));
       if (success && data.analysisStudioEnabled) {
-        await Promise.all([
-          getAnalyzes(),
-          clean(data.region),
-        ]);
+        await Promise.all([getAnalyzes(), clean(data.region)]);
       }
       setLoadingData(false);
     } catch (error) {
@@ -73,7 +74,6 @@ const AnalyticsAnalyzes: React.FC = () => {
       console.log(error);
     }
   };
-
 
   useEffect(() => {
     if (projectId && appId) {

--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -473,3 +473,12 @@ export const FOLDER_OWNER_PERMISSION_ACTIONS = [
   'quicksight:DeleteFolder',
   'quicksight:UpdateFolderPermissions',
 ];
+
+export const DATA_SOURCE_OWNER_PERMISSION_ACTIONS = [
+  'quicksight:UpdateDataSourcePermissions',
+  'quicksight:DescribeDataSourcePermissions',
+  'quicksight:PassDataSource',
+  'quicksight:DescribeDataSource',
+  'quicksight:DeleteDataSource',
+  'quicksight:UpdateDataSource',
+];

--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -1225,7 +1225,7 @@ export class CReportingStack extends JSONObject {
       QuickSightUserParam: resources.quickSightUser?.publishUserName,
       QuickSightNamespaceParam: pipeline.reporting?.quickSight?.namespace,
       QuickSightPrincipalParam: resources.quickSightUser?.publishUserArn,
-      QuickSightOwnerPrincipalParam: resources.quickSightUser?.exploreUserArn,
+      QuickSightOwnerPrincipalParam: resources.quickSightUser?.publishUserArn,
       RedshiftDBParam: pipeline.projectId,
       RedShiftDBSchemaParam: resources.appIds?.join(','),
       QuickSightVpcConnectionSubnetParam: resources.quickSightSubnetIds?.join(','),

--- a/src/control-plane/backend/lambda/api/service/project.ts
+++ b/src/control-plane/backend/lambda/api/service/project.ts
@@ -129,7 +129,6 @@ export class ProjectServ {
       const embed = await generateEmbedUrlForRegisteredUser(
         pipeline.region,
         allowedDomain,
-        true,
         dashboardId,
       );
       if (embed && embed.EmbedUrl) {
@@ -195,7 +194,6 @@ export class ProjectServ {
       const embed = await generateEmbedUrlForRegisteredUser(
         latestPipeline.region,
         allowedDomain,
-        true,
       );
       return res.json(new ApiSuccess(embed));
     } catch (error) {

--- a/src/control-plane/backend/lambda/api/service/quicksight/reporting-utils.ts
+++ b/src/control-plane/backend/lambda/api/service/quicksight/reporting-utils.ts
@@ -36,7 +36,7 @@ import { DataSetProps } from './dashboard-ln';
 import { ReportingCheck } from './reporting-check';
 import { AttributionTouchPoint, ColumnAttribute, Condition, EventAndCondition, PairEventAndCondition, SQLParameters, buildConditionProps } from './sql-builder';
 import { AttributionSQLParameters } from './sql-builder-attribution';
-import { DATASET_ADMIN_PERMISSION_ACTIONS, DATASET_READER_PERMISSION_ACTIONS, QUICKSIGHT_DATASET_INFIX, QUICKSIGHT_RESOURCE_NAME_PREFIX, QUICKSIGHT_TEMP_RESOURCE_NAME_PREFIX } from '../../common/constants-ln';
+import { DATASET_ADMIN_PERMISSION_ACTIONS, QUICKSIGHT_DATASET_INFIX, QUICKSIGHT_RESOURCE_NAME_PREFIX, QUICKSIGHT_TEMP_RESOURCE_NAME_PREFIX } from '../../common/constants-ln';
 import { AnalysisType, AttributionModelType, ExploreAttributionTimeWindowType, ExploreComputeMethod, ExploreConversionIntervalType, ExploreLocales, ExplorePathNodeType, ExplorePathSessionDef, ExploreRelativeTimeUnit, ExploreRequestAction, ExploreTimeScopeType, ExploreVisualName, MetadataValueType, QuickSightChartType } from '../../common/explore-types';
 import { logger } from '../../common/powertools';
 import i18next from '../../i18n';
@@ -288,8 +288,7 @@ export const attributionVisualColumns: InputColumn[] = [
   },
 ];
 
-export const createDataSet = async (quickSight: QuickSight, awsAccountId: string,
-  exploreUserArn: string, publishUserArn: string,
+export const createDataSet = async (quickSight: QuickSight, awsAccountId: string, publishUserArn: string,
   dataSourceArn: string,
   props: DataSetProps, requestAction: ExploreRequestAction)
 : Promise<CreateDataSetCommandOutput|undefined> => {
@@ -354,22 +353,16 @@ export const createDataSet = async (quickSight: QuickSight, awsAccountId: string
     logger.info('start to create dataset');
     const datasetPermissionActions = [
       {
-        Principal: exploreUserArn,
+        Principal: publishUserArn,
         Actions: DATASET_ADMIN_PERMISSION_ACTIONS,
       },
     ];
-    if (requestAction === ExploreRequestAction.PUBLISH) {
-      datasetPermissionActions.push({
-        Principal: publishUserArn,
-        Actions: DATASET_READER_PERMISSION_ACTIONS,
-      });
-    }
     const dataset = await quickSight.createDataSet({
       AwsAccountId: awsAccountId,
       DataSetId: datasetId,
       Name: datasetId,
-      Permissions: datasetPermissionActions,
       ImportMode: props.importMode,
+      Permissions: requestAction === ExploreRequestAction.PUBLISH ? datasetPermissionActions : undefined,
       PhysicalTableMap: {
         PhyTable1: {
           CustomSql: {

--- a/src/control-plane/backend/lambda/api/service/reporting.ts
+++ b/src/control-plane/backend/lambda/api/service/reporting.ts
@@ -990,7 +990,11 @@ async function _cleanDatasets(quickSight: QuickSight) {
   }
 
   for (const dataSetSummary of dataSetSummaries) {
-    if (dataSetSummary.DataSetId?.startsWith(QUICKSIGHT_TEMP_RESOURCE_NAME_PREFIX)) {
+    if (
+      dataSetSummary.DataSetId?.startsWith(QUICKSIGHT_TEMP_RESOURCE_NAME_PREFIX)
+      && dataSetSummary.CreatedTime !== undefined
+      && (new Date().getTime() - dataSetSummary.CreatedTime.getTime()) > 60 * 60 * 1000
+    ) {
       const dataSetId = dataSetSummary.DataSetId;
       logger.info(`deleting data set: ${ dataSetId }`);
       const deletedRes = await quickSight.deleteDataSet({
@@ -1019,7 +1023,11 @@ async function _cleanAnalyses(quickSight: QuickSight) {
 
   for (const analysisSummary of analysisSummaries) {
     const analysisId = analysisSummary.AnalysisId;
-    if (analysisSummary.Status !== ResourceStatus.DELETED) {
+    if (analysisSummary.Status !== ResourceStatus.DELETED
+      && analysisSummary.CreatedTime !== undefined
+      && analysisSummary.AnalysisId?.startsWith(QUICKSIGHT_TEMP_RESOURCE_NAME_PREFIX) &&
+      (new Date().getTime() - analysisSummary.CreatedTime.getTime()) > 60 * 60 * 1000
+    ) {
       await quickSight.deleteAnalysis({
         AwsAccountId: awsAccountId,
         AnalysisId: analysisId,
@@ -1047,7 +1055,10 @@ async function _cleanedDashboard(quickSight: QuickSight) {
 
   for (const dashboardSummary of dashboardSummaries) {
     const dashboardId = dashboardSummary.DashboardId;
-    if (dashboardSummary.DashboardId?.startsWith(QUICKSIGHT_TEMP_RESOURCE_NAME_PREFIX)) {
+    if (dashboardSummary.DashboardId?.startsWith(QUICKSIGHT_TEMP_RESOURCE_NAME_PREFIX)
+      && dashboardSummary.CreatedTime !== undefined
+      && (new Date().getTime() - dashboardSummary.CreatedTime.getTime()) > 60 * 60 * 1000
+    ) {
       await quickSight.deleteDashboard({
         AwsAccountId: awsAccountId,
         DashboardId: dashboardId,

--- a/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
@@ -39,6 +39,7 @@ import { IDashboard } from '../../model/project';
 
 const QUICKSIGHT_NAMESPACE = 'default';
 const QUICKSIGHT_PUBLISH_USER_NAME = 'ClickstreamPublishUser';
+const QUICKSIGHT_EXPLORE_USER_NAME = 'ClickstreamExploreUser';
 
 const sdkClient: SDKClient = new SDKClient();
 const promisePool = pLimit(3);
@@ -91,6 +92,27 @@ export const deleteClickstreamUser = async () => {
       UserName: `${quickSightEmbedRoleName}/${QUICKSIGHT_PUBLISH_USER_NAME}`,
     });
   } catch (err) {
+    if (err instanceof ResourceNotFoundException) {
+      return;
+    }
+    logger.error('Delete Clickstream User Error.', { err });
+    throw err;
+  }
+};
+
+export const deleteExploreUser = async () => {
+  try {
+    const identityRegion = await sdkClient.QuickSightIdentityRegion();
+    const quickSightEmbedRoleName = QuickSightEmbedRoleArn?.split(':role/')[1];
+    await sdkClient.QuickSight({ region: identityRegion }).deleteUser({
+      AwsAccountId: awsAccountId,
+      Namespace: QUICKSIGHT_NAMESPACE,
+      UserName: `${quickSightEmbedRoleName}/${QUICKSIGHT_EXPLORE_USER_NAME}`,
+    });
+  } catch (err) {
+    if (err instanceof ResourceNotFoundException) {
+      return;
+    }
     logger.error('Delete Clickstream User Error.', { err });
     throw err;
   }

--- a/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
@@ -30,7 +30,7 @@ import {
 } from '@aws-sdk/client-quicksight';
 import pLimit from 'p-limit';
 import { awsAccountId, awsRegion, QUICKSIGHT_EMBED_NO_REPLY_EMAIL, QuickSightEmbedRoleArn } from '../../common/constants';
-import { ANALYSIS_ADMIN_PERMISSION_ACTIONS, DASHBOARD_ADMIN_PERMISSION_ACTIONS, DATASET_ADMIN_PERMISSION_ACTIONS, DEFAULT_DASHBOARD_NAME_PREFIX, FOLDER_CONTRIBUTOR_PERMISSION_ACTIONS, FOLDER_OWNER_PERMISSION_ACTIONS, QUICKSIGHT_ANALYSIS_INFIX, QUICKSIGHT_DASHBOARD_INFIX, QUICKSIGHT_DATASET_INFIX, QUICKSIGHT_RESOURCE_NAME_PREFIX } from '../../common/constants-ln';
+import { ANALYSIS_ADMIN_PERMISSION_ACTIONS, DASHBOARD_ADMIN_PERMISSION_ACTIONS, DATASET_ADMIN_PERMISSION_ACTIONS, DEFAULT_DASHBOARD_NAME_PREFIX, FOLDER_OWNER_PERMISSION_ACTIONS, QUICKSIGHT_ANALYSIS_INFIX, QUICKSIGHT_DASHBOARD_INFIX, QUICKSIGHT_DATASET_INFIX, QUICKSIGHT_RESOURCE_NAME_PREFIX } from '../../common/constants-ln';
 import { logger } from '../../common/powertools';
 import { SDKClient } from '../../common/sdk-client';
 import { QuickSightAccountInfo } from '../../common/types';
@@ -38,7 +38,6 @@ import { sleep } from '../../common/utils-ln';
 import { IDashboard } from '../../model/project';
 
 const QUICKSIGHT_NAMESPACE = 'default';
-const QUICKSIGHT_EXPLORE_USER_NAME = 'ClickstreamExploreUser';
 const QUICKSIGHT_PUBLISH_USER_NAME = 'ClickstreamPublishUser';
 
 const sdkClient: SDKClient = new SDKClient();
@@ -55,15 +54,6 @@ export const registerClickstreamUser = async () => {
       Namespace: QUICKSIGHT_NAMESPACE,
       UserRole: UserRole.ADMIN,
       SessionName: QUICKSIGHT_PUBLISH_USER_NAME,
-    });
-    await registerUser(identityRegion, {
-      IdentityType: IdentityType.IAM,
-      AwsAccountId: awsAccountId,
-      Email: QUICKSIGHT_EMBED_NO_REPLY_EMAIL,
-      IamArn: QuickSightEmbedRoleArn,
-      Namespace: QUICKSIGHT_NAMESPACE,
-      UserRole: UserRole.ADMIN,
-      SessionName: QUICKSIGHT_EXPLORE_USER_NAME,
     });
     const clickstreamUserArn = await getClickstreamUserArn();
     return clickstreamUserArn;
@@ -100,11 +90,6 @@ export const deleteClickstreamUser = async () => {
       Namespace: QUICKSIGHT_NAMESPACE,
       UserName: `${quickSightEmbedRoleName}/${QUICKSIGHT_PUBLISH_USER_NAME}`,
     });
-    await sdkClient.QuickSight({ region: identityRegion }).deleteUser({
-      AwsAccountId: awsAccountId,
-      Namespace: QUICKSIGHT_NAMESPACE,
-      UserName: `${quickSightEmbedRoleName}/${QUICKSIGHT_EXPLORE_USER_NAME}`,
-    });
   } catch (err) {
     logger.error('Delete Clickstream User Error.', { err });
     throw err;
@@ -114,7 +99,6 @@ export const deleteClickstreamUser = async () => {
 export const generateEmbedUrlForRegisteredUser = async (
   region: string,
   allowedDomain: string,
-  publish: boolean,
   dashboardId?: string,
   sheetId?: string,
   visualId?: string,
@@ -126,7 +110,7 @@ export const generateEmbedUrlForRegisteredUser = async (
     const arns = await getClickstreamUserArn();
     let commandInput: GenerateEmbedUrlForRegisteredUserCommandInput = {
       AwsAccountId: awsAccountId,
-      UserArn: publish ? arns.publishUserArn : arns.exploreUserArn,
+      UserArn: arns.publishUserArn,
       AllowedDomains: [allowedDomain],
       ExperienceConfiguration: {},
     };
@@ -238,9 +222,7 @@ export const describeClickstreamAccountSubscription = async () => {
 };
 
 export interface QuickSightUserArns {
-  exploreUserArn: string;
   publishUserArn: string;
-  exploreUserName: string;
   publishUserName: string;
 }
 
@@ -248,11 +230,9 @@ export const getClickstreamUserArn = async (): Promise<QuickSightUserArns> => {
   const identityRegion = await sdkClient.QuickSightIdentityRegion();
   const quickSightEmbedRoleName = QuickSightEmbedRoleArn?.split(':role/')[1];
   const partition = awsRegion?.startsWith('cn') ? 'aws-cn' : 'aws';
-  const exploreUserName = `${quickSightEmbedRoleName}/${QUICKSIGHT_EXPLORE_USER_NAME}`;
   const publishUserName = `${quickSightEmbedRoleName}/${QUICKSIGHT_PUBLISH_USER_NAME}`;
-  const exploreUserArn = `arn:${partition}:quicksight:${identityRegion}:${awsAccountId}:user/${QUICKSIGHT_NAMESPACE}/${exploreUserName}`;
   const publishUserArn = `arn:${partition}:quicksight:${identityRegion}:${awsAccountId}:user/${QUICKSIGHT_NAMESPACE}/${publishUserName}`;
-  return { exploreUserArn, publishUserArn, exploreUserName, publishUserName };
+  return { publishUserArn, publishUserName };
 };
 
 export const waitDashboardSuccess = async (region: string, dashboardId: string) => {
@@ -581,10 +561,6 @@ export const checkFolder = async (
         Permissions: [
           {
             Principal: principals.publishUserArn,
-            Actions: FOLDER_CONTRIBUTOR_PERMISSION_ACTIONS,
-          },
-          {
-            Principal: principals.exploreUserArn,
             Actions: FOLDER_OWNER_PERMISSION_ACTIONS,
           },
         ],

--- a/src/control-plane/backend/lambda/api/test/api/project.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/project.test.ts
@@ -630,7 +630,7 @@ describe('Project test', () => {
       success: true,
       message: 'Project deleted.',
     });
-    expect(quickSightMock).toHaveReceivedCommandTimes(DeleteUserCommand, 2);
+    expect(quickSightMock).toHaveReceivedCommandTimes(DeleteUserCommand, 1);
   });
   it('Delete project witch no pipeline', async () => {
     projectExistedMock(ddbMock, true);
@@ -661,7 +661,7 @@ describe('Project test', () => {
       success: true,
       message: 'Project deleted.',
     });
-    expect(quickSightMock).toHaveReceivedCommandTimes(DeleteUserCommand, 2);
+    expect(quickSightMock).toHaveReceivedCommandTimes(DeleteUserCommand, 1);
     expect(ddbMock).toHaveReceivedCommandTimes(ScanCommand, 1);
     expect(ddbMock).toHaveReceivedCommandTimes(UpdateCommand, 2);
   });

--- a/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
@@ -936,7 +936,7 @@ const BASE_REPORTING_PARAMETERS = [
   },
   {
     ParameterKey: 'QuickSightOwnerPrincipalParam',
-    ParameterValue: 'arn:aws:quicksight:us-east-1:555555555555:user/default/QuickSightEmbeddingRole/ClickstreamExploreUser',
+    ParameterValue: 'arn:aws:quicksight:us-east-1:555555555555:user/default/QuickSightEmbeddingRole/ClickstreamPublishUser',
   },
   {
     ParameterKey: 'RedshiftDBParam',
@@ -992,7 +992,7 @@ export const REPORTING_WITH_NEW_REDSHIFT_PARAMETERS = [
   },
   {
     ParameterKey: 'QuickSightOwnerPrincipalParam',
-    ParameterValue: 'arn:aws:quicksight:us-east-1:555555555555:user/default/QuickSightEmbeddingRole/ClickstreamExploreUser',
+    ParameterValue: 'arn:aws:quicksight:us-east-1:555555555555:user/default/QuickSightEmbeddingRole/ClickstreamPublishUser',
   },
   {
     ParameterKey: 'RedshiftDBParam',

--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -44,7 +44,7 @@ import {
 import { Context, CloudFormationCustomResourceEvent, CloudFormationCustomResourceUpdateEvent, CloudFormationCustomResourceCreateEvent, CloudFormationCustomResourceDeleteEvent, CdkCustomResourceResponse } from 'aws-lambda';
 import Mustache from 'mustache';
 import { v4 as uuidv4 } from 'uuid';
-import { ANALYSIS_ADMIN_PERMISSION_ACTIONS, DASHBOARD_ADMIN_PERMISSION_ACTIONS, DATASET_ADMIN_PERMISSION_ACTIONS, DATASET_READER_PERMISSION_ACTIONS, FOLDER_CONTRIBUTOR_PERMISSION_ACTIONS, FOLDER_OWNER_PERMISSION_ACTIONS, QUICKSIGHT_RESOURCE_NAME_PREFIX } from '../../../../common/constant';
+import { ANALYSIS_ADMIN_PERMISSION_ACTIONS, DASHBOARD_ADMIN_PERMISSION_ACTIONS, DATASET_ADMIN_PERMISSION_ACTIONS, DATASET_READER_PERMISSION_ACTIONS, DATA_SOURCE_OWNER_PERMISSION_ACTIONS, FOLDER_CONTRIBUTOR_PERMISSION_ACTIONS, FOLDER_OWNER_PERMISSION_ACTIONS, QUICKSIGHT_RESOURCE_NAME_PREFIX } from '../../../../common/constant';
 import { logger } from '../../../../common/powertools';
 import { aws_sdk_client_common_config } from '../../../../common/sdk-client-config';
 import { sleep } from '../../../../common/utils';
@@ -299,6 +299,27 @@ const getDataSetPermission = (sharePrincipalArn: string, ownerPrincipalArn: stri
     {
       Principal: sharePrincipalArn,
       Actions: DATASET_READER_PERMISSION_ACTIONS,
+    },
+  ];
+};
+
+const getDataSourcePermission = (sharePrincipalArn: string, ownerPrincipalArn: string): ResourcePermission[] => {
+  if (sharePrincipalArn === ownerPrincipalArn) {
+    return [
+      {
+        Principal: sharePrincipalArn,
+        Actions: DATA_SOURCE_OWNER_PERMISSION_ACTIONS,
+      },
+    ];
+  }
+  return [
+    {
+      Principal: ownerPrincipalArn,
+      Actions: DATA_SOURCE_OWNER_PERMISSION_ACTIONS,
+    },
+    {
+      Principal: sharePrincipalArn,
+      Actions: DATA_SOURCE_OWNER_PERMISSION_ACTIONS,
     },
   ];
 };
@@ -1165,7 +1186,7 @@ const grantDataSourcePermission = async (quickSight: QuickSight, dataSourceArn: 
   await quickSight.updateDataSourcePermissions({
     AwsAccountId: awsAccountId,
     DataSourceId: dataSourceId,
-    GrantPermissions: getDataSetPermission(sharePrincipalArn, ownerPrincipalArn),
+    GrantPermissions: getDataSourcePermission(sharePrincipalArn, ownerPrincipalArn),
   });
 };
 

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -761,6 +761,30 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
       PolicyDocument: {
         Statement: [
           {
+            Action: [
+              'logs:CreateLogDelivery',
+              'logs:GetLogDelivery',
+              'logs:UpdateLogDelivery',
+              'logs:DeleteLogDelivery',
+              'logs:ListLogDeliveries',
+              'logs:PutResourcePolicy',
+              'logs:DescribeResourcePolicies',
+              'logs:DescribeLogGroups',
+            ],
+            Effect: 'Allow',
+            Resource: '*',
+          },
+          {
+            Action: [
+              'xray:PutTraceSegments',
+              'xray:PutTelemetryRecords',
+              'xray:GetSamplingRules',
+              'xray:GetSamplingTargets',
+            ],
+            Effect: 'Allow',
+            Resource: '*',
+          },
+          {
             Action: 'lambda:InvokeFunction',
             Effect: 'Allow',
             Resource: [
@@ -785,30 +809,6 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
                 ],
               },
             ],
-          },
-          {
-            Action: [
-              'logs:CreateLogDelivery',
-              'logs:GetLogDelivery',
-              'logs:UpdateLogDelivery',
-              'logs:DeleteLogDelivery',
-              'logs:ListLogDeliveries',
-              'logs:PutResourcePolicy',
-              'logs:DescribeResourcePolicies',
-              'logs:DescribeLogGroups',
-            ],
-            Effect: 'Allow',
-            Resource: '*',
-          },
-          {
-            Action: [
-              'xray:PutTraceSegments',
-              'xray:PutTelemetryRecords',
-              'xray:GetSamplingRules',
-              'xray:GetSamplingTargets',
-            ],
-            Effect: 'Allow',
-            Resource: '*',
           },
         ],
         Version: '2012-10-17',

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -761,30 +761,6 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
       PolicyDocument: {
         Statement: [
           {
-            Action: [
-              'logs:CreateLogDelivery',
-              'logs:GetLogDelivery',
-              'logs:UpdateLogDelivery',
-              'logs:DeleteLogDelivery',
-              'logs:ListLogDeliveries',
-              'logs:PutResourcePolicy',
-              'logs:DescribeResourcePolicies',
-              'logs:DescribeLogGroups',
-            ],
-            Effect: 'Allow',
-            Resource: '*',
-          },
-          {
-            Action: [
-              'xray:PutTraceSegments',
-              'xray:PutTelemetryRecords',
-              'xray:GetSamplingRules',
-              'xray:GetSamplingTargets',
-            ],
-            Effect: 'Allow',
-            Resource: '*',
-          },
-          {
             Action: 'lambda:InvokeFunction',
             Effect: 'Allow',
             Resource: [
@@ -809,6 +785,30 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
                 ],
               },
             ],
+          },
+          {
+            Action: [
+              'logs:CreateLogDelivery',
+              'logs:GetLogDelivery',
+              'logs:UpdateLogDelivery',
+              'logs:DeleteLogDelivery',
+              'logs:ListLogDeliveries',
+              'logs:PutResourcePolicy',
+              'logs:DescribeResourcePolicies',
+              'logs:DescribeLogGroups',
+            ],
+            Effect: 'Allow',
+            Resource: '*',
+          },
+          {
+            Action: [
+              'xray:PutTraceSegments',
+              'xray:PutTelemetryRecords',
+              'xray:GetSamplingRules',
+              'xray:GetSamplingTargets',
+            ],
+            Effect: 'Allow',
+            Resource: '*',
           },
         ],
         Version: '2012-10-17',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. Remove QuickSight explore user
2. Create template dashboards in Publish user
3. Clean template dashboards when access analyses page 

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend