### PR TITLE
fix: assign wrong QuickSight user when editing existing pipeline created by previous version

### DIFF
--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -21,7 +21,7 @@ import {
 } from '@aws/clickstream-base-lib';
 import { Tag } from '@aws-sdk/client-cloudformation';
 import { ExecutionStatus } from '@aws-sdk/client-sfn';
-import { getDiff } from 'json-difference';
+import { EditedPath, getDiff } from 'json-difference';
 import { IDictionary } from './dictionary';
 import { IPlugin } from './plugin';
 import { IProject } from './project';
@@ -367,10 +367,8 @@ export class CPipeline {
     this.pipeline.templateVersion = oldPipeline.templateVersion;
     validateIngestionServerNum(this.pipeline.ingestionServer.size);
     const executionName = getStateMachineExecutionName(this.pipeline.pipelineId);
-    const { editStacks, editParameters } = await this._getEditStacksAndParameters(oldPipeline);
-    // update workflow
-    this.stackManager.updateWorkflowParameters(editParameters);
-    this.stackManager.updateWorkflowAction(editStacks);
+    // update parameters
+    await this._mergeUpdateParameters(oldPipeline);
     // enable reporting
     await this._updateReporting(oldPipeline);
     // update tags
@@ -404,13 +402,49 @@ export class CPipeline {
     }
   }
 
-  private async _getEditStacksAndParameters(oldPipeline: IPipeline):
-  Promise<{ editStacks: string[]; editParameters: StackUpdateParameter[] }> {
+  private async _mergeUpdateParameters(oldPipeline: IPipeline): Promise<void> {
+    // generate parameters accroding to current control plane version
     const newWorkflow = await this.generateWorkflow();
     const newStackParameters = this.stackManager.getWorkflowStackParametersMap(newWorkflow.Workflow);
     const oldStackParameters = this.stackManager.getWorkflowStackParametersMap(oldPipeline.workflow?.Workflow!);
-    const diffParameters = getDiff(newStackParameters, oldStackParameters);
+    // get diff parameters
+    const diffParameters = getDiff(oldStackParameters, newStackParameters);
+    const editedParameters = diffParameters.edited;
 
+    this._checkParametersAllowEdit(editedParameters);
+
+    this._overwriteParameters(editedParameters, oldPipeline);
+
+  }
+
+  private _overwriteParameters(editedParameters: EditedPath[], oldPipeline: IPipeline): void {
+    const editKeys: string[] = editedParameters.map((p: EditedPath) => p[0]);
+    const editStacks: string[] = [];
+    const editParameters: StackUpdateParameter[] = [];
+    console.log('editedParameters:', editedParameters);
+    for (let key of editKeys) {
+      const stackName = key.split('.')[0];
+      const paramName = key.split('.')[1];
+      const parameterValue = editedParameters.find((p: EditedPath) => p[0] === key)?.[2];
+      if (stackName.startsWith(`${getStackPrefix()}-${PipelineStackType.REPORTING}`) &&
+      !oldPipeline.region.startsWith('cn')) {
+        continue; // skip reporting stack
+      }
+      if (!editStacks.includes(stackName)) {
+        editStacks.push(stackName);
+      }
+      editParameters.push({
+        stackName: stackName,
+        parameterKey: paramName,
+        parameterValue: parameterValue,
+      });
+    }
+    // update workflow
+    this.stackManager.updateWorkflowParameters(editParameters);
+    this.stackManager.updateWorkflowAction(editStacks);
+  }
+
+  private _checkParametersAllowEdit(editedParameters: EditedPath[]): void {
     // AllowedList
     const AllowedList: string[] = [
       ...CIngestionServerStack.editAllowedList(),
@@ -420,37 +454,19 @@ export class CPipeline {
       ...CReportingStack.editAllowedList(),
       ...CMetricsStack.editAllowedList(),
     ];
-    const editKeys = diffParameters.edited.map((p: any[]) => p[0]);
+
+    const editKeys: string[] = editedParameters.map((p: EditedPath) => p[0]);
+    // check editKeys all in AllowedList
     const notAllowEdit: string[] = [];
-    const editStacks: string[] = [];
-    const editParameters: StackUpdateParameter[] = [];
     for (let key of editKeys) {
-      const stackName = key.split('.')[0];
       const paramName = key.split('.')[1];
-      if (stackName.startsWith(`${getStackPrefix()}-${PipelineStackType.REPORTING}`) && oldPipeline.templateVersion?.startsWith('v1.0')) {
-        continue; // skip reporting stack when template version is v1.0
-      }
-      if (!editStacks.includes(stackName)) {
-        editStacks.push(stackName);
-      }
       if (!AllowedList.includes(paramName)) {
         notAllowEdit.push(paramName);
-      } else {
-        editParameters.push({
-          stackName: stackName,
-          parameterKey: paramName,
-          parameterValue: diffParameters.edited.find((p: any[]) => p[0] === key)?.[1],
-        });
       }
     }
     if (!isEmpty(notAllowEdit)) {
       throw new ClickStreamBadRequestError(`Property modification not allowed: ${notAllowEdit.join(',')}.`);
     }
-
-    return {
-      editStacks,
-      editParameters,
-    };
   }
 
   private _editStackTags(oldPipeline: IPipeline): boolean {

--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -421,7 +421,6 @@ export class CPipeline {
     const editKeys: string[] = editedParameters.map((p: EditedPath) => p[0]);
     const editStacks: string[] = [];
     const editParameters: StackUpdateParameter[] = [];
-    console.log('editedParameters:', editedParameters);
     for (let key of editKeys) {
       const stackName = key.split('.')[0];
       const paramName = key.split('.')[1];

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -3189,6 +3189,87 @@ describe('Pipeline test', () => {
       message: 'Pipeline updated.',
     });
   });
+  it('Update pipeline remain reporting parameters in global region', async () => {
+    tokenMock(ddbMock, false);
+    projectExistedMock(ddbMock, true);
+    dictionaryMock(ddbMock);
+    createPipelineMock(mockClients, {
+      publicAZContainPrivateAZ: true,
+      subnetsCross3AZ: true,
+      subnetsIsolated: false,
+      update: true,
+      updatePipeline: {
+        ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_UPDATE_PIPELINE_WITH_WORKFLOW,
+        templateVersion: 'v1.0.0',
+        tags: [
+          { key: BuiltInTagKeys.AWS_SOLUTION_VERSION, value: 'v1.0.0' },
+        ],
+      },
+    });
+    cloudFormationMock.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackName: 'xxx',
+          Outputs: [
+            {
+              OutputKey: 'IngestionServerC000IngestionServerURL',
+              OutputValue: 'http://xxx/xxx',
+            },
+            {
+              OutputKey: 'IngestionServerC000IngestionServerDNS',
+              OutputValue: 'yyy/yyy',
+            },
+            {
+              OutputKey: 'Dashboards',
+              OutputValue: '[{"appId":"app1","dashboardId":"clickstream_dashboard_v1_notepad_mtzfsocy_app1"},{"appId":"app2","dashboardId":"clickstream_dashboard_v1_notepad_mtzfsocy_app2"}]',
+            },
+            {
+              OutputKey: 'ObservabilityDashboardName',
+              OutputValue: 'clickstream_dashboard_notepad_mtzfsocy',
+            },
+          ],
+          StackStatus: StackStatus.CREATE_COMPLETE,
+          CreationTime: new Date(),
+        },
+      ],
+    });
+
+    ddbMock.on(TransactWriteItemsCommand).callsFake(input => {
+      const expressionAttributeValues = input.TransactItems[1].Update.ExpressionAttributeValues;
+      const reportInput = expressionAttributeValues[':workflow'].M.Workflow.M.Branches.L[1].M.States.M.Reporting.M.Data.M.Input;
+      expect(
+        expressionAttributeValues[':templateVersion'].S === 'v1.0.0' &&
+        expressionAttributeValues[':tags'].L[0].M.value.S === 'v1.0.0' &&
+        reportInput.M.Parameters.L[0].M.ParameterValue.S === 'Admin/fakeUser' &&
+        reportInput.M.Parameters.L[1].M.ParameterValue.S === 'arn:aws:quicksight:us-west-2:555555555555:user/default/Admin/fakeUser',
+      ).toBeTruthy();
+    });
+    const res = await request(app)
+      .put(`/api/pipeline/${MOCK_PIPELINE_ID}`)
+      .send({
+        ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_UPDATE_PIPELINE_WITH_WORKFLOW,
+        ingestionServer: {
+          ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_UPDATE_PIPELINE_WITH_WORKFLOW.ingestionServer,
+          loadBalancer: {
+            ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_UPDATE_PIPELINE_WITH_WORKFLOW.ingestionServer.loadBalancer,
+            enableApplicationLoadBalancerAccessLog: false,
+          },
+        },
+        reporting: {
+          ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_UPDATE_PIPELINE_WITH_WORKFLOW.reporting,
+        },
+      });
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 6);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toEqual({
+      data: {
+        id: MOCK_PIPELINE_ID,
+      },
+      success: true,
+      message: 'Pipeline updated.',
+    });
+  });
   it('Update pipeline reporting user in GCR region', async () => {
     tokenMock(ddbMock, false);
     projectExistedMock(ddbMock, true);

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -3189,6 +3189,96 @@ describe('Pipeline test', () => {
       message: 'Pipeline updated.',
     });
   });
+  it('Update pipeline reporting user in GCR region', async () => {
+    tokenMock(ddbMock, false);
+    projectExistedMock(ddbMock, true);
+    dictionaryMock(ddbMock);
+    createPipelineMock(mockClients, {
+      publicAZContainPrivateAZ: true,
+      subnetsCross3AZ: true,
+      subnetsIsolated: false,
+      update: true,
+      updatePipeline: {
+        ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_UPDATE_PIPELINE_WITH_WORKFLOW,
+        region: 'cn-north-1',
+        templateVersion: 'v1.0.0',
+        tags: [
+          { key: BuiltInTagKeys.AWS_SOLUTION_VERSION, value: 'v1.0.0' },
+        ],
+      },
+      bucket: {
+        location: BucketLocationConstraint.cn_north_1,
+      },
+    });
+    cloudFormationMock.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackName: 'xxx',
+          Outputs: [
+            {
+              OutputKey: 'IngestionServerC000IngestionServerURL',
+              OutputValue: 'http://xxx/xxx',
+            },
+            {
+              OutputKey: 'IngestionServerC000IngestionServerDNS',
+              OutputValue: 'yyy/yyy',
+            },
+            {
+              OutputKey: 'Dashboards',
+              OutputValue: '[{"appId":"app1","dashboardId":"clickstream_dashboard_v1_notepad_mtzfsocy_app1"},{"appId":"app2","dashboardId":"clickstream_dashboard_v1_notepad_mtzfsocy_app2"}]',
+            },
+            {
+              OutputKey: 'ObservabilityDashboardName',
+              OutputValue: 'clickstream_dashboard_notepad_mtzfsocy',
+            },
+          ],
+          StackStatus: StackStatus.CREATE_COMPLETE,
+          CreationTime: new Date(),
+        },
+      ],
+    });
+
+    ddbMock.on(TransactWriteItemsCommand).callsFake(input => {
+      const expressionAttributeValues = input.TransactItems[1].Update.ExpressionAttributeValues;
+      const reportInput = expressionAttributeValues[':workflow'].M.Workflow.M.Branches.L[1].M.States.M.Reporting.M.Data.M.Input;
+      expect(
+        expressionAttributeValues[':templateVersion'].S === 'v1.0.0' &&
+        expressionAttributeValues[':tags'].L[0].M.value.S === 'v1.0.0' &&
+        reportInput.M.Parameters.L[0].M.ParameterValue.S === 'GCRUser' &&
+        reportInput.M.Parameters.L[1].M.ParameterValue.S === 'arn:aws:quicksight:us-east-1:555555555555:user/default/QuickSightEmbeddingRole/GCRUser',
+      ).toBeTruthy();
+    });
+    const res = await request(app)
+      .put(`/api/pipeline/${MOCK_PIPELINE_ID}`)
+      .send({
+        ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_UPDATE_PIPELINE_WITH_WORKFLOW,
+        ingestionServer: {
+          ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_UPDATE_PIPELINE_WITH_WORKFLOW.ingestionServer,
+          loadBalancer: {
+            ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_UPDATE_PIPELINE_WITH_WORKFLOW.ingestionServer.loadBalancer,
+            enableApplicationLoadBalancerAccessLog: false,
+          },
+        },
+        region: 'cn-north-1',
+        reporting: {
+          ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_UPDATE_PIPELINE_WITH_WORKFLOW.reporting,
+          quickSight: {
+            accountName: 'mockAccount',
+            user: 'arn:aws:quicksight:us-east-1:555555555555:user/default/QuickSightEmbeddingRole/GCRUser',
+          },
+        },
+      });
+    expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 6);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toEqual({
+      data: {
+        id: MOCK_PIPELINE_ID,
+      },
+      success: true,
+      message: 'Pipeline updated.',
+    });
+  });
   it('Update pipeline v1.0 on v1.1 control plane', async () => {
     tokenMock(ddbMock, false);
     projectExistedMock(ddbMock, true);


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend