### PR TITLE
chore: refactor exclude the files not belonged to ods data when enqueue into DDB

### DIFF
--- a/src/analytics/lambdas/load-data-workflow/put-ods-source-to-store.ts
+++ b/src/analytics/lambdas/load-data-workflow/put-ods-source-to-store.ts
@@ -11,6 +11,7 @@
  *  and limitations under the License.
  */
 
+import { PARTITION_APP } from '@aws/clickstream-base-lib';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { PutCommand } from '@aws-sdk/lib-dynamodb';
 import { EventBridgeEvent, S3ObjectCreatedNotificationEventDetail } from 'aws-lambda';
@@ -82,7 +83,7 @@ export const handler = async (event: EventBridgeEvent<'Object Created', S3Object
     await putItem(tableName, s3Bucket, s3Object, s3ObjSize, jobStatus, timestamp);
   } else {
     logger.warn(`S3 file ${s3Object} is not matched with 
-      ${/partition_app=([^/]+)\/partition_year=\d{4}\/partition_month=\d{2}\/partition_day=\d{2}\//} pattern
+      /${PARTITION_APP}=([^/]+)\/partition_year=\d{4}\/partition_month=\d{2}\/partition_day=\d{2}\// pattern
       or ${S3_FILE_SUFFIX} suffix`);
   }
 };
@@ -125,7 +126,7 @@ export const putItem = async (tableName: string, s3Bucket: string, s3Object: str
 };
 
 function checkS3FileValidity(s3FileKey: string, appIdList: string[]) {
-  const regex = /partition_app=([^/]+)\/partition_year=\d{4}\/partition_month=\d{2}\/partition_day=\d{2}\//;
+  const regex = `/${PARTITION_APP}=([^/]+)\/partition_year=\d{4}\/partition_month=\d{2}\/partition_day=\d{2}\//`;
   const match = s3FileKey.match(regex);
   if (!match) {
     return false;

--- a/src/analytics/lambdas/load-data-workflow/put-ods-source-to-store.ts
+++ b/src/analytics/lambdas/load-data-workflow/put-ods-source-to-store.ts
@@ -83,8 +83,8 @@ export const handler = async (event: EventBridgeEvent<'Object Created', S3Object
     await putItem(tableName, s3Bucket, s3Object, s3ObjSize, jobStatus, timestamp);
   } else {
     logger.warn(`S3 file ${s3Object} is not matched with 
-      /${PARTITION_APP}=([^/]+)\/partition_year=\d{4}\/partition_month=\d{2}\/partition_day=\d{2}\// pattern
-      or ${S3_FILE_SUFFIX} suffix`);
+    /${PARTITION_APP}=([^/]+)\\/partition_year=\\d{4}\\/partition_month=\\d{2}\\/partition_day=\\d{2}\\// pattern
+    or ${S3_FILE_SUFFIX} suffix`);
   }
 };
 
@@ -126,7 +126,7 @@ export const putItem = async (tableName: string, s3Bucket: string, s3Object: str
 };
 
 function checkS3FileValidity(s3FileKey: string, appIdList: string[]) {
-  const regex = `/${PARTITION_APP}=([^/]+)\/partition_year=\d{4}\/partition_month=\d{2}\/partition_day=\d{2}\//`;
+  const regex = new RegExp(`${PARTITION_APP}=([^/]+)\\/partition_year=\\d{4}\\/partition_month=\\d{2}\\/partition_day=\\d{2}\\/`);
   const match = s3FileKey.match(regex);
   if (!match) {
     return false;


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

refactor exclude the files not belonged to ods data when enqueue into DDB

## Implementation highlights

refactor exclude the files not belonged to ods data when enqueue into DDB

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend