### PR TITLE
chore: use non-root user to start nginx

### DIFF
--- a/src/ingestion-server/server/images/nginx/Dockerfile
+++ b/src/ingestion-server/server/images/nginx/Dockerfile
@@ -9,8 +9,17 @@ ENV NGINX_WORKER_CONNECTIONS='1024'
 COPY ./config/nginx.conf /etc/nginx/nginx.conf
 COPY ./config/docker-entrypoint.sh /
 
+RUN rm -rf /etc/nginx/conf.d/default.conf
+
+RUN chown -R nginx /etc/nginx \
+    && chown -R nginx /docker-entrypoint.d \
+    && chown -R nginx /usr/share/nginx \
+    && chown -R nginx /run \
+    && chown -R nginx /var/cache/nginx \
+    && chown nginx ./docker-entrypoint.sh
 RUN chmod u+x ./docker-entrypoint.sh && chmod u+rw /etc/nginx/nginx.conf
 
+USER nginx
 
 HEALTHCHECK --interval=2m --timeout=5s \
   CMD curl -f http://127.0.0.1:8088/health || exit 1


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

use nginx user to start nginx server

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [x] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [x] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend