### PR TITLE
docs: update default value for android SDK log event configuration

### DIFF
--- a/docs/en/sdk-manual/android.md
+++ b/docs/en/sdk-manual/android.md
@@ -18,7 +18,7 @@ Add the Clickstream SDK dependency to your `app` module's `build.gradle` file, f
 
 ```groovy
 dependencies {
-    implementation 'software.aws.solution:clickstream:0.10.0'
+    implementation 'software.aws.solution:clickstream:0.10.1'
 }
 ```
 

--- a/docs/en/sdk-manual/android.md
+++ b/docs/en/sdk-manual/android.md
@@ -233,19 +233,19 @@ ClickstreamAnalytics.getClickStreamConfiguration()
 
 Here is an explanation of each method.
 
-| Method name                     | Parameter type | Required | Default value | Description                                                  |
-| ------------------------------- | -------------- | -------- | ------------- | ------------------------------------------------------------ |
-| withAppId()                     | String         | true     | --            | the app id of your application in web console                |
-| withEndpoint()                  | String         | true     | --            | the endpoint path you will upload the event to Clickstream ingestion server |
-| withAuthCookie()                | String         | false    | --            | your auth cookie for AWS application load balancer auth cookie |
-| withSendEventsInterval()        | long           | false    | 1800000       | event sending interval in milliseconds                       |
-| withSessionTimeoutDuration()    | long           | false    | 5000          | the duration of the session timeout in milliseconds          |
-| withTrackScreenViewEvents()     | boolean        | false    | true          | whether to auto-record screen view events                    |
-| withTrackUserEngagementEvents() | boolean        | false    | true          | whether to auto-record user engagement events                |
-| withTrackAppExceptionEvents()   | boolean        | false    | true          | whether to auto-record app exception events                  |
-| withLogEvents()                 | boolean        | false    | true          | whether to automatically print event JSON for debugging events, [Learn more](#debug-events) |
-| withCustomDns()                 | String         | false    | --            | the method for setting your custom DNS, [Learn more](#configure-custom-dns) |
-| withCompressEvents()            | boolean        | false    | true          | whether to compress event content by gzip when uploading events. |
+| Method name                     | Parameter type | Required | Default value | Description                                                                                 |
+|---------------------------------|----------------|----------|---------------|---------------------------------------------------------------------------------------------|
+| withAppId()                     | String         | true     | --            | the app id of your application in web console                                               |
+| withEndpoint()                  | String         | true     | --            | the endpoint path you will upload the event to Clickstream ingestion server                 |
+| withAuthCookie()                | String         | false    | --            | your auth cookie for AWS application load balancer auth cookie                              |
+| withSendEventsInterval()        | long           | false    | 1800000       | event sending interval in milliseconds                                                      |
+| withSessionTimeoutDuration()    | long           | false    | 5000          | the duration of the session timeout in milliseconds                                         |
+| withTrackScreenViewEvents()     | boolean        | false    | true          | whether to auto-record screen view events                                                   |
+| withTrackUserEngagementEvents() | boolean        | false    | true          | whether to auto-record user engagement events                                               |
+| withTrackAppExceptionEvents()   | boolean        | false    | true          | whether to auto-record app exception events                                                 |
+| withLogEvents()                 | boolean        | false    | false         | whether to automatically print event JSON for debugging events, [Learn more](#debug-events) |
+| withCustomDns()                 | String         | false    | --            | the method for setting your custom DNS, [Learn more](#configure-custom-dns)                 |
+| withCompressEvents()            | boolean        | false    | true          | whether to compress event content by gzip when uploading events.                            |
 
 #### Debug events
 

--- a/docs/zh/sdk-manual/android.md
+++ b/docs/zh/sdk-manual/android.md
@@ -19,7 +19,7 @@ Clickstream Android SDK 支持 Android 4.1（API 级别 16）及更高版本。
 
 ```groovy
 dependencies {
-    implementation 'software.aws.solution:clickstream:0.10.0'
+    implementation 'software.aws.solution:clickstream:0.10.1'
 }
 ```
 

--- a/docs/zh/sdk-manual/android.md
+++ b/docs/zh/sdk-manual/android.md
@@ -234,19 +234,19 @@ ClickstreamAnalytics.getClickStreamConfiguration()
 
 以下是每个方法的说明
 
-| 方法名                          | 参数类型 | 是否必需 | 默认值  | 描述                                               |
-| ------------------------------- | -------- | -------- | ------- | -------------------------------------------------- |
-| withAppId()                     | String   | 是       | --      | 在解决方案控制平面中您应用程序的 ID                |
-| withEndpoint()                  | String   | 是       | --      | 您将事件上传到 Clickstream 摄取服务器的URL请求路径 |
-| withAuthCookie()                | String   | 否       | --      | 您的 AWS 应用程序负载均衡器身份验证 cookie         |
-| withSendEventsInterval()        | long     | 否       | 100000  | 事件发送间隔（毫秒）                               |
-| withSessionTimeoutDuration()    | long     | 否       | 1800000 | 会话超时的时长（毫秒）                             |
-| withTrackScreenViewEvents()     | boolean  | 否       | true    | 是否自动记录 screen view（屏幕浏览） 事件          |
-| withTrackUserEngagementEvents() | boolean  | 否       | true    | 是否自动记录 user engagement（用户参与） 事件      |
-| withTrackAppExceptionEvents()   | boolean  | 否       | true    | 是否自动记录应用崩溃事件                           |
-| withLogEvents()                 | boolean  | 否       | true    | 是否自动打印事件 json以调试事件, [了解更多](#_8)   |
-| withCustomDns()                 | String   | 否       | --      | 设置自定义 DNS 的方法, [了解更多](#dns)            |
-| withCompressEvents()            | boolean  | 否       | true    | 上传事件时是否通过gzip压缩事件内容                 |
+| 方法名                             | 参数类型     | 是否必需 | 默认值     | 描述                                |
+|---------------------------------|----------|------|---------|-----------------------------------|
+| withAppId()                     | String   | 是    | --      | 在解决方案控制平面中您应用程序的 ID               |
+| withEndpoint()                  | String   | 是    | --      | 您将事件上传到 Clickstream 摄取服务器的URL请求路径 |
+| withAuthCookie()                | String   | 否    | --      | 您的 AWS 应用程序负载均衡器身份验证 cookie       |
+| withSendEventsInterval()        | long     | 否    | 100000  | 事件发送间隔（毫秒）                        |
+| withSessionTimeoutDuration()    | long     | 否    | 1800000 | 会话超时的时长（毫秒）                       |
+| withTrackScreenViewEvents()     | boolean  | 否    | true    | 是否自动记录 screen view（屏幕浏览） 事件       |
+| withTrackUserEngagementEvents() | boolean  | 否    | true    | 是否自动记录 user engagement（用户参与） 事件   |
+| withTrackAppExceptionEvents()   | boolean  | 否    | true    | 是否自动记录应用崩溃事件                      |
+| withLogEvents()                 | boolean  | 否    | false   | 是否自动打印事件 json以调试事件, [了解更多](#_8)   |
+| withCustomDns()                 | String   | 否    | --      | 设置自定义 DNS 的方法, [了解更多](#dns)       |
+| withCompressEvents()            | boolean  | 否    | true    | 上传事件时是否通过gzip压缩事件内容               |
 
 #### 调试事件
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary
1. update default value for android SDK log event configuration

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend