### PR TITLE
fix: the stack parameter for data rentention in Redshift not work (#994)

### DIFF
--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -174,7 +174,7 @@ export interface DataModeling {
     readonly fileSuffix: string;
   };
   readonly redshift?: {
-    readonly dataRange: string;
+    readonly dataRange: number;
     readonly newServerless?: {
       readonly baseCapacity: number;
       readonly network: RedshiftNetworkProps;

--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -887,6 +887,13 @@ export class CDataModelingStack extends JSONObject {
 
   @JSONObject.optional(365)
   @JSONObject.gte(1)
+  @JSONObject.custom( (stack :CDataModelingStack, _key:string, _value:any) => {
+    const dataRange = stack._pipeline?.dataModeling?.redshift?.dataRange;
+    if (!dataRange) {
+      return 365;
+    }
+    return Math.floor(dataRange / 24 / 60);
+  })
     ClearExpiredEventsRetentionRangeDays?: number;
 
   @JSONObject.optional(REDSHIFT_MODE.NEW_SERVERLESS)

--- a/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
@@ -366,7 +366,7 @@ export const S3_DATA_PROCESSING_WITH_SPECIFY_PREFIX_PIPELINE: IPipeline = {
   dataModeling: {
     athena: false,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       newServerless: {
         network: {
           vpcId: 'vpc-00000000000000001',
@@ -442,7 +442,7 @@ export const MSK_DATA_PROCESSING_NEW_SERVERLESS_PIPELINE: IPipeline = {
     },
     athena: true,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       newServerless: {
         network: {
           vpcId: 'vpc-00000000000000001',
@@ -500,7 +500,7 @@ export const MSK_DATA_PROCESSING_NEW_SERVERLESS_PIPELINE_WITH_WORKFLOW: IPipelin
     },
     athena: true,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       newServerless: {
         network: {
           vpcId: 'vpc-00000000000000001',
@@ -699,7 +699,7 @@ export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE: IPipeline = {
     },
     athena: false,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       newServerless: {
         network: {
           vpcId: 'vpc-00000000000000001',
@@ -757,7 +757,7 @@ export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_WITH_ERROR_RPU_PIPELINE: IPipe
     },
     athena: false,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       newServerless: {
         network: {
           vpcId: 'vpc-00000000000000001',
@@ -815,7 +815,7 @@ export const KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_PIPELINE: IPipeline = 
     },
     athena: true,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       provisioned: {
         clusterIdentifier: 'redshift-cluster-1',
         dbUser: 'clickstream',
@@ -862,7 +862,7 @@ export const KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_THIRDPARTY_PIPELINE: I
     },
     athena: true,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       provisioned: {
         clusterIdentifier: 'redshift-cluster-1',
         dbUser: 'clickstream',
@@ -893,7 +893,7 @@ export const KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_EMPTY_DBUSER_QUICKSIGH
     ...KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_PIPELINE.dataModeling,
     athena: true,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       provisioned: {
         clusterIdentifier: 'redshift-cluster-1',
         dbUser: '',
@@ -908,7 +908,7 @@ export const KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_ERROR_DBUSER_QUICKSIGH
     ...KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_PIPELINE.dataModeling,
     athena: true,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       provisioned: {
         clusterIdentifier: 'redshift-cluster-1',
         dbUser: 'HGF%$#@BHHGF',
@@ -1632,7 +1632,7 @@ const BASE_RETRY_PIPELINE: IPipeline = {
     },
     athena: false,
     redshift: {
-      dataRange: 'rate(6 months)',
+      dataRange: 259200,
       newServerless: {
         network: {
           vpcId: 'vpc-00000000000000001',

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -630,7 +630,7 @@ describe('Pipeline test', () => {
           },
           athena: false,
           redshift: {
-            dataRange: 'rate(6 months)',
+            dataRange: 259200,
             newServerless: {
               network: {
                 vpcId: 'vpc-00000000000000001',
@@ -695,7 +695,7 @@ describe('Pipeline test', () => {
           },
           athena: false,
           redshift: {
-            dataRange: 'rate(6 months)',
+            dataRange: 259200,
             newServerless: {
               network: {
                 vpcId: 'vpc-00000000000000001',

--- a/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
@@ -717,7 +717,7 @@ const BASE_DATAANALYTICS_PARAMETERS = [
   },
   {
     ParameterKey: 'ClearExpiredEventsRetentionRangeDays',
-    ParameterValue: '365',
+    ParameterValue: '180',
   },
   {
     ParameterKey: 'RedshiftMode',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend