### PR TITLE
chore: remove duplicated database schema parameter in reporting stack

### DIFF
--- a/src/reporting/parameter.ts
+++ b/src/reporting/parameter.ts
@@ -120,7 +120,7 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
   };
 
   const redShiftDBSchemaParam = new CfnParameter(scope, 'RedShiftDBSchemaParam', {
-    description: 'Comma delimited Redshift database schema name list ',
+    description: 'Comma delimited Redshift database schema name list',
     type: 'String',
     allowedPattern: MULTI_APP_ID_PATTERN,
     constraintDescription: `Redshift database schema name must match ${MULTI_APP_ID_PATTERN}`,
@@ -170,8 +170,8 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
     Label: { default: 'Redshift Information' },
     Parameters: [
       redshiftEndpointParam.logicalId,
+      redshiftDefaultDBParam.logicalId,
       redshiftDBParam.logicalId,
-      redShiftDBSchemaParam.logicalId,
       redShiftDBSchemaParam.logicalId,
       redshiftPortParam.logicalId,
       redshiftParameterKeyParam.logicalId,

--- a/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
+++ b/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
@@ -84,6 +84,13 @@ describe('DataReportingQuickSightStack parameter test', () => {
     });
   });
 
+  test('Should has Parameter redShiftDBSchemaParam', () => {
+    template.hasParameter('RedShiftDBSchemaParam', {
+      Description: 'Comma delimited Redshift database schema name list',
+      Type: 'String',
+    });
+  });
+
   test('Should has Parameter redshiftPortParam', () => {
     template.hasParameter('RedshiftPortParam', {
       Type: 'Number',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend