### PR TITLE
fix: grant permissions for project deletion

### DIFF
--- a/src/control-plane/backend/stack-action-state-machine-construct.ts
+++ b/src/control-plane/backend/stack-action-state-machine-construct.ts
@@ -139,6 +139,15 @@ export class StackActionStateMachine extends Construct {
             `arn:${Aws.PARTITION}:iam::${Aws.ACCOUNT_ID}:role/aws-service-role/servicecatalog-appregistry.amazonaws.com/AWSServiceRoleForAWSServiceCatalogAppRegistry`,
           ],
         }),
+        new iam.PolicyStatement({
+          actions: [
+            'resource-groups:GetGroup',
+            'resource-groups:DisassociateResource',
+          ],
+          resources: [
+            `arn:${Aws.PARTITION}:resource-groups:*:${Aws.ACCOUNT_ID}:group/AWS_AppRegistry_Application-clickstream-analytics-*`,
+          ],
+        }),
         // This list of actions is to ensure the call stack can be created/updated/deleted successfully.
         new iam.PolicyStatement({
           actions: [
@@ -178,6 +187,8 @@ export class StackActionStateMachine extends Construct {
             'servicecatalog:DisassociateResource',
             'servicecatalog:TagResource',
             'servicecatalog:UntagResource',
+            'tag:GetResources',
+            'tag:UntagResources',
           ],
           resources: ['*'],
         }),

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -1205,6 +1205,29 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
           },
           {
             Action: [
+              'resource-groups:GetGroup',
+              'resource-groups:DisassociateResource',
+            ],
+            Effect: 'Allow',
+            Resource: {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:',
+                  {
+                    Ref: 'AWS::Partition',
+                  },
+                  ':resource-groups:*:',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':group/AWS_AppRegistry_Application-clickstream-analytics-*',
+                ],
+              ],
+            },
+          },
+          {
+            Action: [
               'sns:*',
               'sqs:*',
               'redshift-serverless:*',
@@ -1241,6 +1264,8 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
               'servicecatalog:DisassociateResource',
               'servicecatalog:TagResource',
               'servicecatalog:UntagResource',
+              'tag:GetResources',
+              'tag:UntagResources',
             ],
             Effect: 'Allow',
             Resource: '*',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Cherry-pick commit [#892](https://github.com/awslabs/clickstream-analytics-on-aws/pull/892/commits)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend