### PR TITLE
chore: refactor sql script update according to hash code change

### DIFF
--- a/src/analytics/lambdas/custom-resource/create-schemas.ts
+++ b/src/analytics/lambdas/custom-resource/create-schemas.ts
@@ -134,7 +134,7 @@ function getNewAddedAppIdList(event: CdkCustomResourceEvent): string[] {
   const requestType = event.RequestType;
   const props = event.ResourceProperties as ResourcePropertiesType;
   const appIdList = splitString(props.appIds ?? '');
-  const lastModifiedTime = props.lastModifiedTime;
+  const schemaHash = props.schemaHash;
   const isUpdate = requestType == 'Update';
 
   const applyAllAppSql = process.env.APPLY_ALL_APP_SQL === 'true';
@@ -144,9 +144,9 @@ function getNewAddedAppIdList(event: CdkCustomResourceEvent): string[] {
   if (isUpdate && !applyAllAppSql) {
     const oldAppIds = ((event as CloudFormationCustomResourceUpdateEvent).OldResourceProperties as ResourcePropertiesType).appIds;
     const oldAppIdList = splitString(oldAppIds ?? '');
-    const oldLastModifiedTime = ((event as CloudFormationCustomResourceUpdateEvent).OldResourceProperties as ResourcePropertiesType).lastModifiedTime;
-    logger.info('getNewAddedAppIdList()', { requestType, oldAppIdList, oldLastModifiedTime, appIdList, lastModifiedTime });
-    if (lastModifiedTime === oldLastModifiedTime) {
+    const oldSchemaHash = ((event as CloudFormationCustomResourceUpdateEvent).OldResourceProperties as ResourcePropertiesType).schemaHash;
+    logger.info('getNewAddedAppIdList()', { requestType, oldAppIdList, oldSchemaHash, appIdList, schemaHash });
+    if (schemaHash === oldSchemaHash) {
       newAddedAppIdList = [];
       for (const appId of appIdList) {
         if (!oldAppIdList.includes(appId)) {

--- a/src/analytics/private/model.ts
+++ b/src/analytics/private/model.ts
@@ -112,7 +112,7 @@ export type CreateDatabaseAndSchemas = CustomProperties & {
   readonly redshiftBIUsernamePrefix: string;
   readonly reportingViewsDef: SQLViewDef[];
   readonly schemaDefs: SQLDef[];
-  readonly lastModifiedTime: number;
+  readonly schemaHash: string;
 }
 export type CreateMappingRoleUser = Omit<CustomProperties, 'provisionedRedshiftProps'> & {
   readonly dataRoleName: string;

--- a/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
+++ b/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
@@ -2669,7 +2669,7 @@ describe('DataAnalyticsRedshiftStack serverless custom resource test', () => {
       },
       databaseName: RefAnyValue,
       dataAPIRole: RefAnyValue,
-      lastModifiedTime: Match.anyValue(),
+      schemaHash: Match.anyValue(),
       serverlessRedshiftProps: {
         databaseName: RefAnyValue,
         namespaceId: RefAnyValue,

--- a/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
@@ -69,7 +69,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
       redshiftBIUsernamePrefix: biUserNamePrefix,
       reportingViewsDef,
       schemaDefs,
-      lastModifiedTime: 1699345775001,
+      schemaHash: '123456789',
     },
   };
 
@@ -373,13 +373,13 @@ describe('Custom resource - Create schemas for applications in Redshift database
 
   });
 
-  test('Updated schemas and views in Redshift provisioned cluster with same lastModifiedTime', async () => {
+  test('Updated schemas and views in Redshift provisioned cluster with same lastSchemaHash', async () => {
     redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
     redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
 
-    const lastModifiedTime = new Date().getTime();
-    updateAdditionalProvisionedEvent.OldResourceProperties.lastModifiedTime = lastModifiedTime;
-    updateAdditionalProvisionedEvent.ResourceProperties.lastModifiedTime = lastModifiedTime;
+    const lastSchemaHash = 'this is a hash code';
+    updateAdditionalProvisionedEvent.OldResourceProperties.schemaHash = lastSchemaHash;
+    updateAdditionalProvisionedEvent.ResourceProperties.schemaHash = lastSchemaHash;
 
     const resp = await handler(updateAdditionalProvisionedEvent, context, callback) as CdkCustomResourceResponse;
 
@@ -398,9 +398,9 @@ describe('Custom resource - Create schemas for applications in Redshift database
     redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
     redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
 
-    const lastModifiedTime = new Date().getTime();
-    updateAdditionalProvisionedEvent.OldResourceProperties.lastModifiedTime = lastModifiedTime;
-    updateAdditionalProvisionedEvent.ResourceProperties.lastModifiedTime = lastModifiedTime;
+    const lastSchemaHash = 'this is a hash code';
+    updateAdditionalProvisionedEvent.OldResourceProperties.schemaHash = lastSchemaHash;
+    updateAdditionalProvisionedEvent.ResourceProperties.schemaHash = lastSchemaHash;
 
     const resp = await handler(updateAdditionalProvisionedEvent, context, callback) as CdkCustomResourceResponse;
 
@@ -413,13 +413,13 @@ describe('Custom resource - Create schemas for applications in Redshift database
     expect(sfnClientMock).toHaveReceivedCommandTimes(StartExecutionCommand, 2);
   });
 
-  test('Updated schemas and views in Redshift provisioned cluster with lastModifiedTime changed', async () => {
+  test('Updated schemas and views in Redshift provisioned cluster with last schema hash changed', async () => {
     redshiftDataMock.on(ExecuteStatementCommand).resolves({ Id: 'Id-1' });
     redshiftDataMock.on(DescribeStatementCommand).resolves({ Status: 'FINISHED' });
 
-    const lastModifiedTime = new Date().getTime();
-    updateAdditionalProvisionedEvent.OldResourceProperties.lastModifiedTime = lastModifiedTime;
-    updateAdditionalProvisionedEvent.ResourceProperties.lastModifiedTime = lastModifiedTime + 1;
+    const lastSchemaHash = 'this is a hash code';
+    updateAdditionalProvisionedEvent.OldResourceProperties.schemaHash = lastSchemaHash;
+    updateAdditionalProvisionedEvent.ResourceProperties.schemaHash = lastSchemaHash + '1';
 
     const resp = await handler(updateAdditionalProvisionedEvent, context, callback) as CdkCustomResourceResponse;
 

--- a/test/streaming-ingestion/streaming-ingestion-stack.test.ts
+++ b/test/streaming-ingestion/streaming-ingestion-stack.test.ts
@@ -963,7 +963,7 @@ describe('resources in nested redshift stacks', () => {
           workgroupName: RefAnyValue,
           databaseName: RefAnyValue,
         },
-        lastModifiedTime: Match.anyValue(),
+        schemaHash: Match.anyValue(),
         projectId: RefAnyValue,
         appIds: RefAnyValue,
         databaseName: RefAnyValue,


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

refactor sql script update according to hash code change

## Implementation highlights

refactor sql script update according to hash code change

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend