### PR TITLE
fix: fail to upgrade existing pipeline to latest reporting stack

### DIFF
--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -1147,7 +1147,7 @@ export class CReportingStack extends JSONObject {
   @JSONObject.required
     QuickSightOwnerPrincipalParam?: string;
 
-  @JSONObject.optional('dev')
+  @JSONObject.required
     RedshiftDBParam?: string;
 
   @JSONObject.required
@@ -1226,6 +1226,7 @@ export class CReportingStack extends JSONObject {
       QuickSightNamespaceParam: pipeline.reporting?.quickSight?.namespace,
       QuickSightPrincipalParam: resources.quickSightUser?.publishUserArn,
       QuickSightOwnerPrincipalParam: resources.quickSightUser?.publishUserArn,
+      RedshiftDBParam: pipeline.projectId,
       RedShiftDBSchemaParam: resources.appIds?.join(','),
       QuickSightVpcConnectionSubnetParam: resources.quickSightSubnetIds?.join(','),
       RedshiftParameterKeyParam: getValueFromStackOutputSuffix(

--- a/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
@@ -940,7 +940,7 @@ const BASE_REPORTING_PARAMETERS = [
   },
   {
     ParameterKey: 'RedshiftDBParam',
-    ParameterValue: 'dev',
+    ParameterValue: 'project_8888_8888',
   },
   {
     ParameterKey: 'RedShiftDBSchemaParam',
@@ -996,7 +996,7 @@ export const REPORTING_WITH_NEW_REDSHIFT_PARAMETERS = [
   },
   {
     ParameterKey: 'RedshiftDBParam',
-    ParameterValue: 'dev',
+    ParameterValue: 'project_8888_8888',
   },
   {
     ParameterKey: 'RedShiftDBSchemaParam',

--- a/src/data-reporting-quicksight-stack.ts
+++ b/src/data-reporting-quicksight-stack.ts
@@ -143,7 +143,7 @@ export class DataReportingQuickSightStack extends Stack {
       },
       dataSourceParameters: {
         redshiftParameters: {
-          database: stackParams.redshiftDBParam.valueAsString,
+          database: stackParams.redshiftDefaultDBParam.valueAsString,
           host: stackParams.redshiftEndpointParam.valueAsString,
           port: stackParams.redshiftPortParam.valueAsNumber,
         },

--- a/src/reporting/parameter.ts
+++ b/src/reporting/parameter.ts
@@ -101,12 +101,22 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
   const redshiftDBParam = new CfnParameter(scope, 'RedshiftDBParam', {
     description: 'Redshift database name.',
     type: 'String',
-    default: 'dev',
     allowedPattern: REDSHIFT_DB_NAME_PATTERN,
     constraintDescription: `Redshift database name must match ${REDSHIFT_DB_NAME_PATTERN}`,
   });
   labels[redshiftDBParam.logicalId] = {
     default: 'Redshift Database Name',
+  };
+
+  const redshiftDefaultDBParam = new CfnParameter(scope, 'RedshiftDefaultDBParam', {
+    description: 'Redshift default database name.',
+    type: 'String',
+    default: 'dev',
+    allowedPattern: REDSHIFT_DB_NAME_PATTERN,
+    constraintDescription: `Redshift default database name must match ${REDSHIFT_DB_NAME_PATTERN}`,
+  });
+  labels[redshiftDefaultDBParam.logicalId] = {
+    default: 'Redshift Default Database Name',
   };
 
   const redShiftDBSchemaParam = new CfnParameter(scope, 'RedShiftDBSchemaParam', {
@@ -162,6 +172,7 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
       redshiftEndpointParam.logicalId,
       redshiftDBParam.logicalId,
       redShiftDBSchemaParam.logicalId,
+      redShiftDBSchemaParam.logicalId,
       redshiftPortParam.logicalId,
       redshiftParameterKeyParam.logicalId,
     ],
@@ -177,6 +188,7 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
     quickSightTemplateArnParam,
     redshiftEndpointParam,
     redshiftDBParam,
+    redshiftDefaultDBParam,
     redShiftDBSchemaParam,
     redshiftPortParam,
     redshiftParameterKeyParam,

--- a/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
+++ b/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
@@ -77,6 +77,13 @@ describe('DataReportingQuickSightStack parameter test', () => {
     });
   });
 
+  test('Should has Parameter redshiftDefaultDBParam', () => {
+    template.hasParameter('RedshiftDefaultDBParam', {
+      Type: 'String',
+      Default: 'dev',
+    });
+  });
+
   test('Should has Parameter redshiftPortParam', () => {
     template.hasParameter('RedshiftPortParam', {
       Type: 'Number',
@@ -822,7 +829,7 @@ describe('DataReportingQuickSightStack resource test', () => {
     DataSourceParameters: {
       RedshiftParameters: {
         Database: {
-          Ref: 'RedshiftDBParam',
+          Ref: 'RedshiftDefaultDBParam',
         },
         Host: {
           Ref: 'RedshiftEndpointParam',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend