### PR TITLE
chore: refactor time backoff to lambda decorator

### DIFF
--- a/test/analytics/analytics-on-redshift/lambda/load-data/check-load-status.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/load-data/check-load-status.test.ts
@@ -18,10 +18,11 @@ import { DeleteCommand } from '@aws-sdk/lib-dynamodb';
 import { mockClient } from 'aws-sdk-client-mock';
 import { handler, CheckLoadStatusEvent } from '../../../../../src/analytics/lambdas/load-data-workflow/check-load-status';
 import { REDSHIFT_MODE } from '../../../../../src/common/model';
+import { WaitTimeInfo } from '../../../../../src/common/workflow';
 import { getMockContext } from '../../../../common/lambda-context';
 import 'aws-sdk-client-mock-jest';
 
-const loadStatusEvent: CheckLoadStatusEvent = {
+const loadStatusEvent: CheckLoadStatusEvent & { waitTimeInfo: WaitTimeInfo } = {
   detail: {
     id: '70bfb836-c7d5-7cab-75b0-5222e78194ac',
     status: '',
@@ -45,7 +46,7 @@ const loadStatusEvent: CheckLoadStatusEvent = {
 };
 
 
-const loadStatusEvent2: CheckLoadStatusEvent = {
+const loadStatusEvent2: CheckLoadStatusEvent & { waitTimeInfo: WaitTimeInfo } = {
   detail: {
     id: '70bfb836-c7d5-7cab-75b0-5222e78194ac',
     status: '',
@@ -69,7 +70,7 @@ const loadStatusEvent2: CheckLoadStatusEvent = {
 };
 
 
-const loadStatusEvent3: CheckLoadStatusEvent = {
+const loadStatusEvent3: CheckLoadStatusEvent & { waitTimeInfo: WaitTimeInfo } = {
   detail: {
     id: '70bfb836-c7d5-7cab-75b0-5222e78194ac',
     status: '',
@@ -122,6 +123,10 @@ describe('Lambda - check the COPY query status in Redshift Serverless', () => {
     expect(resp).toEqual({
       detail: {
         status: StatusString.FINISHED,
+      },
+      waitTimeInfo: {
+        waitTime: 10,
+        loopCount: 2,
       },
     });
     expect(redshiftDataMock).toHaveReceivedCommandWith(DescribeStatementCommand, {
@@ -271,6 +276,10 @@ describe('Lambda - check the COPY query status in Redshift Serverless', () => {
     expect(resp).toEqual({
       detail: {
         status: StatusString.FINISHED,
+      },
+      waitTimeInfo: {
+        waitTime: 10,
+        loopCount: 2,
       },
     });
     expect(redshiftDataMock).toHaveReceivedCommandWith(DescribeStatementCommand, {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

refactor time backoff to lambda decorator

## Implementation highlights

refactor time backoff to lambda decorator

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend