### PR TITLE
feat: onboard QuickSight in CN regions

### DIFF
--- a/frontend/public/locales/en-US/pipeline.json
+++ b/frontend/public/locales/en-US/pipeline.json
@@ -50,7 +50,8 @@
     "emailInvalid": "Email invalid.",
     "stackRollbackFailed": "Some stacks are ROLLBACK_FAILED and can not be updated.",
     "transformPluginEmptyError": "Please select transform plugin when use Third-party SDK.",
-    "tagsKeyValueEmpty": "Please input key and value."
+    "tagsKeyValueEmpty": "Please input key and value.",
+    "quickSightUserEmptyError": "Please select a QuickSight user"
   },
   "create": {
     "basicInfo": "Basic configuration",
@@ -225,6 +226,8 @@
     "quickSightNotEnterpriseDesc": "The solution dashboard need the QuickSight Enterprise, you can upgrade edition in QuickSight Management Console.",
     "quickSightSubscription": "Subscription",
     "quickSIghtPlaceholder": "Select a quicksight user",
+    "quickSightUser": "QuickSight user",
+    "quickSightUserDesc": "Select a QuickSight user for the solution to create datasets and analyses.",
     "ingestSettings": "Ingestion setting",
     "clusterSize": "Cluster Size",
     "topic": "Topic",

--- a/frontend/public/locales/en-US/pipeline.json
+++ b/frontend/public/locales/en-US/pipeline.json
@@ -51,7 +51,7 @@
     "stackRollbackFailed": "Some stacks are ROLLBACK_FAILED and can not be updated.",
     "transformPluginEmptyError": "Please select transform plugin when use Third-party SDK.",
     "tagsKeyValueEmpty": "Please input key and value.",
-    "quickSightUserEmptyError": "Please select a QuickSight user"
+    "quickSightUserEmptyError": "Please select a QuickSight admin user"
   },
   "create": {
     "basicInfo": "Basic configuration",

--- a/frontend/public/locales/zh-CN/pipeline.json
+++ b/frontend/public/locales/zh-CN/pipeline.json
@@ -50,7 +50,8 @@
     "emailInvalid": "电子邮件无效。",
     "stackRollbackFailed": "某些堆栈处于 ROLLBACK_FAILED 状态，无法更新。",
     "transformPluginEmptyError": "使用第三方 SDK 时需选择转换插件。",
-    "tagsKeyValueEmpty": "标签键和值不能为空。"
+    "tagsKeyValueEmpty": "标签键和值不能为空。",
+    "quickSightUserEmptyError": "请选择QuickSight管理员用户"
   },
   "create": {
     "basicInfo": "基本配置",
@@ -225,6 +226,8 @@
     "quickSightNotEnterpriseDesc": "解决方案控制面板需要 QuickSight Enterprise，你可以在 QuickSight 管理控制台中升级版本。",
     "quickSightSubscription": "订阅",
     "quickSIghtPlaceholder": "选择 quicksight 用户",
+    "quickSightUser": "QuickSight 用户",
+    "quickSightUserDesc": "为解决方案选择一个QuickSight管理员用户以创建数据集和分析。",
     "ingestSettings": "摄取设置",
     "clusterSize": "集群大小",
     "topic": "主题",

--- a/frontend/src/apis/resource.ts
+++ b/frontend/src/apis/resource.ts
@@ -101,7 +101,7 @@ const getQuickSightStatus = async () => {
 const getQuickSightUsers = async () => {
   const result: any = await apiRequest('get', `/env/quicksight/users`);
   return result;
-}
+};
 
 const getSSMSecrets = async (params: { region: string }) => {
   const result: any = await apiRequest('get', '/env/ssm/secrets', params);

--- a/frontend/src/apis/resource.ts
+++ b/frontend/src/apis/resource.ts
@@ -98,6 +98,11 @@ const getQuickSightStatus = async () => {
   return result;
 };
 
+const getQuickSightUsers = async () => {
+  const result: any = await apiRequest('get', `/env/quicksight/users`);
+  return result;
+}
+
 const getSSMSecrets = async (params: { region: string }) => {
   const result: any = await apiRequest('get', '/env/ssm/secrets', params);
   return result;
@@ -164,6 +169,7 @@ export {
   getMSKList,
   getQuickSightDetail,
   getQuickSightStatus,
+  getQuickSightUsers,
   getRedshiftCluster,
   getRedshiftServerlessWorkgroup,
   getRegionList,

--- a/frontend/src/pages/pipelines/create/CreatePipeline.tsx
+++ b/frontend/src/pages/pipelines/create/CreatePipeline.tsx
@@ -29,6 +29,7 @@ import {
   checkServicesAvailable,
   getCertificates,
   getMSKList,
+  getQuickSightUsers,
   getRedshiftCluster,
   getS3BucketList,
   getSSMSecrets,
@@ -2611,9 +2612,34 @@ const CreatePipeline: React.FC<CreatePipelineProps> = (
       (type) => type.value === reverseRedshiftDataRange.unit
     )[0];
   };
+
+  const setUpdateQuickSightUser = async (pipelineInfo: IExtPipeline) => {
+    if (!pipelineInfo.reporting?.quickSight.user) {
+      return;
+    }
+    try {
+      const { success, data }: ApiResponse<any[]> = await getQuickSightUsers();
+      if (success) {
+        const selectUser = data.filter(
+          (element) => element.Arn === pipelineInfo.reporting.quickSight.user
+        )[0];
+        pipelineInfo.selectedQuickSightUser = {
+          label: selectUser.UserName,
+          value: selectUser.Arn,
+          description: selectUser.Email,
+          labelTag: selectUser.Role,
+          disabled: selectUser.Role !== 'ADMIN',
+        };
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
   const setUpdateReport = async (pipelineInfo: IExtPipeline) => {
     if (!pipelineInfo.enableReporting) {
       return;
+    } else {
+      await setUpdateQuickSightUser(pipelineInfo);
     }
   };
   const getDefaultExtPipeline = (data: IExtPipeline): IExtPipeline => {

--- a/frontend/src/pages/pipelines/create/CreatePipeline.tsx
+++ b/frontend/src/pages/pipelines/create/CreatePipeline.tsx
@@ -193,6 +193,8 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
 
   const [unSupportedServices, setUnSupportedServices] = useState('');
   const [quickSightDisabled, setQuickSightDisabled] = useState(false);
+  const [quickSightUserEmptyError, setQuickSightUserEmptyError] =
+    useState(false);
 
   const [pipelineInfo, setPipelineInfo] = useState<IExtPipeline>(
     updatePipeline
@@ -642,6 +644,19 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
     return true;
   };
 
+  const validateReporting = () => {
+    if (quickSightDisabled && pipelineInfo.enableReporting) {
+      return false;
+    }
+
+    if (!pipelineInfo.selectedQuickSightUser) {
+      setQuickSightUserEmptyError(true);
+      return false;
+    }
+
+    return true;
+  };
+
   const setQuickSightStatus = (quickSightAvailable: boolean) => {
     // Set QuickSight disabled
     if (quickSightAvailable) {
@@ -781,6 +796,7 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
       setPrivateSubnetError(false);
       setPrivateSubnetDiffWithPublicError(false);
       setUnSupportedServices('');
+      setQuickSightUserEmptyError(false);
       try {
         setLoadingServiceAvailable(true);
         const { success, data }: ApiResponse<ServiceAvailableResponse[]> =
@@ -1081,11 +1097,7 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
         if (detail.requestedStepIndex === 3 && !validateDataProcessing()) {
           return;
         }
-        if (
-          detail.requestedStepIndex === 4 &&
-          quickSightDisabled &&
-          pipelineInfo.enableReporting
-        ) {
+        if (detail.requestedStepIndex === 4 && !validateReporting()) {
           return;
         }
         setActiveStepIndex(detail.requestedStepIndex);
@@ -2137,6 +2149,23 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
             <Reporting
               update={update}
               pipelineInfo={pipelineInfo}
+              quickSightUserEmptyError={quickSightUserEmptyError}
+              changeQuickSightSelectedUser={(user) => {
+                setQuickSightUserEmptyError(false);
+                setPipelineInfo((prev) => {
+                  return {
+                    ...prev,
+                    selectedQuickSightUser: user,
+                    reporting: {
+                      ...prev.reporting,
+                      quickSight: {
+                        ...prev.reporting?.quickSight,
+                        user: user.value,
+                      },
+                    },
+                  };
+                });
+              }}
               changeLoadingQuickSight={(loading) => {
                 setloadingQuickSight(loading);
               }}

--- a/frontend/src/pages/pipelines/create/CreatePipeline.tsx
+++ b/frontend/src/pages/pipelines/create/CreatePipeline.tsx
@@ -649,7 +649,7 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
       return false;
     }
 
-    if (!pipelineInfo.selectedQuickSightUser) {
+    if (pipelineInfo.enableReporting && !pipelineInfo.selectedQuickSightUser) {
       setQuickSightUserEmptyError(true);
       return false;
     }

--- a/frontend/src/pages/pipelines/create/steps/ConfigIngestion.tsx
+++ b/frontend/src/pages/pipelines/create/steps/ConfigIngestion.tsx
@@ -321,11 +321,13 @@ const ConfigIngestion: React.FC<ConfigIngestionProps> = (
                   label: t('pipeline:create.networkTypeGeneral'),
                   description: t('pipeline:create.networkTypeGeneralDesc'),
                   value: ENetworkType.General,
+                  disabled: isDisabled(update, pipelineInfo),
                 },
                 {
                   label: t('pipeline:create.networkTypePrivate'),
                   description: t('pipeline:create.networkTypePrivateDesc'),
                   value: ENetworkType.Private,
+                  disabled: isDisabled(update, pipelineInfo),
                 },
               ]}
             />
@@ -401,11 +403,13 @@ const ConfigIngestion: React.FC<ConfigIngestionProps> = (
                   label: 'ECS on Fargate',
                   description: t('pipeline:create.ingestionTypeFargateDesc'),
                   value: EIngestionType.Fargate,
+                  disabled: isDisabled(update, pipelineInfo),
                 },
                 {
                   label: 'ECS on EC2',
                   description: t('pipeline:create.ingestionTypeEC2Desc'),
                   value: EIngestionType.EC2,
+                  disabled: isDisabled(update, pipelineInfo),
                 },
               ]}
             />

--- a/frontend/src/pages/pipelines/create/steps/Reporting.tsx
+++ b/frontend/src/pages/pipelines/create/steps/Reporting.tsx
@@ -125,6 +125,7 @@ const Reporting: React.FC<ReportingProps> = (props: ReportingProps) => {
           value: element.Arn,
           description: element.Email,
           labelTag: element.Role,
+          disabled: element.Role !== 'ADMIN',
         }));
         setQuickSightUserOptions(userOptions);
         setLoadingUsers(false);

--- a/frontend/src/pages/pipelines/create/steps/Reporting.tsx
+++ b/frontend/src/pages/pipelines/create/steps/Reporting.tsx
@@ -39,7 +39,7 @@ import {
   PIPELINE_QUICKSIGHT_GUIDE_LINK_EN,
   PIPELINE_QUICKSIGHT_GUIDE_LINK_CN,
 } from 'ts/url';
-import { isDisabled } from 'ts/utils';
+import { isReportingDisabled } from 'ts/utils';
 
 interface ReportingProps {
   update?: boolean;
@@ -168,11 +168,7 @@ const Reporting: React.FC<ReportingProps> = (props: ReportingProps) => {
                 <FormField>
                   <Toggle
                     controlId="test-quicksight-id"
-                    disabled={
-                      isDisabled(update, pipelineInfo) ??
-                      (!pipelineInfo.serviceStatus?.QUICK_SIGHT ||
-                        !pipelineInfo.enableRedshift)
-                    }
+                    disabled={isReportingDisabled(update, pipelineInfo)}
                     onChange={({ detail }) =>
                       changeEnableReporting(detail.checked)
                     }

--- a/frontend/src/ts/init.ts
+++ b/frontend/src/ts/init.ts
@@ -181,6 +181,7 @@ export const INIT_EXT_PIPELINE_DATA: IExtPipeline = {
   selectedRedshiftRole: null,
   selectedRedshiftExecutionUnit: null,
 
+  selectedQuickSightUser: null,
   selectedTransformPlugins: [],
   selectedEnrichPlugins: [],
   enableReporting: true,

--- a/frontend/src/ts/utils.ts
+++ b/frontend/src/ts/utils.ts
@@ -296,8 +296,29 @@ export const isDisabled = (update?: boolean, pipelineInfo?: IExtPipeline) => {
   return (
     update &&
     (pipelineInfo?.statusType === EPipelineStatus.Failed ||
-      pipelineInfo?.statusType === EPipelineStatus.Active)
+      pipelineInfo?.statusType === EPipelineStatus.Active ||
+      pipelineInfo?.statusType === EPipelineStatus.Warning)
   );
+};
+
+export const isReportingDisabled = (
+  update?: boolean,
+  pipelineInfo?: IExtPipeline
+) => {
+  if (!update) {
+    return false;
+  } else {
+    return (
+      pipelineInfo?.enableReporting ||
+      !pipelineInfo?.serviceStatus?.QUICK_SIGHT ||
+      !pipelineInfo.enableRedshift ||
+      !(
+        pipelineInfo?.statusType === EPipelineStatus.Failed ||
+        pipelineInfo?.statusType === EPipelineStatus.Active ||
+        pipelineInfo?.statusType === EPipelineStatus.Warning
+      )
+    );
+  }
 };
 
 // Validate subnets cross N AZs

--- a/frontend/src/types/pipeline.d.ts
+++ b/frontend/src/types/pipeline.d.ts
@@ -156,6 +156,7 @@ declare global {
     reporting: {
       quickSight: {
         accountName: string;
+        user?: string;
       };
     };
     statusType?: PipelineStatusType;
@@ -219,6 +220,8 @@ declare global {
     enableReporting: boolean;
     arnAccountId: string;
     enableAuthentication: boolean;
+
+    selectedQuickSightUser: SelectProps.Option | null;
 
     redshiftType: string; // 'provisioned' | 'serverless';
     redshiftServerlessVPC: SelectProps.Option | null;

--- a/src/cloudfront-control-plane-stack.ts
+++ b/src/cloudfront-control-plane-stack.ts
@@ -177,6 +177,8 @@ export class CloudFrontControlPlaneStack extends Stack {
 
     const frameCSPUrl = [
       `*.quicksight.${Aws.PARTITION}.amazon.com`,
+      'cn-north-1.quicksight.amazonaws.cn',
+      'cn-northwest-1.quicksight.amazonaws.cn',
     ].join(' ');
 
     if (createCognitoUserPool) {

--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -218,6 +218,7 @@ export interface DataModeling {
 export interface Reporting {
   readonly quickSight?: {
     readonly accountName: string;
+    readonly user?: string;
     readonly namespace?: string;
     readonly vpcConnection?: string;
   };
@@ -646,11 +647,21 @@ export class CPipeline {
     }
 
     if (this.pipeline.reporting) {
-      const quickSightUser = await registerClickstreamUser();
-      this.resources = {
-        ...this.resources,
-        quickSightUser: quickSightUser,
-      };
+      if (this.pipeline.region.startsWith('cn')) {
+        this.resources = {
+          ...this.resources,
+          quickSightUser: {
+            publishUserArn: this.pipeline.reporting.quickSight?.user ?? '',
+            publishUserName: this.pipeline.reporting.quickSight?.user?.split('/').pop() ?? '',
+          },
+        };
+      } else {
+        const quickSightUser = await registerClickstreamUser();
+        this.resources = {
+          ...this.resources,
+          quickSightUser: quickSightUser,
+        };
+      }
     }
   }
 

--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -368,6 +368,8 @@ export class CPipeline {
     // update workflow
     this.stackManager.updateWorkflowParameters(editParameters);
     this.stackManager.updateWorkflowAction(editStacks);
+    // enable reporting
+    await this._updateReporting(oldPipeline);
     // update tags
     this.pipeline.tags = getUpdateTags(this.pipeline, oldPipeline);
     if (this._editStackTags(oldPipeline)) {
@@ -384,6 +386,19 @@ export class CPipeline {
     this.pipeline.statusType = PipelineStatusType.UPDATING;
     this.pipeline.workflow = this.stackManager.getWorkflow();
     await store.updatePipeline(this.pipeline, oldPipeline);
+  }
+
+  private async _updateReporting(oldPipeline: IPipeline) {
+    if (oldPipeline.reporting?.quickSight?.accountName === this.pipeline.reporting?.quickSight?.accountName) {
+      return;
+    }
+    if (this.pipeline.reporting?.quickSight?.accountName) {
+      const reportingState = await this.getReportingState();
+      if (!reportingState) {
+        return;
+      }
+      this.stackManager.updateWorkflowReporting(reportingState);
+    }
   }
 
   private async _getEditStacksAndParameters(oldPipeline: IPipeline):

--- a/src/control-plane/backend/lambda/api/router/environment.ts
+++ b/src/control-plane/backend/lambda/api/router/environment.ts
@@ -137,6 +137,12 @@ router_env.get(
   });
 
 router_env.get(
+  '/quicksight/users',
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return environmentServ.quickSightListUsers(req, res, next);
+  });
+
+router_env.get(
   '/quicksight/describe',
   async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     return environmentServ.describeAccountSubscription(req, res, next);

--- a/src/control-plane/backend/lambda/api/service/environment.ts
+++ b/src/control-plane/backend/lambda/api/service/environment.ts
@@ -28,6 +28,7 @@ import { listRoles } from '../store/aws/iam';
 import { listMSKCluster } from '../store/aws/kafka';
 import {
   describeClickstreamAccountSubscription,
+  listUsers,
   quickSightIsSubscribed,
 } from '../store/aws/quicksight';
 import { describeRedshiftClusters, listRedshiftServerlessWorkgroups } from '../store/aws/redshift';
@@ -179,6 +180,15 @@ export class EnvironmentServ {
   public async quickSightIsSubscribed(_req: any, res: any, next: any) {
     try {
       const result = await quickSightIsSubscribed();
+      return res.json(new ApiSuccess(result));
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async quickSightListUsers(_req: any, res: any, next: any) {
+    try {
+      const result = await listUsers();
       return res.json(new ApiSuccess(result));
     } catch (error) {
       next(error);

--- a/src/control-plane/backend/lambda/api/service/project.ts
+++ b/src/control-plane/backend/lambda/api/service/project.ts
@@ -128,6 +128,7 @@ export class ProjectServ {
       }
       const embed = await generateEmbedUrlForRegisteredUser(
         pipeline.region,
+        pipeline.reporting?.quickSight?.user ?? '',
         allowedDomain,
         dashboardId,
       );
@@ -193,6 +194,7 @@ export class ProjectServ {
       }
       const embed = await generateEmbedUrlForRegisteredUser(
         latestPipeline.region,
+        latestPipeline.reporting?.quickSight?.user ?? '',
         allowedDomain,
       );
       return res.json(new ApiSuccess(embed));

--- a/src/control-plane/backend/lambda/api/service/reporting.ts
+++ b/src/control-plane/backend/lambda/api/service/reporting.ts
@@ -48,7 +48,7 @@ import {
   encodeQueryValueForSql,
 } from './quicksight/reporting-utils';
 import { SQLParameters, buildEventAnalysisView, buildEventPathAnalysisView, buildFunnelTableView, buildFunnelView, buildNodePathAnalysisView, buildRetentionAnalysisView } from './quicksight/sql-builder';
-import { awsAccountId } from '../common/constants';
+import { awsAccountId, awsRegion } from '../common/constants';
 import { ExploreLocales, AnalysisType, ExplorePathNodeType, ExploreRequestAction, ExploreTimeScopeType, ExploreVisualName, QuickSightChartType, ExploreComputeMethod } from '../common/explore-types';
 import { PipelineStackType } from '../common/model-ln';
 import { logger } from '../common/powertools';
@@ -831,6 +831,11 @@ export class ReportingService {
     });
 
     //create QuickSight dashboard
+    const embedUserArn = await _getEmbedUserArnFromPipeline(query.projectId);
+    let ownerArn = principals.publishUserArn;
+    if (awsRegion.startsWith('cn')) {
+      ownerArn = embedUserArn;
+    }
     const dashboardId = `${QUICKSIGHT_TEMP_RESOURCE_NAME_PREFIX}${uuidv4()}`;
     const newDashboard = await quickSight.createDashboard({
       AwsAccountId: awsAccountId,
@@ -838,7 +843,7 @@ export class ReportingService {
       Name: `${resourceName}`,
       Definition: dashboard,
       Permissions: [{
-        Principal: principals.publishUserArn,
+        Principal: ownerArn,
         Actions: DASHBOARD_READER_PERMISSION_ACTIONS,
       }],
     });
@@ -849,6 +854,7 @@ export class ReportingService {
       if (dashboardSuccess) {
         const embedUrl = await generateEmbedUrlForRegisteredUser(
           dashboardCreateParameters.region,
+          ownerArn,
           dashboardCreateParameters.allowedDomain,
           dashboardId,
         );
@@ -1076,7 +1082,7 @@ async function _cleanedDashboard(quickSight: QuickSight) {
 
 async function _cleanUser() {
   const pipelines = await store.listPipeline('', 'latest', 'asc');
-  if (pipelines.every(p => !_needExploreUserVersion(p))) {
+  if (pipelines.every(p => !_needExploreUserVersion(p)) && !awsRegion.startsWith('cn')) {
     await deleteExploreUser();
   }
 }
@@ -1086,4 +1092,13 @@ function _needExploreUserVersion(pipeline: IPipeline) {
   const oldVersions = ['v1.1.0', 'v1.1.1', 'v1.1.2', 'v1.1.3'];
   return oldVersions.includes(version);
 
+}
+
+async function _getEmbedUserArnFromPipeline(projectId: string) {
+  let embedUserArn = '';
+  const pipelines = await store.listPipeline(projectId, 'latest', 'asc');
+  if (pipelines.length > 0) {
+    embedUserArn = pipelines[0].reporting?.quickSight?.user ?? '';
+  }
+  return embedUserArn;
 }

--- a/src/control-plane/backend/lambda/api/service/reporting.ts
+++ b/src/control-plane/backend/lambda/api/service/reporting.ts
@@ -48,7 +48,7 @@ import {
   encodeQueryValueForSql,
 } from './quicksight/reporting-utils';
 import { SQLParameters, buildEventAnalysisView, buildEventPathAnalysisView, buildFunnelTableView, buildFunnelView, buildNodePathAnalysisView, buildRetentionAnalysisView } from './quicksight/sql-builder';
-import { awsAccountId, awsRegion } from '../common/constants';
+import { awsAccountId } from '../common/constants';
 import { ExploreLocales, AnalysisType, ExplorePathNodeType, ExploreRequestAction, ExploreTimeScopeType, ExploreVisualName, QuickSightChartType, ExploreComputeMethod } from '../common/explore-types';
 import { PipelineStackType } from '../common/model-ln';
 import { logger } from '../common/powertools';
@@ -833,7 +833,7 @@ export class ReportingService {
     //create QuickSight dashboard
     const embedUserArn = await _getEmbedUserArnFromPipeline(query.projectId);
     let ownerArn = principals.publishUserArn;
-    if (awsRegion.startsWith('cn')) {
+    if (process.env.AWS_REGION?.startsWith('cn')) {
       ownerArn = embedUserArn;
     }
     const dashboardId = `${QUICKSIGHT_TEMP_RESOURCE_NAME_PREFIX}${uuidv4()}`;
@@ -1082,7 +1082,7 @@ async function _cleanedDashboard(quickSight: QuickSight) {
 
 async function _cleanUser() {
   const pipelines = await store.listPipeline('', 'latest', 'asc');
-  if (pipelines.every(p => !_needExploreUserVersion(p)) && !awsRegion.startsWith('cn')) {
+  if (pipelines.every(p => !_needExploreUserVersion(p)) && !process.env.AWS_REGION?.startsWith('cn')) {
     await deleteExploreUser();
   }
 }

--- a/src/control-plane/backend/lambda/api/store/aws/cloudformation.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/cloudformation.ts
@@ -101,9 +101,6 @@ export const pingServiceResource = async (region: string, service: string) => {
       break;
   };
   if (!resourceName) return false;
-  if (service === 'quicksight' && region.startsWith('cn-')) {
-    return false;
-  }
   const resource = await describeType(region, resourceName);
   return resource?.Arn ? true : false;
 };

--- a/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
@@ -528,7 +528,7 @@ export const listDashboardIdsInFolder = async (
       });
       nextToken = resp.NextToken;
     } while (nextToken);
-    return dashboardIds;
+    return Array.from(new Set(dashboardIds));
   } catch (err) {
     logger.error('List Dashboard Ids In Folder Error.', { err });
     throw err;

--- a/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
@@ -46,6 +46,9 @@ const promisePool = pLimit(3);
 
 export const registerClickstreamUser = async () => {
   try {
+    if (awsRegion.startsWith('cn')) {
+      return;
+    }
     const identityRegion = await sdkClient.QuickSightIdentityRegion();
     await registerUser(identityRegion, {
       IdentityType: IdentityType.IAM,
@@ -82,8 +85,25 @@ const registerUser = async (
   }
 };
 
+export const listUsers = async () => {
+  try {
+    const identityRegion = await sdkClient.QuickSightIdentityRegion();
+    const res = await sdkClient.QuickSight({ region: identityRegion }).listUsers({
+      AwsAccountId: awsAccountId,
+      Namespace: QUICKSIGHT_NAMESPACE,
+    });
+    return res.UserList;
+  } catch (err) {
+    logger.error('List Users Error.', { err });
+    throw err;
+  }
+};
+
 export const deleteClickstreamUser = async () => {
   try {
+    if (awsRegion.startsWith('cn')) {
+      return;
+    }
     const identityRegion = await sdkClient.QuickSightIdentityRegion();
     const quickSightEmbedRoleName = QuickSightEmbedRoleArn?.split(':role/')[1];
     await sdkClient.QuickSight({ region: identityRegion }).deleteUser({
@@ -120,6 +140,7 @@ export const deleteExploreUser = async () => {
 
 export const generateEmbedUrlForRegisteredUser = async (
   region: string,
+  userArn: string,
   allowedDomain: string,
   dashboardId?: string,
   sheetId?: string,
@@ -130,9 +151,13 @@ export const generateEmbedUrlForRegisteredUser = async (
       region: region,
     });
     const arns = await getClickstreamUserArn();
+    let embedUserArn = arns.publishUserArn;
+    if (region.startsWith('cn')) {
+      embedUserArn = userArn;
+    }
     let commandInput: GenerateEmbedUrlForRegisteredUserCommandInput = {
       AwsAccountId: awsAccountId,
-      UserArn: arns.publishUserArn,
+      UserArn: embedUserArn,
       AllowedDomains: [allowedDomain],
       ExperienceConfiguration: {},
     };

--- a/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
@@ -125,6 +125,33 @@ function tokenMock(ddbMock: AwsClientStub<DynamoDBDocumentClient>, existed: bool
   });
 }
 
+function quickSightUserMock(ddbMock: AwsClientStub<DynamoDBDocumentClient>, inGCR: boolean): any {
+  if (inGCR) {
+    return ddbMock.on(QueryCommand).resolves({
+      Items: [
+        {
+          id: MOCK_PROJECT_ID,
+          region: 'cn-north-1',
+          reporting: {
+            quickSight: {
+              user: 'arn:aws-cn:quicksight:cn-north-1:55555555555555:user/default/user1',
+            },
+          },
+        },
+      ],
+    });
+  } else {
+    return ddbMock.on(QueryCommand).resolves({
+      Items: [
+        {
+          id: MOCK_PROJECT_ID,
+          region: 'us-east-1',
+        },
+      ],
+    });
+  }
+}
+
 function tokenMockTwice(ddbMock: AwsClientStub<DynamoDBDocumentClient>): any {
   return ddbMock.on(PutCommand).callsFakeOnce(input => {
     if (
@@ -1015,4 +1042,5 @@ export {
   deleteEventRuleMock,
   createEventRuleMock,
   createSNSTopicMock,
+  quickSightUserMock,
 };

--- a/src/control-plane/backend/lambda/api/test/api/env.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/env.test.ts
@@ -1402,12 +1402,12 @@ describe('Account Env test', () => {
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(200);
     expect(res.body.data).toContainEqual({ service: 'global-accelerator', available: false });
-    expect(res.body.data).toContainEqual({ service: 'quicksight', available: false });
+    expect(res.body.data).toContainEqual({ service: 'quicksight', available: true });
     expect(res.body.data).toContainEqual({ service: 'emr-serverless', available: true });
     expect(res.body.data).toContainEqual({ service: 'redshift-serverless', available: true });
     expect(res.body.data).toContainEqual({ service: 'athena', available: true });
     expect(res.body.data).toContainEqual({ service: 'msk', available: true });
-    expect(cloudFormationMock).toHaveReceivedCommandTimes(DescribeTypeCommand, 5);
+    expect(cloudFormationMock).toHaveReceivedCommandTimes(DescribeTypeCommand, 6);
   });
   it('Get Host Zones', async () => {
     route53Client.on(ListHostedZonesCommand).resolves({

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -2681,6 +2681,73 @@ describe('Pipeline test', () => {
       error: 'Error',
     });
   });
+  it('Update pipeline add reporting', async () => {
+    tokenMock(ddbMock, false);
+    projectExistedMock(ddbMock, true);
+    dictionaryMock(ddbMock);
+    createPipelineMock(mockClients, {
+      publicAZContainPrivateAZ: true,
+      subnetsCross3AZ: true,
+      subnetsIsolated: true,
+      update: true,
+      updatePipeline: {
+        ...MSK_DATA_PROCESSING_NEW_SERVERLESS_PIPELINE_WITH_WORKFLOW,
+        reporting: undefined,
+      },
+    });
+    cloudFormationMock.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackName: 'xxx',
+          Outputs: [
+            {
+              OutputKey: 'IngestionServerC000IngestionServerURL',
+              OutputValue: 'http://xxx/xxx',
+            },
+            {
+              OutputKey: 'IngestionServerC000IngestionServerDNS',
+              OutputValue: 'yyy/yyy',
+            },
+            {
+              OutputKey: 'Dashboards',
+              OutputValue: '[{"appId":"app1","dashboardId":"clickstream_dashboard_v1_notepad_mtzfsocy_app1"},{"appId":"app2","dashboardId":"clickstream_dashboard_v1_notepad_mtzfsocy_app2"}]',
+            },
+            {
+              OutputKey: 'ObservabilityDashboardName',
+              OutputValue: 'clickstream_dashboard_notepad_mtzfsocy',
+            },
+          ],
+          StackStatus: StackStatus.CREATE_COMPLETE,
+          CreationTime: new Date(),
+        },
+      ],
+    });
+
+    ddbMock.on(TransactWriteItemsCommand).callsFake(input => {
+      expect(
+        input.TransactItems[0].Put.Item.workflow.M.Workflow.M.Branches.L[1].M.States.M.Reporting.M.End.BOOL === true,
+      ).toBeTruthy();
+    });
+    const res = await request(app)
+      .put(`/api/pipeline/${MOCK_PIPELINE_ID}`)
+      .send({
+        ...MSK_DATA_PROCESSING_NEW_SERVERLESS_PIPELINE_WITH_WORKFLOW,
+        reporting: {
+          ...MSK_DATA_PROCESSING_NEW_SERVERLESS_PIPELINE_WITH_WORKFLOW.reporting,
+        },
+      });
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 6);
+    expect(ddbMock).toHaveReceivedCommandTimes(TransactWriteItemsCommand, 1);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toEqual({
+      data: {
+        id: MOCK_PIPELINE_ID,
+      },
+      success: true,
+      message: 'Pipeline updated.',
+    });
+  });
   it('Update pipeline when QuickSight user already existed', async () => {
     tokenMock(ddbMock, false);
     projectExistedMock(ddbMock, true);

--- a/src/control-plane/backend/lambda/api/test/api/reporting.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/reporting.test.ts
@@ -40,7 +40,7 @@ import { BatchExecuteStatementCommand, DescribeStatementCommand, RedshiftDataCli
 import { DynamoDBDocumentClient, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { mockClient } from 'aws-sdk-client-mock';
 import request from 'supertest';
-import { MOCK_TOKEN, tokenMock } from './ddb-mock';
+import { MOCK_TOKEN, quickSightUserMock, tokenMock } from './ddb-mock';
 import { KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW } from './pipeline-mock';
 import { clickStreamTableName } from '../../common/constants';
 import { AttributionModelType, ConditionCategory, ExploreAttributionTimeWindowType, ExploreComputeMethod, ExploreLocales, ExplorePathNodeType, ExplorePathSessionDef, MetadataPlatform, MetadataValueType, QuickSightChartType } from '../../common/explore-types';
@@ -114,10 +114,10 @@ describe('reporting test', () => {
     quickSightMock.reset();
     redshiftClientMock.reset();
     tokenMock(ddbMock, false);
+    quickSightUserMock(ddbMock, false);
   });
 
   it('funnel bar visual - preview', async () => {
-    tokenMock(ddbMock, false);
     quickSightMock.on(CreateAnalysisCommand).resolves({
       Arn: 'arn:aws:quicksight:us-east-1:11111111:analysis/analysisaaaaaaaa',
     });
@@ -173,7 +173,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -196,7 +196,6 @@ describe('reporting test', () => {
   });
 
   it('funnel visual - preview', async () => {
-    tokenMock(ddbMock, false);
     quickSightMock.on(CreateAnalysisCommand).resolves({
       Arn: 'arn:aws:quicksight:us-east-1:11111111:analysis/analysisaaaaaaaa',
     });
@@ -253,7 +252,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -277,8 +276,6 @@ describe('reporting test', () => {
   });
 
   it('funnel visual - preview - resources create failed', async () => {
-    tokenMock(ddbMock, false);
-
     redshiftClientMock.on(BatchExecuteStatementCommand).resolves({
     });
     redshiftClientMock.on(DescribeStatementCommand).resolves({
@@ -345,7 +342,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -360,8 +357,6 @@ describe('reporting test', () => {
   });
 
   it('funnel visual - publish', async () => {
-    tokenMock(ddbMock, false);
-
     quickSightMock.on(DescribeDashboardDefinitionCommand).resolves({
       Definition: dashboardDef,
     });
@@ -416,7 +411,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -437,7 +432,6 @@ describe('reporting test', () => {
   });
 
   it('funnel visual - XSS check', async () => {
-    tokenMock(ddbMock, false);
     const res = await request(app)
       .post('/api/reporting/funnel')
       .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
@@ -470,7 +464,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -483,7 +477,6 @@ describe('reporting test', () => {
   });
 
   it('event visual - preview', async () => {
-    tokenMock(ddbMock, false);
     quickSightMock.on(CreateAnalysisCommand).resolves({
       Arn: 'arn:aws:quicksight:us-east-1:11111111:analysis/analysisaaaaaaaa',
     });
@@ -540,7 +533,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -563,8 +556,6 @@ describe('reporting test', () => {
   });
 
   it('event visual - preview - twice request with group condition', async () => {
-    tokenMock(ddbMock, false);
-
     quickSightMock.on(CreateDataSetCommand).callsFake(input => {
       expect(
         input.PhysicalTableMap.PhyTable1.CustomSql.Columns.length === 4,
@@ -636,7 +627,7 @@ describe('reporting test', () => {
       },
       dashboardCreateParameters: {
         region: 'us-east-1',
-        allowDomain: 'https://example.com',
+        allowedDomain: 'https://example.com',
         quickSight: {
           dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
         },
@@ -662,7 +653,6 @@ describe('reporting test', () => {
   });
 
   it('event visual - publish', async () => {
-    tokenMock(ddbMock, false);
     quickSightMock.on(DescribeDashboardDefinitionCommand).resolves({
       Definition: dashboardDef,
     });
@@ -718,7 +708,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -738,7 +728,6 @@ describe('reporting test', () => {
   });
 
   it('path visual - preview', async () => {
-    tokenMock(ddbMock, false);
     quickSightMock.on(CreateAnalysisCommand).resolves({
       Arn: 'arn:aws:quicksight:us-east-1:11111111:analysis/analysisaaaaaaaa',
     });
@@ -794,7 +783,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -821,7 +810,6 @@ describe('reporting test', () => {
   });
 
   it('path visual - publish', async () => {
-    tokenMock(ddbMock, false);
     quickSightMock.on(DescribeDashboardDefinitionCommand).resolves({
       Definition: dashboardDef,
       Name: 'dashboard-test',
@@ -883,7 +871,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -910,7 +898,6 @@ describe('reporting test', () => {
   });
 
   it('retention visual - publish', async () => {
-    tokenMock(ddbMock, false);
     quickSightMock.on(DescribeDashboardDefinitionCommand).resolves({
       Definition: dashboardDef,
       Name: 'dashboard-test',
@@ -971,7 +958,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -1010,7 +997,6 @@ describe('reporting test', () => {
   });
 
   it('attribution visual - preview', async () => {
-    tokenMock(ddbMock, false);
     quickSightMock.on(CreateAnalysisCommand).resolves({
       Arn: 'arn:aws:quicksight:us-east-1:11111111:analysis/analysisaaaaaaaa',
     });
@@ -1264,7 +1250,6 @@ describe('reporting test', () => {
   });
 
   it('attribution visual - publish', async () => {
-    tokenMock(ddbMock, false);
     quickSightMock.on(DescribeDashboardDefinitionCommand).resolves({
       Definition: dashboardDef,
       Name: 'dashboard-test',
@@ -1477,7 +1462,7 @@ describe('reporting test', () => {
         timeUnit: 'DD',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -1502,7 +1487,6 @@ describe('reporting test', () => {
   });
 
   it('attribution visual - linear model', async () => {
-    tokenMock(ddbMock, false);
     quickSightMock.on(CreateAnalysisCommand).resolves({
       Arn: 'arn:aws:quicksight:us-east-1:11111111:analysis/analysisaaaaaaaa',
     });
@@ -1756,7 +1740,6 @@ describe('reporting test', () => {
   });
 
   it('attribution visual - position model', async () => {
-    tokenMock(ddbMock, false);
     quickSightMock.on(CreateAnalysisCommand).resolves({
       Arn: 'arn:aws:quicksight:us-east-1:11111111:analysis/analysisaaaaaaaa',
     });
@@ -2080,7 +2063,6 @@ describe('reporting test', () => {
   });
 
   it('clean - ThrottlingException', async () => {
-
     quickSightMock.on(ListDashboardsCommand).resolves({
       DashboardSummaryList: [{
         Arn: 'arn:aws:quicksight:us-east-1:11111111:dashboard/dashboard-aaaaaaaa',
@@ -2352,7 +2334,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -2396,7 +2378,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -2439,7 +2421,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -2482,7 +2464,7 @@ describe('reporting test', () => {
       groupColumn: 'week',
       dashboardCreateParameters: {
         region: 'us-east-1',
-        allowDomain: 'https://example.com',
+        allowedDomain: 'https://example.com',
         quickSight: {
           dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
         },
@@ -2596,7 +2578,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -2642,7 +2624,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -2686,7 +2668,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -2729,7 +2711,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -2765,7 +2747,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -2810,7 +2792,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -2854,7 +2836,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -2899,7 +2881,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -2942,7 +2924,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -2989,7 +2971,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -3038,7 +3020,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -3085,7 +3067,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -3138,7 +3120,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -3189,7 +3171,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -3220,7 +3202,6 @@ describe('reporting test', () => {
   });
 
   it('event visual - preview - same event with different filter', async () => {
-    tokenMock(ddbMock, false);
     quickSightMock.on(CreateAnalysisCommand).resolves({
       Arn: 'arn:aws:quicksight:us-east-1:11111111:analysis/analysisaaaaaaaa',
     });
@@ -3303,7 +3284,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -3326,7 +3307,6 @@ describe('reporting test', () => {
   });
 
   it('retention visual - special chars', async () => {
-    tokenMock(ddbMock, false);
     quickSightMock.on(DescribeDashboardDefinitionCommand).resolves({
       Definition: dashboardDef,
       Name: 'dashboard-test',
@@ -3388,7 +3368,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -3521,7 +3501,6 @@ describe('reporting test', () => {
 
 
   it('retention visual - special chars for like condition', async () => {
-    tokenMock(ddbMock, false);
     quickSightMock.on(DescribeDashboardDefinitionCommand).resolves({
       Definition: dashboardDef,
       Name: 'dashboard-test',
@@ -3544,7 +3523,6 @@ describe('reporting test', () => {
         Name: 'test-analysis',
       },
     });
-
 
     const res = await request(app)
       .post('/api/reporting/retention')
@@ -3583,7 +3561,7 @@ describe('reporting test', () => {
         groupColumn: 'week',
         dashboardCreateParameters: {
           region: 'us-east-1',
-          allowDomain: 'https://example.com',
+          allowedDomain: 'https://example.com',
           quickSight: {
             dataSourceArn: 'arn:aws:quicksight:us-east-1:11111111:datasource/clickstream_datasource_aaaaaaa',
           },
@@ -3712,6 +3690,102 @@ describe('reporting test', () => {
     expect(res.body.data.visualIds.length).toEqual(2);
     expect(quickSightMock).toHaveReceivedCommandTimes(DescribeAnalysisCommand, 0);
 
+  });
+
+  afterAll((done) => {
+    server.close();
+    done();
+  });
+});
+
+describe('reporting test in China region', () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    cloudFormationMock.reset();
+    quickSightMock.reset();
+    redshiftClientMock.reset();
+    tokenMock(ddbMock, false);
+    quickSightUserMock(ddbMock, true);
+  });
+
+  it('funnel bar visual - preview', async () => {
+    quickSightMock.on(CreateAnalysisCommand).resolves({
+      Arn: 'arn:aws-cn:quicksight:cn-north-1:11111111:analysis/analysisaaaaaaaa',
+    });
+    quickSightMock.on(CreateDashboardCommand).resolves({
+      Arn: 'arn:aws-cn:quicksight:cn-north-1:11111111:dashboard/dashboard-aaaaaaaa',
+      VersionArn: 'arn:aws-cn:quicksight:cn-north-1:11111111:dashboard/dashboard-aaaaaaaa/1',
+    });
+    quickSightMock.on(GenerateEmbedUrlForRegisteredUserCommand).resolves({
+      EmbedUrl: 'https://cn-north-1.quicksight.aws.amazon.com/embed/4ui7xyvq73/studies/4a05631e-cbe6-477c-915d-1704aec9f101?isauthcode=true&identityprovider=quicksight&code=4a05631e-cbe6-477c-915d-1704aec9f101',
+    });
+    quickSightMock.on(DescribeDashboardCommand).resolvesOnce({
+      Dashboard: {
+        Version: {
+          Status: ResourceStatus.CREATION_IN_PROGRESS,
+        },
+      },
+    }).resolves({
+      Dashboard: {
+        Version: {
+          Status: ResourceStatus.CREATION_SUCCESSFUL,
+        },
+      },
+    });
+
+    process.env.AWS_REGION = 'cn-north-1';
+    const res = await request(app)
+      .post('/api/reporting/funnel')
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
+      .send({
+        action: 'PREVIEW',
+        chartType: QuickSightChartType.BAR,
+        viewName: 'testview0002',
+        projectId: 'project01_wvzh',
+        pipelineId: 'pipeline-1111111',
+        appId: 'app1',
+        sheetName: 'sheet99',
+        computeMethod: 'USER_ID_CNT',
+        specifyJoinColumn: true,
+        joinColumn: 'user_pseudo_id',
+        conversionIntervalType: 'CUSTOMIZE',
+        conversionIntervalInSeconds: 7200,
+        eventAndConditions: [{
+          eventName: 'add_button_click',
+        },
+        {
+          eventName: 'note_share',
+        },
+        {
+          eventName: 'note_export',
+        }],
+        timeScopeType: 'RELATIVE',
+        lastN: 4,
+        timeUnit: 'WK',
+        groupColumn: 'week',
+        dashboardCreateParameters: {
+          region: 'cn-north-1',
+          allowedDomain: 'https://example.com',
+          quickSight: {
+            dataSourceArn: 'arn:aws-cn:quicksight:cn-north-1:11111111:datasource/clickstream_datasource_aaaaaaa',
+          },
+        },
+      });
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(201);
+    expect(res.body.success).toEqual(true);
+    expect(res.body.data.dashboardArn).toEqual('arn:aws-cn:quicksight:cn-north-1:11111111:dashboard/dashboard-aaaaaaaa');
+    expect(res.body.data.dashboardName).toEqual('_tmp_testview0002');
+    expect(res.body.data.analysisArn).toEqual('arn:aws-cn:quicksight:cn-north-1:11111111:analysis/analysisaaaaaaaa');
+    expect(res.body.data.analysisName).toEqual('_tmp_testview0002');
+    expect(res.body.data.analysisId).toBeDefined();
+    expect(res.body.data.dashboardId).toBeDefined();
+    expect(res.body.data.visualIds).toBeDefined();
+    expect(res.body.data.visualIds.length).toEqual(2);
+    expect(res.body.data.dashboardEmbedUrl).toEqual('https://cn-north-1.quicksight.aws.amazon.com/embed/4ui7xyvq73/studies/4a05631e-cbe6-477c-915d-1704aec9f101?isauthcode=true&identityprovider=quicksight&code=4a05631e-cbe6-477c-915d-1704aec9f101');
+    expect(quickSightMock).toHaveReceivedCommandTimes(DescribeDashboardCommand, 2);
+    expect(quickSightMock).toHaveReceivedCommandTimes(GenerateEmbedUrlForRegisteredUserCommand, 1);
+    process.env.AWS_REGION = undefined;
   });
 
   afterAll((done) => {

--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -443,6 +443,8 @@ const deleteQuickSightDashboard = async (quickSight: QuickSight,
   schema: string,
   dashboardDef: QuickSightDashboardDefProps)
 : Promise<DeleteDashboardCommandOutput|undefined> => {
+  // Delete Folder
+  await deleteFolder(quickSight, accountId, dashboardDef.databaseName, schema);
 
   // Delete Dashboard
   const dashboardId = buildDashBoardId(dashboardDef.databaseName, schema);
@@ -457,36 +459,6 @@ const deleteQuickSightDashboard = async (quickSight: QuickSight,
   const databaseName = dashboardDef.databaseName;
   for ( const dataSet of dataSets) {
     await deleteDataSet(quickSight, accountId, schema, databaseName, dataSet);
-  }
-
-  let deleteFolder: boolean = true;
-  await quickSight.listFolderMembers({
-    AwsAccountId: accountId,
-    FolderId: getQuickSightFolderId(databaseName, schema),
-  }).then(async (data) => {
-    if (data !== undefined && data.FolderMemberList !== undefined) {
-      for (const member of data.FolderMemberList) {
-        if (!member.MemberId?.startsWith(QUICKSIGHT_RESOURCE_NAME_PREFIX)) {
-          deleteFolder = false;
-          continue;
-        }
-        const memberType = getMemberType(member.MemberArn!, member.MemberId);
-        await quickSight.deleteFolderMembership({
-          AwsAccountId: accountId,
-          FolderId: getQuickSightFolderId(databaseName, schema),
-          MemberId: member.MemberId,
-          MemberType: memberType,
-        });
-      }
-    }
-  });
-
-  //delete folder
-  if (deleteFolder) {
-    await quickSight.deleteFolder({
-      AwsAccountId: accountId,
-      FolderId: getQuickSightFolderId(databaseName, schema),
-    });
   }
 
   return result;
@@ -871,6 +843,52 @@ const createDashboard = async (quickSight: QuickSight, commonParams: ResourceCom
 
   } catch (err: any) {
     logger.error(`Create QuickSight dashboard failed due to: ${(err as Error).message}`);
+    throw err;
+  }
+};
+
+const deleteFolder = async (quickSight: QuickSight, awsAccountId: string, databaseName: string, schema: string): Promise<void> => {
+  let needDeleteFolder: boolean = true;
+  const res = await quickSight.listFolderMembers({
+    AwsAccountId: awsAccountId,
+    FolderId: getQuickSightFolderId(databaseName, schema),
+  });
+  if (res && res.FolderMemberList) {
+    for (const member of res.FolderMemberList) {
+      if (!member.MemberId?.startsWith(QUICKSIGHT_RESOURCE_NAME_PREFIX)) {
+        needDeleteFolder = false;
+        continue;
+      }
+      await deleteFolderMembership(quickSight, awsAccountId, member.MemberArn!, member.MemberId, databaseName, schema);
+    }
+  }
+
+  //delete folder
+  if (needDeleteFolder) {
+    await quickSight.deleteFolder({
+      AwsAccountId: awsAccountId,
+      FolderId: getQuickSightFolderId(databaseName, schema),
+    });
+  }
+};
+
+const deleteFolderMembership = async (quickSight: QuickSight, awsAccountId: string,
+  memberArn: string, memberId: string,
+  databaseName: string, schema: string): Promise<void> => {
+  try {
+    const memberType = getMemberType(memberArn, memberId);
+    await quickSight.deleteFolderMembership({
+      AwsAccountId: awsAccountId,
+      FolderId: getQuickSightFolderId(databaseName, schema),
+      MemberId: memberId,
+      MemberType: memberType,
+    });
+  } catch (err: any) {
+    if ((err as Error) instanceof ResourceNotFoundException) {
+      logger.info('Folder membership not exist. skip delete operation.');
+      return;
+    }
+    logger.error(`Delete QuickSight folder membership failed due to: ${(err as Error).message}`);
     throw err;
   }
 };

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -786,30 +786,6 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
       PolicyDocument: {
         Statement: [
           {
-            Action: [
-              'logs:CreateLogDelivery',
-              'logs:GetLogDelivery',
-              'logs:UpdateLogDelivery',
-              'logs:DeleteLogDelivery',
-              'logs:ListLogDeliveries',
-              'logs:PutResourcePolicy',
-              'logs:DescribeResourcePolicies',
-              'logs:DescribeLogGroups',
-            ],
-            Effect: 'Allow',
-            Resource: '*',
-          },
-          {
-            Action: [
-              'xray:PutTraceSegments',
-              'xray:PutTelemetryRecords',
-              'xray:GetSamplingRules',
-              'xray:GetSamplingTargets',
-            ],
-            Effect: 'Allow',
-            Resource: '*',
-          },
-          {
             Action: 'lambda:InvokeFunction',
             Effect: 'Allow',
             Resource: [
@@ -834,6 +810,30 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
                 ],
               },
             ],
+          },
+          {
+            Action: [
+              'logs:CreateLogDelivery',
+              'logs:GetLogDelivery',
+              'logs:UpdateLogDelivery',
+              'logs:DeleteLogDelivery',
+              'logs:ListLogDeliveries',
+              'logs:PutResourcePolicy',
+              'logs:DescribeResourcePolicies',
+              'logs:DescribeLogGroups',
+            ],
+            Effect: 'Allow',
+            Resource: '*',
+          },
+          {
+            Action: [
+              'xray:PutTraceSegments',
+              'xray:PutTelemetryRecords',
+              'xray:GetSamplingRules',
+              'xray:GetSamplingTargets',
+            ],
+            Effect: 'Allow',
+            Resource: '*',
           },
         ],
         Version: '2012-10-17',

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -786,6 +786,30 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
       PolicyDocument: {
         Statement: [
           {
+            Action: [
+              'logs:CreateLogDelivery',
+              'logs:GetLogDelivery',
+              'logs:UpdateLogDelivery',
+              'logs:DeleteLogDelivery',
+              'logs:ListLogDeliveries',
+              'logs:PutResourcePolicy',
+              'logs:DescribeResourcePolicies',
+              'logs:DescribeLogGroups',
+            ],
+            Effect: 'Allow',
+            Resource: '*',
+          },
+          {
+            Action: [
+              'xray:PutTraceSegments',
+              'xray:PutTelemetryRecords',
+              'xray:GetSamplingRules',
+              'xray:GetSamplingTargets',
+            ],
+            Effect: 'Allow',
+            Resource: '*',
+          },
+          {
             Action: 'lambda:InvokeFunction',
             Effect: 'Allow',
             Resource: [
@@ -810,30 +834,6 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
                 ],
               },
             ],
-          },
-          {
-            Action: [
-              'logs:CreateLogDelivery',
-              'logs:GetLogDelivery',
-              'logs:UpdateLogDelivery',
-              'logs:DeleteLogDelivery',
-              'logs:ListLogDeliveries',
-              'logs:PutResourcePolicy',
-              'logs:DescribeResourcePolicies',
-              'logs:DescribeLogGroups',
-            ],
-            Effect: 'Allow',
-            Resource: '*',
-          },
-          {
-            Action: [
-              'xray:PutTraceSegments',
-              'xray:PutTelemetryRecords',
-              'xray:GetSamplingRules',
-              'xray:GetSamplingTargets',
-            ],
-            Effect: 'Allow',
-            Resource: '*',
           },
         ],
         Version: '2012-10-17',

--- a/test/control-plane/cloudfront-control-plane-stack.test.ts
+++ b/test/control-plane/cloudfront-control-plane-stack.test.ts
@@ -650,7 +650,7 @@ describe('CloudFrontS3PortalStack - Default stack props for common features', ()
                   {
                     Ref: 'AWS::Partition',
                   },
-                  '.amazon.com;',
+                  '.amazon.com cn-north-1.quicksight.amazonaws.cn cn-northwest-1.quicksight.amazonaws.cn;',
                 ],
               ],
             },


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. If it is the third step of creating pipelines in China regions, a user must be selected to create preset QuickSight resources. And global region unchanged.
2. Backend pass the selected user to reporting stack.
3. Analytics Studio embedding user change to the selected user in China regions.

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend