### PR TITLE
chore: fix example data generator user first touch timestamp

### DIFF
--- a/examples/standalone-data-generator/application/shopping/ShoppingApp.py
+++ b/examples/standalone-data-generator/application/shopping/ShoppingApp.py
@@ -123,12 +123,13 @@ def get_launch_events(user, event):
         event["attributes"]["_latest_referrer_host"] = referrer[1]
     # handle first open
     if user.is_first_open:
-        event["attributes"]["_session_start_timestamp"] = user.current_timestamp
-        event["user"]["_user_first_touch_timestamp"]["value"] = user.current_timestamp
-        event["user"]["_user_first_touch_timestamp"]["set_timestamp"] = user.current_timestamp
+        current_timestamp = user.current_timestamp
+        event["attributes"]["_session_start_timestamp"] = current_timestamp
+        event["user"]["_user_first_touch_timestamp"]["value"] = current_timestamp
+        event["user"]["_user_first_touch_timestamp"]["set_timestamp"] = current_timestamp
         events.append(get_final_event(user, EventType.FIRST_OPEN, clean_event(event)))
         user.is_first_open = False
-        user.first_touch_timestamp = user.current_timestamp
+        user.first_touch_timestamp = current_timestamp
     # add user attribute if user is login
     if user.is_login:
         user_id = {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. fix example data generator user first touch timestamp

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend