### PR TITLE
fix: failure of building frontend image for web console deployment within vpc

### DIFF
--- a/src/control-plane/backend/Dockerfile
+++ b/src/control-plane/backend/Dockerfile
@@ -6,7 +6,6 @@ COPY src src
 COPY package.json package.json
 COPY pnpm-lock.yaml pnpm-lock.yaml
 COPY nx.json nx.json
-COPY .projenrc.js .projenrc.js
 COPY projenrc projenrc
 COPY pnpm-workspace.yaml pnpm-workspace.yaml
 

--- a/src/control-plane/backend/Dockerfile
+++ b/src/control-plane/backend/Dockerfile
@@ -6,6 +6,7 @@ COPY src src
 COPY package.json package.json
 COPY pnpm-lock.yaml pnpm-lock.yaml
 COPY nx.json nx.json
+COPY .projenrc.js .projenrc.js
 COPY projenrc projenrc
 COPY pnpm-workspace.yaml pnpm-workspace.yaml
 

--- a/src/control-plane/frontend/Dockerfile
+++ b/src/control-plane/frontend/Dockerfile
@@ -6,6 +6,7 @@ COPY src src
 COPY package.json package.json
 COPY pnpm-lock.yaml pnpm-lock.yaml
 COPY nx.json nx.json
+COPY .projenrc.js .projenrc.js
 COPY projenrc projenrc
 COPY pnpm-workspace.yaml pnpm-workspace.yaml
 

--- a/src/control-plane/frontend/Dockerfile
+++ b/src/control-plane/frontend/Dockerfile
@@ -26,7 +26,7 @@ RUN pnpm run crabuild
 
 FROM public.ecr.aws/docker/library/nginx:1.22
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.6.1	/lambda-adapter /opt/extensions/lambda-adapter
-COPY --from=builder /home/node/app/build/ /usr/share/nginx/public/
+COPY --from=builder /home/node/app/frontend/build/ /usr/share/nginx/public/
 COPY src/control-plane/frontend/config/ /etc/nginx/
 USER nginx
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend