### PR TITLE
chore: redirect the last visited page when user re-login

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -42,7 +42,7 @@ import React, { Suspense, useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AuthContextProps } from 'react-oidc-context';
 import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
-import { IUserRole } from 'ts/const';
+import { IUserRole, LAST_VISIT_URL } from 'ts/const';
 import { getIntersectArrays, getUserInfoFromLocalStorage } from 'ts/utils';
 import Home from './pages/home/Home';
 
@@ -63,10 +63,15 @@ const LoginCallback: React.FC<LoginCallbackProps> = (
   const [unexpectedErrorMessage, setUnexpectedErrorMessage] = useState('');
 
   const gotoBasePage = () => {
-    window.location.href = `${BASE_URL}`;
+    const lastVisitUrl = localStorage.getItem(LAST_VISIT_URL) ?? BASE_URL;
+    localStorage.removeItem(LAST_VISIT_URL);
+    window.location.href = `${lastVisitUrl}`;
   };
   const gotoAnalyticsPage = () => {
-    window.location.href = `${BASE_URL}analytics`;
+    const lastVisitUrl =
+      localStorage.getItem(LAST_VISIT_URL) ?? `${BASE_URL}analytics`;
+    localStorage.removeItem(LAST_VISIT_URL);
+    window.location.href = `${lastVisitUrl}`;
   };
 
   const getUserInfo = async () => {
@@ -122,10 +127,11 @@ const LoginCallback: React.FC<LoginCallbackProps> = (
 
 interface AppRouterProps {
   auth: any;
+  sessionExpired: boolean;
 }
 
 const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
-  const { auth } = props;
+  const { auth, sessionExpired } = props;
   return (
     <Router>
       <Suspense fallback={null}>
@@ -135,6 +141,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="common"
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.OPERATOR]}
@@ -147,6 +154,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/projects"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="common"
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.OPERATOR]}
@@ -159,6 +167,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/alarms"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="common"
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.OPERATOR]}
@@ -170,7 +179,12 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
           <Route
             path="/user"
             element={
-              <RoleRoute layout="common" auth={auth} roles={[IUserRole.ADMIN]}>
+              <RoleRoute
+                sessionExpired={sessionExpired}
+                layout="common"
+                auth={auth}
+                roles={[IUserRole.ADMIN]}
+              >
                 <UserList />
               </RoleRoute>
             }
@@ -180,6 +194,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/project/detail/:id"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="common"
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.OPERATOR]}
@@ -192,6 +207,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/project/:pid/pipeline/:id"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="common"
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.OPERATOR]}
@@ -204,6 +220,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/project/:pid/pipeline/:id/update"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="common"
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.OPERATOR]}
@@ -216,6 +233,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/project/:projectId/pipelines/create"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="common"
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.OPERATOR]}
@@ -228,6 +246,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/pipelines/create"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="common"
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.OPERATOR]}
@@ -240,6 +259,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/project/:id/application/create"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="common"
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.OPERATOR]}
@@ -252,6 +272,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/plugins"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="common"
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.OPERATOR]}
@@ -264,6 +285,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/plugins/create"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="common"
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.OPERATOR]}
@@ -276,6 +298,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/project/:pid/application/detail/:id"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="common"
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.OPERATOR]}
@@ -288,6 +311,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/analytics"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="none"
                 auth={auth}
                 roles={[
@@ -304,6 +328,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/analytics/:projectId/app/:appId/data-management"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="analytics"
                 auth={auth}
                 roles={[
@@ -320,6 +345,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/analytics/:projectId/app/:appId/realtime"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="analytics"
                 auth={auth}
                 roles={[
@@ -336,6 +362,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/analytics/:projectId/app/:appId/explore"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="analytics"
                 auth={auth}
                 roles={[
@@ -352,6 +379,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/analytics/:projectId/app/:appId/analyzes"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="analytics"
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.ANALYST]}
@@ -364,6 +392,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/analytics/:projectId/app/:appId/analyzes/full"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="none"
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.ANALYST]}
@@ -376,6 +405,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/analytics/:projectId/app/:appId/dashboards"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="analytics"
                 auth={auth}
                 roles={[
@@ -392,6 +422,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/analytics/:projectId/app/:appId/dashboard/:dashboardId"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="analytics"
                 auth={auth}
                 roles={[
@@ -408,6 +439,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/analytics/:projectId/app/:appId/dashboard/full/:dashboardId"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="none"
                 auth={auth}
                 roles={[
@@ -424,6 +456,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/analytics/:projectId/app/:appId/segments"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="analytics"
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.ANALYST]}
@@ -436,6 +469,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
             path="/analytics/:projectId/app/:appId/segments/add"
             element={
               <RoleRoute
+                sessionExpired={sessionExpired}
                 layout="analytics"
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.ANALYST]}

--- a/frontend/src/AppSignInPage.tsx
+++ b/frontend/src/AppSignInPage.tsx
@@ -47,7 +47,6 @@ const SignedInPage: React.FC = () => {
   };
 
   useEffect(() => {
-    console.info('auth:', auth);
     if (auth.isAuthenticated) {
       getCurrentUser();
     }

--- a/frontend/src/AppSignInPage.tsx
+++ b/frontend/src/AppSignInPage.tsx
@@ -47,6 +47,7 @@ const SignedInPage: React.FC = () => {
   };
 
   useEffect(() => {
+    console.info('auth:', auth);
     if (auth.isAuthenticated) {
       getCurrentUser();
     }
@@ -57,13 +58,18 @@ const SignedInPage: React.FC = () => {
   }
 
   if (auth.error) {
-    return <ReSignIn auth={auth} />;
+    return (
+      <>
+        <ReSignIn auth={auth} />
+        <AppRouter sessionExpired={true} auth={auth} />
+      </>
+    );
   }
 
   if (auth.isAuthenticated) {
     return (
       <UserContext.Provider value={currentUser}>
-        <AppRouter auth={auth} />
+        <AppRouter auth={auth} sessionExpired={false} />
       </UserContext.Provider>
     );
   }

--- a/frontend/src/components/common/RoleRoute.tsx
+++ b/frontend/src/components/common/RoleRoute.tsx
@@ -25,11 +25,13 @@ const RoleRoute = ({
   layout,
   auth,
   children,
+  sessionExpired,
   roles,
 }: {
   auth: AuthContextProps;
   layout: 'common' | 'analytics' | 'none';
   children: ReactElement;
+  sessionExpired: boolean;
   roles: Array<IUserRole>;
 }) => {
   const currentUser = useContext(UserContext) ?? getUserInfoFromLocalStorage();
@@ -42,7 +44,7 @@ const RoleRoute = ({
     return <Loading isPage />;
   }
 
-  if (!userHasRequiredRole) {
+  if (!userHasRequiredRole && !sessionExpired) {
     if (layout === 'analytics') {
       return (
         <AnalyticsLayout auth={auth}>

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1293,3 +1293,17 @@ ul.menu-list li.checkbox-item {
     }
   }
 }
+
+.re-sign-in {
+  .alert-container {
+    display: flex;
+    height: 100vh;
+    align-items: center;
+    justify-content: center;
+  }
+}
+.re-sign-in-modal {
+  [class^='awsui_dismiss-control'] {
+    display: none !important;
+  }
+}

--- a/frontend/src/pages/error-page/ReSignIn.tsx
+++ b/frontend/src/pages/error-page/ReSignIn.tsx
@@ -11,42 +11,53 @@
  *  and limitations under the License.
  */
 
-import { Container, Alert, Button } from '@cloudscape-design/components';
-import CommonLayout from 'components/layouts/CommonLayout';
+import {
+  Alert,
+  Box,
+  Button,
+  Modal,
+  SpaceBetween,
+} from '@cloudscape-design/components';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { AuthContextProps } from 'react-oidc-context';
+import { LAST_VISIT_URL } from 'ts/const';
 
 interface ReSignInProps {
   auth: AuthContextProps;
 }
 
 const ReSignIn: React.FC<ReSignInProps> = (props: ReSignInProps) => {
-  const { auth } = props;
   const { t } = useTranslation();
   return (
-    <CommonLayout auth={auth}>
-      <Container>
-        <div className="mt-10">
-          <Alert
-            action={
+    <div className="re-sign-in">
+      <Modal
+        className="re-sign-in-modal"
+        visible={true}
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
               <Button
                 onClick={() => {
-                  window.location.href = '/';
+                  localStorage.setItem(LAST_VISIT_URL, window.location.href);
+                  window.location.reload();
                 }}
+                variant="primary"
               >
                 {t('button.reload')}
               </Button>
-            }
-            statusIconAriaLabel="Error"
-            type="warning"
-            header={t('header.reSignIn')}
-          >
+            </SpaceBetween>
+          </Box>
+        }
+        header={t('header.reSignIn')}
+      >
+        <div className="mt-10">
+          <Alert statusIconAriaLabel="Error" type="warning">
             {t('header.reSignInDesc')}
           </Alert>
         </div>
-      </Container>
-    </CommonLayout>
+      </Modal>
+    </div>
   );
 };
 

--- a/frontend/src/ts/const.ts
+++ b/frontend/src/ts/const.ts
@@ -26,6 +26,7 @@ export const ANALYTICS_NAV_STATUS = 'ClickStreamAnalyticsNavigationStatus';
 export const ANALYTICS_NAV_ITEM = 'ClickStreamAnalyticsNavigationItem';
 export const CLICK_STREAM_USER_DATA = 'ClickStreamAnalyticsUserInformation';
 export const CONFIG_URL = '/aws-exports.json';
+export const LAST_VISIT_URL = 'ClickStreamAnalyticsLastVisitUrl';
 
 export const ALPHABETS = Array.from({ length: 26 }, (_, index) =>
   String.fromCharCode(65 + index)


### PR DESCRIPTION
----

All brand new session expire experience.

The code already renew the token by the OIDC configuration:
https://github.com/awslabs/clickstream-analytics-on-aws/blob/acf13f12f360980f2c4f9f3b5923aed1c656db33/frontend/src/App.tsx#L39

New session expire UI:
<img width="1301" alt="image" src="https://github.com/awslabs/clickstream-analytics-on-aws/assets/7011985/2140493b-a497-4d1d-bf9d-a5d830f5d7be">



*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend