### PR TITLE
chore: add backoff for sql execution

### DIFF
--- a/src/analytics/lambdas/load-data-workflow/check-load-status.ts
+++ b/src/analytics/lambdas/load-data-workflow/check-load-status.ts
@@ -21,6 +21,7 @@ import { DeleteCommand } from '@aws-sdk/lib-dynamodb';
 import { Context } from 'aws-lambda';
 import { logger } from '../../../common/powertools';
 import { aws_sdk_client_common_config } from '../../../common/sdk-client-config';
+import { calculateWaitTime, WaitTimeInfo } from '../../../common/workflow';
 import { ManifestBody } from '../../private/model';
 import { getRedshiftClient } from '../redshift-data';
 
@@ -48,11 +49,6 @@ type CheckLoadStatusEventDetail = ManifestBody & {
 export interface CheckLoadStatusEvent {
   detail: CheckLoadStatusEventDetail;
   waitTimeInfo: WaitTimeInfo;
-}
-
-interface WaitTimeInfo {
-  waitTime: number;
-  loopCount: number;
 }
 
 const redshiftDataApiClient = getRedshiftClient(REDSHIFT_DATA_API_ROLE_ARN);
@@ -203,12 +199,3 @@ export const delFinishedJobInDynamodb = async (tableName: string, s3Uri: string)
   const response = await ddbClient.send(new DeleteCommand(params));
   return response;
 };
-
-export function calculateWaitTime(waitTime: number, loopCount: number, maxWaitTime = 600) {
-  if (loopCount > 4) {
-    const additionalTime = (loopCount - 4) * 10;
-    waitTime += additionalTime;
-  }
-  loopCount++;
-  return { waitTime: Math.min(waitTime, maxWaitTime), loopCount };
-}

--- a/src/analytics/lambdas/load-data-workflow/check-load-status.ts
+++ b/src/analytics/lambdas/load-data-workflow/check-load-status.ts
@@ -204,7 +204,7 @@ export const delFinishedJobInDynamodb = async (tableName: string, s3Uri: string)
   return response;
 };
 
-function calculateWaitTime(waitTime: number, loopCount: number, maxWaitTime = 600) {
+export function calculateWaitTime(waitTime: number, loopCount: number, maxWaitTime = 600) {
   if (loopCount > 4) {
     const additionalTime = (loopCount - 4) * 10;
     waitTime += additionalTime;

--- a/src/analytics/lambdas/sql-execution-sfn/sql-execution-step-fn.ts
+++ b/src/analytics/lambdas/sql-execution-sfn/sql-execution-step-fn.ts
@@ -13,18 +13,13 @@
 
 import { DescribeStatementCommand, RedshiftDataClient } from '@aws-sdk/client-redshift-data';
 import { logger } from '../../../common/powertools';
-import { calculateWaitTime } from '../load-data-workflow/check-load-status';
+import { calculateWaitTime, WaitTimeInfo } from '../../../common/workflow';
 import { executeBySqlOrS3File, getRedshiftClient } from '../redshift-data';
 
 interface EventType {
   waitTimeInfo: WaitTimeInfo;
   queryId?: string;
   sql?: string;
-}
-
-interface WaitTimeInfo {
-  waitTime: number;
-  loopCount: number;
 }
 
 interface SubmitSqlResponse {

--- a/src/analytics/private/sql-execution-workflow.ts
+++ b/src/analytics/private/sql-execution-workflow.ts
@@ -18,7 +18,7 @@ import { Function } from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import {
   StateMachine, TaskInput, Wait, WaitTime, Succeed, Choice, Map,
-  Condition, Fail, DefinitionBody, JsonPath, LogLevel,
+  Condition, Fail, DefinitionBody, JsonPath, LogLevel, Pass,
 } from 'aws-cdk-lib/aws-stepfunctions';
 import { LambdaInvoke } from 'aws-cdk-lib/aws-stepfunctions-tasks';
 import { Construct } from 'constructs';
@@ -54,13 +54,14 @@ export function createSQLExecutionStepFunctions(scope: Construct, props: SQLExec
   });
 
   const wait1 = new Wait(scope, 'Wait #1', {
-    time: WaitTime.duration(Duration.seconds(2)),
+    time: WaitTime.secondsPath('$.waitTimeInfo.waitTime'),
   });
 
   const checkStatus = new LambdaInvoke(scope, 'Check Status', {
     lambdaFunction: fn,
     payload: TaskInput.fromObject({
       'queryId.$': '$.queryId',
+      'waitTimeInfo.$': '$.waitTimeInfo',
     }),
     outputPath: '$.Payload',
   });
@@ -75,10 +76,22 @@ export function createSQLExecutionStepFunctions(scope: Construct, props: SQLExec
   const isDoneChoice = new Choice(scope, 'Is Done?');
 
   const checkStatusAgain = new Wait(scope, 'Wait #2', {
-    time: WaitTime.duration(Duration.seconds(2)),
+    time: WaitTime.secondsPath('$.waitTimeInfo.waitTime'),
   }).next(checkStatus);
 
-  const definition = submitSQL.next(wait1).next(checkStatus).next(isDoneChoice);
+  const initWaitTimeInfo = new Pass(scope, 'Init wait time info', {
+    parameters: {
+      waitTime: 2,
+      loopCount: 0,
+    },
+    resultPath: '$.waitTimeInfo',
+  });
+
+  const definition = initWaitTimeInfo
+    .next(submitSQL)
+    .next(wait1)
+    .next(checkStatus)
+    .next(isDoneChoice);
 
   isDoneChoice.when(Condition.stringEquals('$.status', 'FAILED'), new Fail(scope, 'Fail'));
   isDoneChoice.when(Condition.stringEquals('$.status', 'FINISHED'), new Succeed(scope, 'Succeed'));

--- a/src/common/workflow.ts
+++ b/src/common/workflow.ts
@@ -1,0 +1,27 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+export interface WaitTimeInfo {
+  waitTime: number;
+  loopCount: number;
+}
+
+export function calculateWaitTime(waitTime: number, loopCount: number, maxWaitTime = 600) {
+  if (loopCount > 4) {
+    const additionalTime = (loopCount - 4) * 10;
+    waitTime += additionalTime;
+  }
+  loopCount++;
+  return { waitTime: Math.min(waitTime, maxWaitTime), loopCount };
+}
+

--- a/test/analytics/analytics-on-redshift/lambda/sql-execution-sfn/sql-execution-sfn-provisioned.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/sql-execution-sfn/sql-execution-sfn-provisioned.test.ts
@@ -36,8 +36,16 @@ beforeEach(async () => {
   s3Mock.reset();
 });
 
+const waitTimeInfo = {
+  waitTime: 2,
+  loopCount: 0,
+};
+
 test('handler submit sql - s3 file', async () => {
-  const event = { sql: 's3://test/test.sql' };
+  const event = {
+    sql: 's3://test/test.sql',
+    waitTimeInfo,
+  };
   s3Mock.on(GetObjectCommand).resolves({
     Body: {
       transformToString: () => { return 'select * from test'; },
@@ -47,7 +55,13 @@ test('handler submit sql - s3 file', async () => {
 
   const response = await handler(event);
 
-  expect(response).toEqual({ queryId: 'id-1' });
+  expect(response).toEqual({
+    queryId: 'id-1',
+    waitTimeInfo: {
+      waitTime: 2,
+      loopCount: 1,
+    },
+  });
   expect(s3Mock).toHaveReceivedCommandTimes(GetObjectCommand, 1);
   expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 1);
 

--- a/test/analytics/analytics-on-redshift/workflow/sql-execution-sfn.json
+++ b/test/analytics/analytics-on-redshift/workflow/sql-execution-sfn.json
@@ -2,7 +2,7 @@
     "Fn::Join": [
         "",
         [
-            "{\"StartAt\":\"Execute SQL statements\",\"States\":{\"Execute SQL statements\":{\"Type\":\"Map\",\"End\":true,\"Parameters\":{\"sql.$\":\"$$.Map.Item.Value\"},\"ItemsPath\":\"$.sqls\",\"ItemProcessor\":{\"ProcessorConfig\":{\"Mode\":\"INLINE\"},\"StartAt\":\"Submit SQL\",\"States\":{\"Submit SQL\":{\"Next\":\"Wait #1\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2},{\"ErrorEquals\":[\"Lambda.TooManyRequestsException\"],\"IntervalSeconds\":3,\"MaxAttempts\":10,\"BackoffRate\":2}],\"Type\":\"Task\",\"OutputPath\":\"$.Payload\",\"Resource\":\"arn:",
+            "{\"StartAt\":\"Execute SQL statements\",\"States\":{\"Execute SQL statements\":{\"Type\":\"Map\",\"End\":true,\"Parameters\":{\"sql.$\":\"$$.Map.Item.Value\"},\"ItemsPath\":\"$.sqls\",\"ItemProcessor\":{\"ProcessorConfig\":{\"Mode\":\"INLINE\"},\"StartAt\":\"Init wait time info\",\"States\":{\"Init wait time info\":{\"Type\":\"Pass\",\"ResultPath\":\"$.waitTimeInfo\",\"Parameters\":{\"waitTime\":2,\"loopCount\":0},\"Next\":\"Submit SQL\"},\"Submit SQL\":{\"Next\":\"Wait #1\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2},{\"ErrorEquals\":[\"Lambda.TooManyRequestsException\"],\"IntervalSeconds\":3,\"MaxAttempts\":10,\"BackoffRate\":2}],\"Type\":\"Task\",\"OutputPath\":\"$.Payload\",\"Resource\":\"arn:",
             {
                 "Ref": "AWS::Partition"
             },
@@ -13,7 +13,7 @@
                     "Arn"
                 ]
             },
-            "\",\"Payload.$\":\"$\"}},\"Wait #1\":{\"Type\":\"Wait\",\"Seconds\":2,\"Next\":\"Check Status\"},\"Check Status\":{\"Next\":\"Is Done?\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2},{\"ErrorEquals\":[\"Lambda.TooManyRequestsException\"],\"IntervalSeconds\":3,\"MaxAttempts\":10,\"BackoffRate\":2}],\"Type\":\"Task\",\"OutputPath\":\"$.Payload\",\"Resource\":\"arn:",
+            "\",\"Payload.$\":\"$\"}},\"Wait #1\":{\"Type\":\"Wait\",\"SecondsPath\":\"$.waitTimeInfo.waitTime\",\"Next\":\"Check Status\"},\"Check Status\":{\"Next\":\"Is Done?\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2},{\"ErrorEquals\":[\"Lambda.TooManyRequestsException\"],\"IntervalSeconds\":3,\"MaxAttempts\":10,\"BackoffRate\":2}],\"Type\":\"Task\",\"OutputPath\":\"$.Payload\",\"Resource\":\"arn:",
             {
                 "Ref": "AWS::Partition"
             },
@@ -24,7 +24,7 @@
                     "Arn"
                 ]
             },
-            "\",\"Payload\":{\"queryId.$\":\"$.queryId\"}}},\"Wait #2\":{\"Type\":\"Wait\",\"Seconds\":2,\"Next\":\"Check Status\"},\"Is Done?\":{\"Type\":\"Choice\",\"Choices\":[{\"Variable\":\"$.status\",\"StringEquals\":\"FAILED\",\"Next\":\"Fail\"},{\"Variable\":\"$.status\",\"StringEquals\":\"FINISHED\",\"Next\":\"Succeed\"}],\"Default\":\"Wait #2\"},\"Fail\":{\"Type\":\"Fail\"},\"Succeed\":{\"Type\":\"Succeed\"}}},\"MaxConcurrency\":1}},\"TimeoutSeconds\":7200,\"Comment\":\"Execute SQL in Redshift using Redshift Data API\"}"
+            "\",\"Payload\":{\"queryId.$\":\"$.queryId\",\"waitTimeInfo.$\":\"$.waitTimeInfo\"}}},\"Wait #2\":{\"Type\":\"Wait\",\"SecondsPath\":\"$.waitTimeInfo.waitTime\",\"Next\":\"Check Status\"},\"Is Done?\":{\"Type\":\"Choice\",\"Choices\":[{\"Variable\":\"$.status\",\"StringEquals\":\"FAILED\",\"Next\":\"Fail\"},{\"Variable\":\"$.status\",\"StringEquals\":\"FINISHED\",\"Next\":\"Succeed\"}],\"Default\":\"Wait #2\"},\"Fail\":{\"Type\":\"Fail\"},\"Succeed\":{\"Type\":\"Succeed\"}}},\"MaxConcurrency\":1}},\"TimeoutSeconds\":7200,\"Comment\":\"Execute SQL in Redshift using Redshift Data API\"}"
         ]
     ]
 }


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

add backoff for sql execution

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend