### PR TITLE
chore: add parameters for AppRegistry and role boundary

### DIFF
--- a/test/streaming-ingestion/streaming-ingestion-stack.test.ts
+++ b/test/streaming-ingestion/streaming-ingestion-stack.test.ts
@@ -172,6 +172,18 @@ describe('common parameter test of StreamingIngestionStack', () => {
           e[CFN_FN.NOT][0][CFN_FN.EQUALS][0].Ref === 'RedshiftDataAPIRole').toBeTruthy();
     }
   });
+
+  test('Should has Parameter AppRegistryApplicationArn', () => {
+    template.hasParameter('AppRegistryApplicationArn', {
+      Type: 'String',
+    });
+  });
+
+  test('Should has Parameter IamRoleBoundaryArn', () => {
+    template.hasParameter('IamRoleBoundaryArn', {
+      Type: 'String',
+    });
+  });
 });
 
 describe('have custom resource to provisioning sink kinesis', () => {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend