### PR TITLE
fix: fail to create schema in provisioned redshift

### DIFF
--- a/src/analytics/lambdas/sql-execution-sfn/sql-execution-step-fn.ts
+++ b/src/analytics/lambdas/sql-execution-sfn/sql-execution-step-fn.ts
@@ -66,16 +66,23 @@ async function _handler(event: EventType): Promise<ResponseType> {
 async function submitSql(sqlOrs3File: string, redShiftClient: RedshiftDataClient): Promise<SubmitSqlResponse> {
   logger.info('submitSql() sqlOrs3File: ' + sqlOrs3File);
 
-  const provisionedRedshiftProps = {
-    clusterIdentifier,
-    databaseName,
-    dbUser: dbUser,
-  };
+  let provisionedRedshiftProps = undefined;
+  let serverlessRedshiftProps = undefined;
 
-  const serverlessRedshiftProps = {
-    workgroupName,
-    databaseName,
-  };
+  if (clusterIdentifier) {
+    provisionedRedshiftProps = {
+      clusterIdentifier,
+      databaseName,
+      dbUser: dbUser,
+    };
+  }
+
+  if (workgroupName) {
+    serverlessRedshiftProps = {
+      workgroupName,
+      databaseName,
+    };
+  }
   const res = await exeucteBySqlorS3File(sqlOrs3File, redShiftClient, serverlessRedshiftProps, provisionedRedshiftProps, databaseName);
   logger.info('submitSql() return queryId: ' + res.queryId);
   return res;

--- a/test/analytics/analytics-on-redshift/lambda/sql-execution-sfn/sql-execution-sfn-provisioned.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/sql-execution-sfn/sql-execution-sfn-provisioned.test.ts
@@ -1,0 +1,64 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+//@ts-nocheck
+
+process.env.REDSHIFT_DATABASE = 'testdb';
+process.env.REDSHIFT_CLUSTER_IDENTIFIER = 'testcluster';
+process.env.REDSHIFT_DB_USER = 'testuser';
+process.env.REDSHIFT_SERVERLESS_WORKGROUP_NAME = '';
+process.env.REDSHIFT_DATA_API_ROLE = 'arn:aws:iam::123456789012:role/testrole';
+
+import { ExecuteStatementCommand, RedshiftDataClient } from '@aws-sdk/client-redshift-data';
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { mockClient } from 'aws-sdk-client-mock';
+import 'aws-sdk-client-mock-jest';
+
+import {
+  handler,
+} from '../../../../../src/analytics/lambdas/sql-execution-sfn/sql-execution-step-fn';
+
+const redshiftDataMock = mockClient(RedshiftDataClient);
+const s3Mock = mockClient(S3Client);
+
+beforeEach(async () => {
+  redshiftDataMock.reset();
+  s3Mock.reset();
+});
+
+test('handler submit sql - s3 file', async () => {
+  const event = { sql: 's3://test/test.sql' };
+  s3Mock.on(GetObjectCommand).resolves({
+    Body: {
+      transformToString: () => { return 'select * from test'; },
+    } as any,
+  });
+  redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'id-1' });
+
+  const response = await handler(event);
+
+  expect(response).toEqual({ queryId: 'id-1' });
+  expect(s3Mock).toHaveReceivedCommandTimes(GetObjectCommand, 1);
+  expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 1);
+
+  expect(redshiftDataMock).toReceiveNthSpecificCommandWith(1, ExecuteStatementCommand, {
+    ClusterIdentifier: 'testcluster',
+    Database: 'testdb',
+    DbUser: 'testuser',
+    Sql: 'select * from test',
+    WithEvent: true,
+    WorkgroupName: undefined,
+  });
+});
+
+

--- a/test/analytics/analytics-on-redshift/lambda/sql-execution-sfn/sql-execution-sfn-serverless.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/sql-execution-sfn/sql-execution-sfn-serverless.test.ts
@@ -14,8 +14,8 @@
 //@ts-nocheck
 
 process.env.REDSHIFT_DATABASE = 'testdb';
-process.env.REDSHIFT_CLUSTER_IDENTIFIER = 'testcluster';
-process.env.REDSHIFT_DB_USER = 'testuser';
+process.env.REDSHIFT_CLUSTER_IDENTIFIER = '';
+process.env.REDSHIFT_DB_USER = '';
 process.env.REDSHIFT_SERVERLESS_WORKGROUP_NAME = 'testworkgroup';
 process.env.REDSHIFT_DATA_API_ROLE = 'arn:aws:iam::123456789012:role/testrole';
 
@@ -52,9 +52,9 @@ test('handler submit sql - s3 file', async () => {
   expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 1);
 
   expect(redshiftDataMock).toReceiveNthSpecificCommandWith(1, ExecuteStatementCommand, {
-    ClusterIdentifier: 'testcluster',
+    ClusterIdentifier: undefined,
     Database: 'testdb',
-    DbUser: 'testuser',
+    DbUser: undefined,
     Sql: 'select * from test',
     WithEvent: true,
     WorkgroupName: 'testworkgroup',
@@ -73,9 +73,9 @@ test('handler submit sql - raw sql', async () => {
   expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 1);
 
   expect(redshiftDataMock).toReceiveNthSpecificCommandWith(1, ExecuteStatementCommand, {
-    ClusterIdentifier: 'testcluster',
+    ClusterIdentifier: undefined,
     Database: 'testdb',
-    DbUser: 'testuser',
+    DbUser: undefined,
     Sql: 'select * from test1',
     WithEvent: true,
     WorkgroupName: 'testworkgroup',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

v114 provision error

## Implementation highlights

v114 provision error

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend