### PR TITLE
chore: add backoff for sql execution 

### DIFF
--- a/src/analytics/lambdas/sql-execution-sfn/sql-execution-step-fn.ts
+++ b/src/analytics/lambdas/sql-execution-sfn/sql-execution-step-fn.ts
@@ -13,21 +13,25 @@
 
 import { DescribeStatementCommand, RedshiftDataClient } from '@aws-sdk/client-redshift-data';
 import { logger } from '../../../common/powertools';
+import { calculateWaitTime, WaitTimeInfo } from '../../../common/workflow';
 import { exeucteBySqlorS3File, getRedshiftClient } from '../redshift-data';
 
 interface EventType {
+  waitTimeInfo: WaitTimeInfo;
   queryId?: string;
   sql?: string;
 }
 
 interface SubmitSqlResponse {
   queryId: string;
+  waitTimeInfo: WaitTimeInfo;
 }
 
 interface QueryResponse {
   status: string;
   queryId: string;
   reason?: string;
+  waitTimeInfo: WaitTimeInfo;
 }
 
 type ResponseType = SubmitSqlResponse | QueryResponse;
@@ -52,18 +56,18 @@ export const handler = async (event: EventType): Promise<ResponseType> => {
 async function _handler(event: EventType): Promise<ResponseType> {
 
   const redShiftClient = getRedshiftClient(dataAPIRole);
+  const waitTimeInfo = calculateWaitTime(event.waitTimeInfo.waitTime, event.waitTimeInfo.loopCount);
   if (event.sql) {
-
-    return submitSql(event.sql, redShiftClient);
+    return submitSql(event.sql, redShiftClient, waitTimeInfo);
   } else if (event.queryId) {
-    return queryStatus(event.queryId, redShiftClient);
+    return queryStatus(event.queryId, redShiftClient, waitTimeInfo);
   } else {
     logger.error('event', { event });
     throw new Error('Invalid event');
   }
 }
 
-async function submitSql(sqlOrs3File: string, redShiftClient: RedshiftDataClient): Promise<SubmitSqlResponse> {
+async function submitSql(sqlOrs3File: string, redShiftClient: RedshiftDataClient, waitTimeInfo: WaitTimeInfo): Promise<SubmitSqlResponse> {
   logger.info('submitSql() sqlOrs3File: ' + sqlOrs3File);
 
   let provisionedRedshiftProps = undefined;
@@ -85,10 +89,13 @@ async function submitSql(sqlOrs3File: string, redShiftClient: RedshiftDataClient
   }
   const res = await exeucteBySqlorS3File(sqlOrs3File, redShiftClient, serverlessRedshiftProps, provisionedRedshiftProps, databaseName);
   logger.info('submitSql() return queryId: ' + res.queryId);
-  return res;
+  return {
+    queryId: res.queryId,
+    waitTimeInfo,
+  };
 }
 
-async function queryStatus(queryId: string, redShiftClient: RedshiftDataClient): Promise<QueryResponse> {
+async function queryStatus(queryId: string, redShiftClient: RedshiftDataClient, waitTimeInfo: WaitTimeInfo): Promise<QueryResponse> {
   logger.info('queryStatus() queryId: ' + queryId);
 
   const checkParams = new DescribeStatementCommand({
@@ -106,6 +113,7 @@ async function queryStatus(queryId: string, redShiftClient: RedshiftDataClient):
         status: 'FINISHED',
         queryId: queryId,
         reason: errorMsg,
+        waitTimeInfo,
       };
     }
   }
@@ -114,5 +122,6 @@ async function queryStatus(queryId: string, redShiftClient: RedshiftDataClient):
     status: response.Status!,
     queryId: queryId,
     reason: errorMsg,
+    waitTimeInfo,
   };
 }

--- a/src/common/workflow.ts
+++ b/src/common/workflow.ts
@@ -1,0 +1,27 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+export interface WaitTimeInfo {
+  waitTime: number;
+  loopCount: number;
+}
+
+export function calculateWaitTime(waitTime: number, loopCount: number, maxWaitTime = 600) {
+  if (loopCount > 4) {
+    const additionalTime = (loopCount - 4) * 10;
+    waitTime += additionalTime;
+  }
+  loopCount++;
+  return { waitTime: Math.min(waitTime, maxWaitTime), loopCount };
+}
+

--- a/test/analytics/analytics-on-redshift/lambda/sql-execution-sfn/sql-execution-sfn-provisioned.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/sql-execution-sfn/sql-execution-sfn-provisioned.test.ts
@@ -36,8 +36,16 @@ beforeEach(async () => {
   s3Mock.reset();
 });
 
+const waitTimeInfo = {
+  waitTime: 2,
+  loopCount: 0,
+};
+
 test('handler submit sql - s3 file', async () => {
-  const event = { sql: 's3://test/test.sql' };
+  const event = {
+    sql: 's3://test/test.sql',
+    waitTimeInfo,
+  };
   s3Mock.on(GetObjectCommand).resolves({
     Body: {
       transformToString: () => { return 'select * from test'; },
@@ -47,7 +55,13 @@ test('handler submit sql - s3 file', async () => {
 
   const response = await handler(event);
 
-  expect(response).toEqual({ queryId: 'id-1' });
+  expect(response).toEqual({
+    queryId: 'id-1',
+    waitTimeInfo: {
+      waitTime: 2,
+      loopCount: 1,
+    },
+  });
   expect(s3Mock).toHaveReceivedCommandTimes(GetObjectCommand, 1);
   expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 1);
 

--- a/test/analytics/analytics-on-redshift/workflow/sql-execution-sfn.json
+++ b/test/analytics/analytics-on-redshift/workflow/sql-execution-sfn.json
@@ -2,7 +2,7 @@
     "Fn::Join": [
         "",
         [
-            "{\"StartAt\":\"Execute SQL statements\",\"States\":{\"Execute SQL statements\":{\"Type\":\"Map\",\"End\":true,\"Parameters\":{\"sql.$\":\"$$.Map.Item.Value\"},\"Iterator\":{\"StartAt\":\"Submit SQL\",\"States\":{\"Submit SQL\":{\"Next\":\"Wait #1\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2},{\"ErrorEquals\":[\"Lambda.TooManyRequestsException\"],\"IntervalSeconds\":3,\"MaxAttempts\":10,\"BackoffRate\":2}],\"Type\":\"Task\",\"OutputPath\":\"$.Payload\",\"Resource\":\"arn:",
+            "{\"StartAt\":\"Execute SQL statements\",\"States\":{\"Execute SQL statements\":{\"Type\":\"Map\",\"End\":true,\"Parameters\":{\"sql.$\":\"$$.Map.Item.Value\"},\"ItemsPath\":\"$.sqls\",\"MaxConcurrency\":1,\"Iterator\":{\"StartAt\":\"Init wait time info\",\"States\":{\"Init wait time info\":{\"Type\":\"Pass\",\"ResultPath\":\"$.waitTimeInfo\",\"Parameters\":{\"waitTime\":2,\"loopCount\":0},\"Next\":\"Submit SQL\"},\"Submit SQL\":{\"Next\":\"Wait #1\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2},{\"ErrorEquals\":[\"Lambda.TooManyRequestsException\"],\"IntervalSeconds\":3,\"MaxAttempts\":10,\"BackoffRate\":2}],\"Type\":\"Task\",\"OutputPath\":\"$.Payload\",\"Resource\":\"arn:",
             {
                 "Ref": "AWS::Partition"
             },
@@ -13,7 +13,7 @@
                     "Arn"
                 ]
             },
-            "\",\"Payload.$\":\"$\"}},\"Wait #1\":{\"Type\":\"Wait\",\"Seconds\":2,\"Next\":\"Check Status\"},\"Check Status\":{\"Next\":\"Is Done?\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2},{\"ErrorEquals\":[\"Lambda.TooManyRequestsException\"],\"IntervalSeconds\":3,\"MaxAttempts\":10,\"BackoffRate\":2}],\"Type\":\"Task\",\"OutputPath\":\"$.Payload\",\"Resource\":\"arn:",
+            "\",\"Payload.$\":\"$\"}},\"Wait #1\":{\"Type\":\"Wait\",\"SecondsPath\":\"$.waitTimeInfo.waitTime\",\"Next\":\"Check Status\"},\"Check Status\":{\"Next\":\"Is Done?\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2},{\"ErrorEquals\":[\"Lambda.TooManyRequestsException\"],\"IntervalSeconds\":3,\"MaxAttempts\":10,\"BackoffRate\":2}],\"Type\":\"Task\",\"OutputPath\":\"$.Payload\",\"Resource\":\"arn:",
             {
                 "Ref": "AWS::Partition"
             },
@@ -24,7 +24,7 @@
                     "Arn"
                 ]
             },
-            "\",\"Payload\":{\"queryId.$\":\"$.queryId\"}}},\"Wait #2\":{\"Type\":\"Wait\",\"Seconds\":2,\"Next\":\"Check Status\"},\"Is Done?\":{\"Type\":\"Choice\",\"Choices\":[{\"Variable\":\"$.status\",\"StringEquals\":\"FAILED\",\"Next\":\"Fail\"},{\"Variable\":\"$.status\",\"StringEquals\":\"FINISHED\",\"Next\":\"Succeed\"}],\"Default\":\"Wait #2\"},\"Fail\":{\"Type\":\"Fail\"},\"Succeed\":{\"Type\":\"Succeed\"}}},\"ItemsPath\":\"$.sqls\",\"MaxConcurrency\":1}},\"TimeoutSeconds\":7200,\"Comment\":\"Execute SQL in Redshift using Redshift Data API\"}"
+            "\",\"Payload\":{\"queryId.$\":\"$.queryId\",\"waitTimeInfo.$\":\"$.waitTimeInfo\"}}},\"Wait #2\":{\"Type\":\"Wait\",\"SecondsPath\":\"$.waitTimeInfo.waitTime\",\"Next\":\"Check Status\"},\"Is Done?\":{\"Type\":\"Choice\",\"Choices\":[{\"Variable\":\"$.status\",\"StringEquals\":\"FAILED\",\"Next\":\"Fail\"},{\"Variable\":\"$.status\",\"StringEquals\":\"FINISHED\",\"Next\":\"Succeed\"}],\"Default\":\"Wait #2\"},\"Fail\":{\"Type\":\"Fail\"},\"Succeed\":{\"Type\":\"Succeed\"}}}}},\"TimeoutSeconds\":7200,\"Comment\":\"Execute SQL in Redshift using Redshift Data API\"}"
         ]
     ]
 }

--- a/test/analytics/analytics-on-redshift/workflow/sql-execution-sfn.json
+++ b/test/analytics/analytics-on-redshift/workflow/sql-execution-sfn.json
@@ -2,7 +2,7 @@
     "Fn::Join": [
         "",
         [
-            "{\"StartAt\":\"Execute SQL statements\",\"States\":{\"Execute SQL statements\":{\"Type\":\"Map\",\"End\":true,\"Parameters\":{\"sql.$\":\"$$.Map.Item.Value\"},\"ItemsPath\":\"$.sqls\",\"MaxConcurrency\":1,\"Iterator\":{\"StartAt\":\"Init wait time info\",\"States\":{\"Init wait time info\":{\"Type\":\"Pass\",\"ResultPath\":\"$.waitTimeInfo\",\"Parameters\":{\"waitTime\":2,\"loopCount\":0},\"Next\":\"Submit SQL\"},\"Submit SQL\":{\"Next\":\"Wait #1\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2},{\"ErrorEquals\":[\"Lambda.TooManyRequestsException\"],\"IntervalSeconds\":3,\"MaxAttempts\":10,\"BackoffRate\":2}],\"Type\":\"Task\",\"OutputPath\":\"$.Payload\",\"Resource\":\"arn:",
+            "{\"StartAt\":\"Execute SQL statements\",\"States\":{\"Execute SQL statements\":{\"Type\":\"Map\",\"End\":true,\"Parameters\":{\"sql.$\":\"$$.Map.Item.Value\"},\"Iterator\":{\"StartAt\":\"Init wait time info\",\"States\":{\"Init wait time info\":{\"Type\":\"Pass\",\"ResultPath\":\"$.waitTimeInfo\",\"Parameters\":{\"waitTime\":2,\"loopCount\":0},\"Next\":\"Submit SQL\"},\"Submit SQL\":{\"Next\":\"Wait #1\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2},{\"ErrorEquals\":[\"Lambda.TooManyRequestsException\"],\"IntervalSeconds\":3,\"MaxAttempts\":10,\"BackoffRate\":2}],\"Type\":\"Task\",\"OutputPath\":\"$.Payload\",\"Resource\":\"arn:",
             {
                 "Ref": "AWS::Partition"
             },
@@ -24,7 +24,7 @@
                     "Arn"
                 ]
             },
-            "\",\"Payload\":{\"queryId.$\":\"$.queryId\",\"waitTimeInfo.$\":\"$.waitTimeInfo\"}}},\"Wait #2\":{\"Type\":\"Wait\",\"SecondsPath\":\"$.waitTimeInfo.waitTime\",\"Next\":\"Check Status\"},\"Is Done?\":{\"Type\":\"Choice\",\"Choices\":[{\"Variable\":\"$.status\",\"StringEquals\":\"FAILED\",\"Next\":\"Fail\"},{\"Variable\":\"$.status\",\"StringEquals\":\"FINISHED\",\"Next\":\"Succeed\"}],\"Default\":\"Wait #2\"},\"Fail\":{\"Type\":\"Fail\"},\"Succeed\":{\"Type\":\"Succeed\"}}}}},\"TimeoutSeconds\":7200,\"Comment\":\"Execute SQL in Redshift using Redshift Data API\"}"
+            "\",\"Payload\":{\"queryId.$\":\"$.queryId\",\"waitTimeInfo.$\":\"$.waitTimeInfo\"}}},\"Wait #2\":{\"Type\":\"Wait\",\"SecondsPath\":\"$.waitTimeInfo.waitTime\",\"Next\":\"Check Status\"},\"Is Done?\":{\"Type\":\"Choice\",\"Choices\":[{\"Variable\":\"$.status\",\"StringEquals\":\"FAILED\",\"Next\":\"Fail\"},{\"Variable\":\"$.status\",\"StringEquals\":\"FINISHED\",\"Next\":\"Succeed\"}],\"Default\":\"Wait #2\"},\"Fail\":{\"Type\":\"Fail\"},\"Succeed\":{\"Type\":\"Succeed\"}}},\"ItemsPath\":\"$.sqls\",\"MaxConcurrency\":1}},\"TimeoutSeconds\":7200,\"Comment\":\"Execute SQL in Redshift using Redshift Data API\"}"
         ]
     ]
 }


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

add backoff for sql execution 

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend