### PR TITLE
fix: do not select QuickSight users when deploying in global regions

### DIFF
--- a/frontend/src/pages/pipelines/create/CreatePipeline.tsx
+++ b/frontend/src/pages/pipelines/create/CreatePipeline.tsx
@@ -650,7 +650,11 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
       return false;
     }
 
-    if (pipelineInfo.enableReporting && !pipelineInfo.selectedQuickSightUser) {
+    if (
+      pipelineInfo.region.startsWith('cn') &&
+      pipelineInfo.enableReporting &&
+      !pipelineInfo.selectedQuickSightUser
+    ) {
       setQuickSightUserEmptyError(true);
       return false;
     }

--- a/frontend/src/pages/pipelines/create/steps/Reporting.tsx
+++ b/frontend/src/pages/pipelines/create/steps/Reporting.tsx
@@ -237,7 +237,8 @@ const Reporting: React.FC<ReportingProps> = (props: ReportingProps) => {
                         </Alert>
                       )}
 
-                      {pipelineInfo.enableReporting &&
+                      {pipelineInfo.region.startsWith('cn') &&
+                        pipelineInfo.enableReporting &&
                         quickSightEnabled &&
                         quickSightEnterprise && (
                           <>

--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -118,8 +118,8 @@ interface IngestionServerLoadBalancerProps {
 
 interface IngestionServerSinkS3Props {
   readonly sinkBucket: S3Bucket;
-  readonly s3BatchMaxBytes?: number;
-  readonly s3BatchTimeout?: number;
+  readonly s3BufferSize?: number;
+  readonly s3BufferInterval?: number;
 }
 
 interface IngestionServerSinkKafkaProps {

--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -275,8 +275,8 @@ export class CIngestionServerStack extends JSONObject {
   @JSONObject.optional(30000000)
   @JSONObject.gte(1000000)
   @JSONObject.lte(50000000)
-  @JSONObject.custom( (stack:CIngestionServerStack, _key:string, value:string) => {
-    return stack._pipeline?.ingestionServer.sinkType == PipelineSinkType.S3 ? value : undefined;
+  @JSONObject.custom( (stack:CIngestionServerStack, _key:string, value:number) => {
+    return stack._pipeline?.ingestionServer.sinkType == PipelineSinkType.S3 ? value * 1000 * 1000 : undefined;
   })
     S3BatchMaxBytes?: number;
 
@@ -445,8 +445,8 @@ export class CIngestionServerStack extends JSONObject {
       // S3 sink
       S3DataBucket: pipeline.ingestionServer.sinkS3?.sinkBucket.name ?? pipeline.bucket.name,
       S3DataPrefix: getBucketPrefix(pipeline.projectId, BucketPrefix.DATA_BUFFER, pipeline.ingestionServer.sinkS3?.sinkBucket.prefix),
-      S3BatchMaxBytes: pipeline.ingestionServer.sinkS3?.s3BatchMaxBytes,
-      S3BatchTimeout: pipeline.ingestionServer.sinkS3?.s3BatchTimeout,
+      S3BatchMaxBytes: pipeline.ingestionServer.sinkS3?.s3BufferSize,
+      S3BatchTimeout: pipeline.ingestionServer.sinkS3?.s3BufferInterval,
       // Kafka sink
       MskClusterName: pipeline.ingestionServer.sinkKafka?.mskCluster?.name,
       MskSecurityGroupId: pipeline.ingestionServer.sinkKafka?.securityGroupId,

--- a/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
@@ -128,8 +128,8 @@ export const S3_INGESTION_PIPELINE: IPipeline = {
         name: 'EXAMPLE_BUCKET',
         prefix: '',
       },
-      s3BatchMaxBytes: 1000000,
-      s3BatchTimeout: 60,
+      s3BufferSize: 10,
+      s3BufferInterval: 60,
     },
     loadBalancer: {
       ...BASE_PIPELINE_ATTRIBUTES.ingestionServer.loadBalancer,
@@ -155,8 +155,8 @@ export const S3_INGESTION_HTTP_AUTHENTICATION_PIPELINE: IPipeline = {
         name: 'EXAMPLE_BUCKET',
         prefix: '',
       },
-      s3BatchMaxBytes: 1000000,
-      s3BatchTimeout: 60,
+      s3BufferSize: 10,
+      s3BufferInterval: 60,
     },
     loadBalancer: {
       ...BASE_PIPELINE_ATTRIBUTES.ingestionServer.loadBalancer,
@@ -294,8 +294,8 @@ export const S3_DATA_PROCESSING_WITH_ERROR_PREFIX_PIPELINE: IPipeline = {
         name: 'EXAMPLE_BUCKET',
         prefix: 'EXAMPLE_PREFIX_ERROR',
       },
-      s3BatchMaxBytes: 1000000,
-      s3BatchTimeout: 60,
+      s3BufferSize: 10,
+      s3BufferInterval: 60,
     },
     loadBalancer: {
       ...BASE_PIPELINE_ATTRIBUTES.ingestionServer.loadBalancer,
@@ -342,8 +342,8 @@ export const S3_DATA_PROCESSING_WITH_SPECIFY_PREFIX_PIPELINE: IPipeline = {
         name: 'EXAMPLE_BUCKET_NEW',
         prefix: '',
       },
-      s3BatchMaxBytes: 1000000,
-      s3BatchTimeout: 60,
+      s3BufferSize: 10,
+      s3BufferInterval: 60,
     },
     loadBalancer: {
       ...BASE_PIPELINE_ATTRIBUTES.ingestionServer.loadBalancer,

--- a/src/control-plane/backend/lambda/api/test/api/pipeline-status.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline-status.test.ts
@@ -31,8 +31,8 @@ const BASE_STATUS_PIPELINE: IPipeline = {
         name: 'EXAMPLE_BUCKET',
         prefix: '',
       },
-      s3BatchMaxBytes: 1000000,
-      s3BatchTimeout: 60,
+      s3BufferSize: 10,
+      s3BufferInterval: 60,
     },
   },
 };

--- a/src/control-plane/backend/lambda/api/test/api/store.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/store.test.ts
@@ -265,10 +265,10 @@ describe('App test', () => {
               },
               sinkS3: {
                 M: {
-                  s3BatchMaxBytes: {
-                    N: '1000000',
+                  s3BufferSize: {
+                    N: '10',
                   },
-                  s3BatchTimeout: {
+                  s3BufferInterval: {
                     N: '60',
                   },
                   sinkBucket: {
@@ -541,10 +541,10 @@ describe('App test', () => {
           },
           sinkS3: {
             M: {
-              s3BatchMaxBytes: {
-                N: '1000000',
+              s3BufferSize: {
+                N: '10',
               },
-              s3BatchTimeout: {
+              s3BufferInterval: {
                 N: '60',
               },
               sinkBucket: {

--- a/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
@@ -170,7 +170,7 @@ export const INGESTION_S3_PARAMETERS = mergeParameters(
     },
     {
       ParameterKey: 'S3BatchMaxBytes',
-      ParameterValue: '1000000',
+      ParameterValue: '10000000',
     },
     {
       ParameterKey: 'S3BatchTimeout',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend