### PR TITLE
fix: the stack parameter for data rentention in Redshift not work

### DIFF
--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -198,7 +198,7 @@ export interface DataModeling {
     readonly fileSuffix: string;
   };
   readonly redshift?: {
-    readonly dataRange: string;
+    readonly dataRange: number;
     readonly newServerless?: {
       readonly baseCapacity: number;
       readonly network: RedshiftNetworkProps;

--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -924,6 +924,13 @@ export class CDataModelingStack extends JSONObject {
 
   @JSONObject.optional(365)
   @JSONObject.gte(1)
+  @JSONObject.custom( (stack :CDataModelingStack, _key:string, _value:any) => {
+    const dataRange = stack._pipeline?.dataModeling?.redshift?.dataRange;
+    if (!dataRange) {
+      return 365;
+    }
+    return Math.floor(dataRange / 24 / 60);
+  })
     ClearExpiredEventsRetentionRangeDays?: number;
 
   @JSONObject.optional(REDSHIFT_MODE.NEW_SERVERLESS)

--- a/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
@@ -372,7 +372,7 @@ export const S3_DATA_PROCESSING_WITH_SPECIFY_PREFIX_PIPELINE: IPipeline = {
   dataModeling: {
     athena: false,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       newServerless: {
         network: {
           vpcId: 'vpc-00000000000000001',
@@ -448,7 +448,7 @@ export const MSK_DATA_PROCESSING_NEW_SERVERLESS_PIPELINE: IPipeline = {
     },
     athena: true,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       newServerless: {
         network: {
           vpcId: 'vpc-00000000000000001',
@@ -506,7 +506,7 @@ export const MSK_DATA_PROCESSING_NEW_SERVERLESS_PIPELINE_WITH_WORKFLOW: IPipelin
     },
     athena: true,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       newServerless: {
         network: {
           vpcId: 'vpc-00000000000000001',
@@ -705,7 +705,7 @@ export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE: IPipeline = {
     },
     athena: false,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       newServerless: {
         network: {
           vpcId: 'vpc-00000000000000001',
@@ -763,7 +763,7 @@ export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_WITH_ERROR_RPU_PIPELINE: IPipe
     },
     athena: false,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       newServerless: {
         network: {
           vpcId: 'vpc-00000000000000001',
@@ -821,7 +821,7 @@ export const KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_PIPELINE: IPipeline = 
     },
     athena: true,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       provisioned: {
         clusterIdentifier: 'redshift-cluster-1',
         dbUser: 'clickstream',
@@ -868,7 +868,7 @@ export const KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_THIRDPARTY_PIPELINE: I
     },
     athena: true,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       provisioned: {
         clusterIdentifier: 'redshift-cluster-1',
         dbUser: 'clickstream',
@@ -899,7 +899,7 @@ export const KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_EMPTY_DBUSER_QUICKSIGH
     ...KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_PIPELINE.dataModeling,
     athena: true,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       provisioned: {
         clusterIdentifier: 'redshift-cluster-1',
         dbUser: '',
@@ -914,7 +914,7 @@ export const KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_ERROR_DBUSER_QUICKSIGH
     ...KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_PIPELINE.dataModeling,
     athena: true,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       provisioned: {
         clusterIdentifier: 'redshift-cluster-1',
         dbUser: 'HGF%$#@BHHGF',
@@ -1650,7 +1650,7 @@ const BASE_RETRY_PIPELINE: IPipeline = {
     },
     athena: false,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       newServerless: {
         network: {
           vpcId: 'vpc-00000000000000001',

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -637,7 +637,7 @@ describe('Pipeline test', () => {
           },
           athena: false,
           redshift: {
-            dataRange: 'rate(6 months)',
+            dataRange: 259200,
             newServerless: {
               network: {
                 vpcId: 'vpc-00000000000000001',
@@ -701,7 +701,7 @@ describe('Pipeline test', () => {
           },
           athena: false,
           redshift: {
-            dataRange: 'rate(6 months)',
+            dataRange: 259200,
             newServerless: {
               network: {
                 vpcId: 'vpc-00000000000000001',

--- a/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
@@ -758,7 +758,7 @@ const BASE_DATAANALYTICS_PARAMETERS = [
   },
   {
     ParameterKey: 'ClearExpiredEventsRetentionRangeDays',
-    ParameterValue: '365',
+    ParameterValue: '180',
   },
   {
     ParameterKey: 'RedshiftMode',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend