### PR TITLE
chore: run streaming flink unit tests in script

### DIFF
--- a/deployment/run-unit-tests.sh
+++ b/deployment/run-unit-tests.sh
@@ -29,3 +29,5 @@ pnpm --dir frontend run test
 
 docker run -i --rm -v `pwd`/src/data-pipeline/spark-etl/:/data --workdir /data \
   public.ecr.aws/docker/library/gradle:7.6-jdk17 gradle test jacocoAggregatedReport
+docker run -i --rm -v `pwd`/src/streaming-ingestion/flink-etl/:/data --workdir /data \
+  public.ecr.aws/docker/library/gradle:7.6-jdk11 gradle clean build jacocoAggregatedReport

--- a/src/common/s3-asset.ts
+++ b/src/common/s3-asset.ts
@@ -24,6 +24,7 @@ export function uploadBuiltInJarsAndRemoteFiles(
   shadowJar: boolean,
   destinationBucket: IBucket,
   destinationKeyPrefix: string,
+  buildImage: string = 'public.ecr.aws/docker/library/gradle:7.6-jdk17',
   additionalBuildArgument: string = '',
   remoteFiles: string[] = ['https://cdn.jsdelivr.net/npm/geolite2-city@1.0.0/GeoLite2-City.mmdb.gz'],
 ) {
@@ -47,7 +48,7 @@ export function uploadBuiltInJarsAndRemoteFiles(
 
   let bundling: BundlingOptions = {
     user: 'gradle',
-    image: DockerImage.fromRegistry('public.ecr.aws/docker/library/gradle:7.6-jdk17'),
+    image: DockerImage.fromRegistry(buildImage),
     command: ['sh', '-c', shellCommands.join(' && ')],
   };
 

--- a/src/streaming-ingestion-stack.ts
+++ b/src/streaming-ingestion-stack.ts
@@ -99,6 +99,7 @@ export class StreamingIngestionStack extends Stack {
       true,
       dataBucket,
       appPrefix,
+      'public.ecr.aws/docker/library/gradle:7.6-jdk11',
     );
 
     // create managed flink application


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend