### PR TITLE
fix: do not delete explore user when pipeline versions contain v1.1.4

### DIFF
--- a/src/control-plane/backend/lambda/api/service/reporting.ts
+++ b/src/control-plane/backend/lambda/api/service/reporting.ts
@@ -1276,7 +1276,7 @@ async function _cleanUser() {
 
 function _needExploreUserVersion(pipeline: IPipeline) {
   const version = pipeline.templateVersion?.split('-')[0] ?? '';
-  const oldVersions = ['v1.1.0', 'v1.1.1', 'v1.1.2', 'v1.1.3'];
+  const oldVersions = ['v1.1.0', 'v1.1.1', 'v1.1.2', 'v1.1.3', 'v1.1.4'];
   return oldVersions.includes(version);
 
 }

--- a/src/control-plane/backend/lambda/api/test/api/reporting.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/reporting.test.ts
@@ -2216,7 +2216,7 @@ describe('reporting test', () => {
     expect(quickSightMock).toHaveReceivedCommandTimes(DeleteUserCommand, 1);
   });
 
-  it('clean - include v1.1.3 pipeline', async () => {
+  it('clean - include v1.1.4 pipeline', async () => {
 
     quickSightMock.on(ListDashboardsCommand).resolves({
       DashboardSummaryList: [{
@@ -2279,7 +2279,7 @@ describe('reporting test', () => {
 
     ddbMock.on(QueryCommand).resolves({
       Items: [
-        { templateVersion: 'v1.1.3' },
+        { templateVersion: 'v1.1.4' },
         { templateVersion: 'v1.2.0' },
       ],
     });


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend