### PR TITLE
chore: remove GlueTablePartition default concurrent executions config

### DIFF
--- a/src/data-pipeline/utils/utils-lambda.ts
+++ b/src/data-pipeline/utils/utils-lambda.ts
@@ -99,7 +99,6 @@ export class LambdaUtil {
         securityGroups: [securityGroupForLambda],
         role: lambdaRole,
         entry: join(__dirname, '..', 'lambda', 'partition-syncer', 'index.ts'),
-        reservedConcurrentExecutions: 1,
         environment: {
           SOURCE_S3_BUCKET_NAME: this.props.sourceS3Bucket.bucketName,
           SOURCE_S3_PREFIX: this.props.sourceS3Prefix,

--- a/src/data-pipeline/utils/utils-lambda.ts
+++ b/src/data-pipeline/utils/utils-lambda.ts
@@ -13,7 +13,7 @@
 
 import { join } from 'path';
 import { Database, Table } from '@aws-cdk/aws-glue-alpha';
-import { Duration, Stack } from 'aws-cdk-lib';
+import { Duration, Stack, CfnResource } from 'aws-cdk-lib';
 
 import { ISecurityGroup, IVpc, SubnetSelection } from 'aws-cdk-lib/aws-ec2';
 import { Tracing, Function } from 'aws-cdk-lib/aws-lambda';
@@ -23,6 +23,7 @@ import { Construct } from 'constructs';
 
 import { RoleUtil } from './utils-role';
 
+import { addCfnNagSuppressRules } from '../../common/cfn-nag';
 import { attachListTagsPolicyForFunction } from '../../common/lambda/tags';
 import { getShortIdOfStack } from '../../common/stack';
 import { SolutionNodejsFunction } from '../../private/function';
@@ -116,9 +117,14 @@ export class LambdaUtil {
         applicationLogLevel: 'WARN',
       },
     );
+    addCfnNagSuppressRules(fn.node.defaultChild as CfnResource, [
+      {
+        id: 'W92',
+        reason: 'Lambda is used as custom resource, ignore setting ReservedConcurrentExecutions',
+      },
+    ]);
     return fn;
   }
-
 
   public createEmrJobSubmitterLambda(
     glueDB: Database,

--- a/test/data-pipeline/data-pipeline-stack.test.ts
+++ b/test/data-pipeline/data-pipeline-stack.test.ts
@@ -868,6 +868,7 @@ describe('DataPipelineStack Glue catalog resources test', () => {
       Role: {
         'Fn::GetAtt': [lambdaRoleKey, 'Arn'],
       },
+      ReservedConcurrentExecutions: Match.absent(),
     });
   });
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

remove GlueTablePartition default concurrent executions config

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [x] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend