### PR TITLE
fix: QuickSight stack update fail when shared database name not equals source database name

### DIFF
--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -478,7 +478,7 @@ const deleteQuickSightDashboard = async (quickSight: QuickSight,
     for ( const dataSet of dataSets) {
       await deleteDataSet(quickSight, accountId, schema, databaseName, dataSet);
     }
-    return result;
+    return await result;
 
   } catch (err: any) {
     logger.error('Delete QuickSight dashboard failed, skip retry. Manually delete it if necessary.', err);
@@ -486,7 +486,7 @@ const deleteQuickSightDashboard = async (quickSight: QuickSight,
       deleteDatabase,
       schema,
     });
-    
+
     return {
       $metadata: {},
       DashboardId: 'NULL',

--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -459,26 +459,39 @@ const deleteQuickSightDashboard = async (quickSight: QuickSight,
   schema: string,
   dashboardDef: QuickSightDashboardDefProps)
 : Promise<DeleteDashboardCommandOutput|undefined> => {
-  // Delete Folder
-  await deleteFolder(quickSight, accountId, deleteDatabase, schema);
 
-  // Delete Dashboard
-  const dashboardId = buildDashBoardId(deleteDatabase, schema);
-  const result = deleteDashboardById(quickSight, accountId, dashboardId.id);
+  try {
+    // Delete Folder
+    await deleteFolder(quickSight, accountId, deleteDatabase, schema);
 
-  //delete Analysis
-  const analysisId = buildAnalysisId(deleteDatabase, schema);
-  await deleteAnalysisById(quickSight, accountId, analysisId.id);
+    // Delete Dashboard
+    const dashboardId = buildDashBoardId(deleteDatabase, schema);
+    const result = deleteDashboardById(quickSight, accountId, dashboardId.id);
 
-  //delete DataSets
-  const dataSets = dashboardDef.dataSets;
-  const databaseName = deleteDatabase;
-  for ( const dataSet of dataSets) {
-    await deleteDataSet(quickSight, accountId, schema, databaseName, dataSet);
+    //delete Analysis
+    const analysisId = buildAnalysisId(deleteDatabase, schema);
+    await deleteAnalysisById(quickSight, accountId, analysisId.id);
+
+    //delete DataSets
+    const dataSets = dashboardDef.dataSets;
+    const databaseName = deleteDatabase;
+    for ( const dataSet of dataSets) {
+      await deleteDataSet(quickSight, accountId, schema, databaseName, dataSet);
+    }
+    return result;
+
+  } catch (err: any) {
+    logger.error('Delete QuickSight dashboard failed, skip retry. Manually delete it if necessary.', err);
+    logger.error('Delete fail at:', {
+      deleteDatabase,
+      schema,
+    });
+    
+    return {
+      $metadata: {},
+      DashboardId: 'NULL',
+    };
   }
-
-  return result;
-
 };
 
 const getMemberType = function(memberArn: string, memberId: string): MemberType | undefined {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [x] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend