### PR TITLE
docs: add record screen views for react navigation in SDK manual

### DIFF
--- a/.github/workflows/ghpage.yml
+++ b/.github/workflows/ghpage.yml
@@ -10,7 +10,7 @@ on:
       - src/analytics/private/sqls/**
       - .github/workflows/ghpage.yml
   pull_request:
-  merge_group: { }
+  merge_group: {}
 jobs:
   pages:
     runs-on: ubuntu-latest

--- a/.github/workflows/ghpage.yml
+++ b/.github/workflows/ghpage.yml
@@ -10,7 +10,7 @@ on:
       - src/analytics/private/sqls/**
       - .github/workflows/ghpage.yml
   pull_request:
-  merge_group: {}
+  merge_group: { }
 jobs:
   pages:
     runs-on: ubuntu-latest

--- a/docs/en/sdk-manual/android.md
+++ b/docs/en/sdk-manual/android.md
@@ -545,6 +545,9 @@ You can use the above preset item attributes, of course, you can also add custom
 
 [GitHub change log](https://github.com/awslabs/clickstream-android/releases)
 
+## Sample project
+Sample [Android Project](https://github.com/aws-samples/clickstream-sdk-samples/tree/main/android) for SDK integration.
+
 ## Reference link
 
 [Source code](https://github.com/awslabs/clickstream-android)

--- a/docs/en/sdk-manual/react-native.md
+++ b/docs/en/sdk-manual/react-native.md
@@ -193,6 +193,11 @@ ClickstreamAnalytics.record({
 });
 ```
 
+#### Record Screen Views for React Navigation
+Here's an [example](https://github.com/aws-samples/clickstream-sdk-samples/pull/25/files#diff-96a74db413b2f02988e5537fdbdf4f307334e8f5ef3a9999df7de3c6785af75bR344-R397) of globally logging React Native screen view events when using React Navigation 6.x
+
+For other version of React Navigation, you can refer to official documentation: [Screen tracking for analytics](https://reactnavigation.org/docs/screen-tracking/).
+
 #### Send event immediately
 
 ```typescript
@@ -319,6 +324,9 @@ React Native SDK version dependencies
 | React Native SDK Version | Android SDK Version | Swift SDK Version |
 |--------------------------|---------------------|-------------------|
 | 0.1.0                    | 0.12.0              | 0.11.0            |
+
+## Sample project
+Sample [React Native Project](https://github.com/aws-samples/clickstream-sdk-samples/tree/main/react-native) for SDK integration.
 
 ## Reference link
 

--- a/docs/en/sdk-manual/swift.md
+++ b/docs/en/sdk-manual/swift.md
@@ -686,6 +686,9 @@ You can use the above preset item attributes, of course, you can also add custom
 
 [GitHub change log](https://github.com/awslabs/clickstream-swift/releases)
 
+## Sample project
+Sample [iOS Project](https://github.com/aws-samples/clickstream-sdk-samples/tree/main/ios) for SDK integration.
+
 ## Reference link
 
 [Source code](https://github.com/awslabs/clickstream-swift)

--- a/docs/en/sdk-manual/web.md
+++ b/docs/en/sdk-manual/web.md
@@ -508,6 +508,9 @@ You can use the above preset item attributes, of course, you can also add custom
 
 [GitHub Change log](https://github.com/awslabs/clickstream-web/releases)
 
+## Sample project
+Sample [Web Project](https://github.com/aws-samples/clickstream-sdk-samples/tree/main/web) for SDK integration.
+
 ## Reference link
 
 [Source code](https://github.com/awslabs/clickstream-web)

--- a/docs/zh/sdk-manual/android.md
+++ b/docs/zh/sdk-manual/android.md
@@ -551,6 +551,9 @@ Clickstream Android SDK 支持以下数据类型：
 
 参考：[GitHub 更新日志](https://github.com/awslabs/clickstream-android/releases)
 
+## 示例项目
+集成 SDK 的示例 [Android 项目](https://github.com/aws-samples/clickstream-sdk-samples/tree/main/android)
+
 ## 参考链接
 
 [SDK 源码](https://github.com/awslabs/clickstream-android)

--- a/docs/zh/sdk-manual/react-native.md
+++ b/docs/zh/sdk-manual/react-native.md
@@ -188,6 +188,11 @@ ClickstreamAnalytics.record({
 });
 ```
 
+#### 记录 React Navigation 的 Screen View 事件
+此 [示例](https://github.com/aws-samples/clickstream-sdk-samples/pull/25/files#diff-96a74db413b2f02988e5537fdbdf4f307334e8f5ef3a9999df7de3c6785af75bR344-R397) 代码演示了 React Navigation 6.x 版本如何全局记录 `_screen_view` 事件。
+
+对于其他版本的 React Navigation，你可以参考官方文档：[Screen tracking for analytics](https://reactnavigation.org/docs/screen-tracking/)
+
 #### 实时发送事件
 
 ```typescript
@@ -312,6 +317,9 @@ iOS: 参考 [Swift SDK 事件属性](./swift.md#_18)
 | React Native SDK 版本 | Android SDK 版本 | Swift SDK 版本 |
 |---------------------|----------------|--------------|
 | 0.1.0               | 0.12.0         | 0.11.0       |
+
+## 示例项目
+集成 SDK 的示例 [React Native 项目](https://github.com/aws-samples/clickstream-sdk-samples/tree/main/react-native)
 
 ## 参考链接
 

--- a/docs/zh/sdk-manual/swift.md
+++ b/docs/zh/sdk-manual/swift.md
@@ -688,6 +688,9 @@ Clickstream Swift SDK 支持以下数据类型：
 
 参考：[GitHub 更新日志](https://github.com/awslabs/clickstream-swift/releases)
 
+## 示例项目
+集成 SDK 的示例 [iOS 项目](https://github.com/aws-samples/clickstream-sdk-samples/tree/main/ios)
+
 ## 参考链接
 
 [SDK 源码](https://github.com/awslabs/clickstream-swift)

--- a/docs/zh/sdk-manual/web.md
+++ b/docs/zh/sdk-manual/web.md
@@ -510,6 +510,9 @@ Clickstream Web SDK 支持以下数据类型：
 
 参考：[GitHub 更新日志](https://github.com/awslabs/clickstream-web/releases)
 
+## 示例项目
+集成 SDK 的示例 [Web 项目](https://github.com/aws-samples/clickstream-sdk-samples/tree/main/web)
+
 ## 参考链接
 
 [SDK 源码](https://github.com/awslabs/clickstream-web)


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. add record screen view events documentation for react navigation
2. add sample project link in SDK manual

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend