### PR TITLE
chore: handle upload_timestamp query parameter from client side

### DIFF
--- a/src/ingestion-server/server/images/vector/config/vector.toml
+++ b/src/ingestion-server/server/images/vector/config/vector.toml
@@ -3,7 +3,7 @@ type = "http_server"
 address = "0.0.0.0:8685"
 strict_path = false
 headers = [ "X_Uri", "X_User_Agent", "X_Forwarded_For", "X_Date", "X_Request_ID", "X_Method"]
-query_parameters = [ "platform", "appId", "compression", "fakeIp" ]
+query_parameters = [ "platform", "appId", "compression", "fakeIp", "upload_timestamp" ]
 method = "POST"
 encoding = "binary"
 
@@ -18,6 +18,9 @@ if get_env_var!("DEV_MODE") == "Yes" && !is_null(.fakeIp) {
   .ip = del(.fakeIp)
 } else {
   .ip = del(.X_Forwarded_For)
+}
+if !is_null(.upload_timestamp) {
+  .client_timestamp = del(.upload_timestamp)
 }
 .rid = del(.X_Request_ID)
 .method = del(.X_Method)


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

handle upload_timestamp query parameter from client side

## Implementation highlights

handle upload_timestamp query parameter from client side

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [x] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [x] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend