### PR TITLE
fix: filter out dynamic tags in pipeline detail page

### DIFF
--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -1209,6 +1209,19 @@ function mergeIntoPipelineTags(pipelineTags: ITag[], newTag: Tag): ITag[] {
   return pipelineTags;
 }
 
+/**
+ * Filter out dynamic pipeline tags with prefix '#.'
+ * @param pipeline
+ * @returns IPipeline
+ */
+function filterDynamicPipelineTags(pipeline: IPipeline): IPipeline {
+  const tags = pipeline.tags.filter(tag => !tag.key.startsWith('#.') && !tag.value.startsWith('#.'));
+  return {
+    ...pipeline,
+    tags,
+  };
+}
+
 function getStateMachineExecutionName(pipelineId: string) {
   return `main-${pipelineId}-${new Date().getTime()}`;
 }
@@ -1405,6 +1418,7 @@ export {
   getDefaultTags,
   mergeIntoStackTags,
   mergeIntoPipelineTags,
+  filterDynamicPipelineTags,
   getStateMachineExecutionName,
   getPipelineStatusType,
   getPipelineLastActionFromStacksStatus,

--- a/src/control-plane/backend/lambda/api/service/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/service/pipeline.ts
@@ -11,15 +11,27 @@
  *  and limitations under the License.
  */
 
-import { OUTPUT_INGESTION_SERVER_DNS_SUFFIX, OUTPUT_INGESTION_SERVER_URL_SUFFIX, OUTPUT_METRICS_OBSERVABILITY_DASHBOARD_NAME, OUTPUT_REPORT_DASHBOARDS_SUFFIX } from '@aws/clickstream-base-lib';
+import {
+  OUTPUT_INGESTION_SERVER_DNS_SUFFIX,
+  OUTPUT_INGESTION_SERVER_URL_SUFFIX,
+  OUTPUT_METRICS_OBSERVABILITY_DASHBOARD_NAME,
+  OUTPUT_REPORT_DASHBOARDS_SUFFIX,
+} from '@aws/clickstream-base-lib';
 import { v4 as uuidv4 } from 'uuid';
 import { PipelineStackType, PipelineStatusType } from '../common/model-ln';
 import { ApiFail, ApiSuccess } from '../common/types';
-import { getStackOutputFromPipelineStatus, getReportingDashboardsUrl, paginateData, pipelineAnalysisStudioEnabled, getPipelineStatusType, isEmpty } from '../common/utils';
-import { IPipeline, CPipeline } from '../model/pipeline';
+import {
+  filterDynamicPipelineTags,
+  getPipelineStatusType,
+  getReportingDashboardsUrl,
+  getStackOutputFromPipelineStatus,
+  isEmpty,
+  paginateData,
+  pipelineAnalysisStudioEnabled,
+} from '../common/utils';
+import { CPipeline, IPipeline } from '../model/pipeline';
 import { ClickStreamStore } from '../store/click-stream-store';
 import { DynamoDbStore } from '../store/dynamodb/dynamodb-store';
-
 
 const store: ClickStreamStore = new DynamoDbStore();
 
@@ -77,7 +89,7 @@ export class PipelineServ {
       const pluginsInfo = await pipeline.getPluginsInfo();
       const templateInfo = pipeline.getTemplateInfo();
       return res.json(new ApiSuccess({
-        ...latestPipeline,
+        ...filterDynamicPipelineTags(latestPipeline),
         statusType: getPipelineStatusType(latestPipeline),
         dataProcessing: !isEmpty(latestPipeline.dataProcessing) ? {
           ...latestPipeline.dataProcessing,

--- a/src/control-plane/backend/lambda/api/test/api/utils.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/utils.test.ts
@@ -31,9 +31,21 @@ import {
 import { SecurityGroupRule } from '@aws-sdk/client-ec2';
 import { MOCK_APP_ID, MOCK_PROJECT_ID } from './ddb-mock';
 import { S3_INGESTION_PIPELINE } from './pipeline-mock';
-import { validateDataProcessingInterval, validatePattern, validateSinkBatch, validateXSS } from '../../common/stack-params-valid';
+import {
+  validateDataProcessingInterval,
+  validatePattern,
+  validateSinkBatch,
+  validateXSS,
+} from '../../common/stack-params-valid';
 import { ClickStreamBadRequestError, PipelineSinkType } from '../../common/types';
-import { containRule, corsStackInput, getAppRegistryApplicationArn, getStackPrefix, isEmpty } from '../../common/utils';
+import {
+  containRule,
+  corsStackInput,
+  filterDynamicPipelineTags,
+  getAppRegistryApplicationArn,
+  getStackPrefix,
+  isEmpty,
+} from '../../common/utils';
 
 describe('Utils test', () => {
 
@@ -791,5 +803,28 @@ describe('Network test', () => {
       region: 'cn-north-1',
     };
     expect(getAppRegistryApplicationArn(pipeline)).toEqual('');
+  });
+
+  it('filters out dynamic pipeline tags', () => {
+    const pipeline = {
+      ...S3_INGESTION_PIPELINE,
+      tags: [
+        ...S3_INGESTION_PIPELINE.tags,
+        {
+          key: 'DynamicTagKey',
+          value: '#.dynamicTag.value',
+        },
+        {
+          key: '#.DynamicTag.key',
+          value: 'DynamicTagValue',
+        },
+        {
+          key: '#.DynamicTag.key',
+          value: '#.dynamicTag.value',
+        },
+      ],
+    };
+
+    expect(filterDynamicPipelineTags(pipeline).tags).toEqual(S3_INGESTION_PIPELINE.tags);
   });
 });


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Filter out dynamic tags in pipeline detail page

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend