### PR TITLE
docs: add record screen view events in flutter SDK manual

### DIFF
--- a/docs/en/sdk-manual/flutter.md
+++ b/docs/en/sdk-manual/flutter.md
@@ -75,19 +75,36 @@ analytics.record(name: "button_click");
 
 #### Add global attribute
 
-```dart
-analytics.addGlobalAttributes({
-  "_traffic_source_medium": "Search engine",
-  "_traffic_source_name": "Summer promotion",
-  "level": 10
-});
+1. Add global attributes when initializing the SDK
 
-// delete global attribute
-analytics.deleteGlobalAttributes(["level"]);
-```
+   ```dart
+   analytics.init({
+     appId: "your appId",
+     endpoint: "https://example.com/collect",
+     globalAttributes: {
+       "_traffic_source_medium": "Search engine",
+       "_traffic_source_name": "Summer promotion",
+     }
+   });
+   ```
+
+2. Add global attributes after initializing the SDK
+   ```dart
+   analytics.addGlobalAttributes({
+     "_traffic_source_medium": "Search engine",
+     "_traffic_source_name": "Summer promotion",
+     "level": 10
+   });
+   ```
 
 It is recommended to set global attributes after each SDK initialization, global attributes will be included in all
 events that occur after it is set.
+
+#### Delete global attribute
+
+```
+analytics.deleteGlobalAttributes(["level"]);
+```
 
 #### Login and logout
 
@@ -133,8 +150,8 @@ var itemBook = ClickstreamItem(
 analytics.record(
     name: "view_item", 
     attributes: {
-        "currency": 'USD',
-        "event_category": 'recommended'
+        "currency": "USD",
+        "event_category": "recommended"
     }, 
     items: [itemBook]
 );
@@ -147,6 +164,26 @@ For logging more attribute in an item, please refer to [item attributes](android
     Only pipelines from version 1.1+ can handle items with custom attribute.
     
     item id is required attribute, if not set the item will be discarded.
+
+#### Record Screen View events manually
+
+By default, SDK will automatically track the preset `_screen_view` event when Android Activity triggers `onResume` or
+iOS ViewController triggers `viewDidAppear`.
+
+You can also manually record screen view events whether automatic screen view tracking is enabled, add the following
+code to record a screen view event with two attributes.
+
+* `screenName` Required. Your screen's name.
+* `screenUniqueId` Optional. Set the id of your Widget. If you do not set, the SDK will set a default value based on the
+  hashcode of the current Activity or ViewController.
+
+```dart
+analytics.recordScreenView(
+  screenName: 'Main',
+  screenUniqueId: '123adf',
+  attributes: { ... }
+);
+```
 
 #### Other configurations
 
@@ -164,24 +201,28 @@ analytics.init(
   isTrackUserEngagementEvents: true,
   isTrackAppExceptionEvents: false,
   authCookie: "your auth cookie",
-  sessionTimeoutDuration: 1800000
+  sessionTimeoutDuration: 1800000,
+  globalAttributes: {
+    "_traffic_source_medium": "Search engine",
+  }
 );
 ```
 
 Here is an explanation of each option:
 
-| Name                        | Required | Default value | Description                                                                                    |
-|-----------------------------|----------|---------------|------------------------------------------------------------------------------------------------|
-| appId                       | true     | --            | the app id of your application in control plane                                                |
-| endpoint                    | true     | --            | the endpoint path you will upload the event to Clickstream ingestion server                    |
-| isLogEvents                 | false    | false         | whether to print out event json in console for debugging events, [Learn more](#debug-events)   |
-| isCompressEvents            | false    | true          | whether to compress event content by gzip when uploading events                                |
-| sendEventsInterval          | false    | 10000         | event sending interval in milliseconds                                                         |
-| isTrackScreenViewEvents     | false    | true          | whether auto record screen view events in app                                                  |
-| isTrackUserEngagementEvents | false    | true          | whether auto record user engagement events in app                                              |
-| isTrackAppExceptionEvents   | false    | false         | whether auto track exception event in app                                                      |
-| authCookie                  | false    | --            | your auth cookie for AWS application load balancer auth cookie                                 |
-| sessionTimeoutDuration      | false    | 1800000       | the duration for session timeout in milliseconds                                               |
+| Name                        | Required | Default value | Description                                                                                  |
+|-----------------------------|----------|---------------|----------------------------------------------------------------------------------------------|
+| appId                       | true     | --            | the app id of your application in control plane                                              |
+| endpoint                    | true     | --            | the endpoint path you will upload the event to Clickstream ingestion server                  |
+| isLogEvents                 | false    | false         | whether to print out event json in console for debugging events, [Learn more](#debug-events) |
+| isCompressEvents            | false    | true          | whether to compress event content by gzip when uploading events                              |
+| sendEventsInterval          | false    | 10000         | event sending interval in milliseconds                                                       |
+| isTrackScreenViewEvents     | false    | true          | whether auto record screen view events in app                                                |
+| isTrackUserEngagementEvents | false    | true          | whether auto record user engagement events in app                                            |
+| isTrackAppExceptionEvents   | false    | false         | whether auto track exception event in app                                                    |
+| authCookie                  | false    | --            | your auth cookie for AWS application load balancer auth cookie                               |
+| sessionTimeoutDuration      | false    | 1800000       | the duration for session timeout in milliseconds                                             |
+| globalAttributes            | false    | --            | the global attributes when initializing the SDK                                              |
 
 #### Configuration update
 
@@ -198,7 +239,6 @@ analytics.updateConfigure(
     isTrackScreenViewEvents: false
     isTrackUserEngagementEvents: false,
     isTrackAppExceptionEvents: false,
-    sessionTimeoutDuration: 100000,
     authCookie: "test cookie");
 ```
 
@@ -315,6 +355,7 @@ Native SDK version dependencies
 
 | Flutter SDK Version | Android SDK Version | Swift SDK Version |
 |---------------------|---------------------|-------------------|
+| 0.3.0               | 0.12.0              | 0.11.0            |
 | 0.2.0               | 0.10.0              | 0.9.1             |
 | 0.1.0               | 0.9.0               | 0.8.0             |
 

--- a/docs/zh/sdk-manual/flutter.md
+++ b/docs/zh/sdk-manual/flutter.md
@@ -73,17 +73,35 @@ analytics.record(name: "button_click");
 
 #### 添加全局属性
 
+1. 在初始化 SDK 时添加全局属性。
+
+   ```dart
+   analytics.init({
+     appId: "your appId",
+     endpoint: "https://example.com/collect",
+     globalAttributes: {
+       "_traffic_source_medium": "Search engine",
+       "_traffic_source_name": "Summer promotion",
+     }
+   });
+   ```
+
+2. 在初始化 SDK 后添加全局属性。
+   ```dart
+   analytics.addGlobalAttributes({
+     "_traffic_source_medium": "Search engine",
+     "_traffic_source_name": "Summer promotion",
+     "level": 10
+   });
+   ```
+
+建议在初始化 SDK 时设置全局属性，设置后记录的所有事件都会包含全局属性。
+
+#### 删除全局属性
+
 ```dart
-analytics.addGlobalAttributes({
-  "_traffic_source_medium": "Search engine",
-  "_traffic_source_name": "Summer promotion",
-  "level": 10
-});
-// 删除全局属性
 analytics.deleteGlobalAttributes(["level"]);
 ```
-
-建议每次 SDK 初始化后设置全局属性，全局属性将包含在设置后产生的所有事件中。
 
 #### 登录和登出
 
@@ -111,7 +129,6 @@ API `analytics.setUserAttributes()` 在当用户属性改变时来更新当前�
 
     如果您的应用已经上线，这时大部分用户已经登录过，则第一次接入Clickstream SDK时请手动设置一次用户属性，确保后续事件都带有用户属性。
 
-
 #### 记录带有 Item 的事件
 
 您可以添加以下代码来记录带有 Item 的事件，同时您可以在 `attributes` Map 中添加自定义 Item 属性。 除了预置属性外，一个 Item
@@ -131,12 +148,13 @@ var itemBook = ClickstreamItem(
 analytics.record(
     name: "view_item", 
     attributes: {
-        "currency": 'USD',
-        "event_category": 'recommended'
+        "currency": "USD",
+        "event_category": "recommended"
     }, 
     items: [itemBook]
 );
 ```
+
 要记录 Item 中的更多属性，请参阅 [Item 属性](android.md#item_1)。
 
 !!! warning "重要提示"
@@ -144,6 +162,26 @@ analytics.record(
     数据管道的版本需要在 v1.1 及以上才能够处理带有自定义属性的 Item。
     
     ITEM_ID 为必需字段，如果不设置，该 Item 将被丢弃。
+
+#### 手动记录 Screen View 事件
+
+默认情况下，当 Android Activity 触发 `onResume` 或 iOS ViewController 触发 `viewDidAppear` 时，SDK
+会自动记录预置的 `_screen_view` 事件。
+
+无论是否启用预置的 `_screen_view` 事件，您都可以手动记录屏幕浏览事件。添加以下代码以记录带有如下两个属性的 `_screen_view`
+事件。
+
+* `screenName` 必需字段，屏幕的名称。
+* `screenUniqueId` 可选字段，设置为您组件的 id。如果不设置，SDK会以当前原生 Activity 或原生 ViewController 的 hashcode
+  作为默认值。
+
+```dart
+analytics.recordScreenView(
+  screenName: 'Main',
+  screenUniqueId: '123adf',
+  attributes: { ... }
+);
+```
 
 #### 其他配置项
 
@@ -161,7 +199,10 @@ analytics.init(
   isTrackUserEngagementEvents: true,
   isTrackAppExceptionEvents: false,
   authCookie: "your auth cookie",
-  sessionTimeoutDuration: 1800000
+  sessionTimeoutDuration: 1800000,
+  globalAttributes: {
+    "_traffic_source_medium": "Search engine",
+  }
 );
 ```
 
@@ -179,6 +220,7 @@ analytics.init(
 | isTrackAppExceptionEvents   | 否     | false   | 是否自动记录应用崩溃事件                        |
 | authCookie                  | 否     | --      | 您的 AWS 应用程序负载均衡器身份验证 cookie         |
 | sessionTimeoutDuration      | 否     | 1800000 | 会话超时的时长（毫秒）                         |
+| globalAttributes            | 否     | --      | 初始化SDK时的全局属性                        |
 
 #### 更新配置
 
@@ -194,7 +236,6 @@ analytics.updateConfigure(
     isTrackScreenViewEvents: false
     isTrackUserEngagementEvents: false,
     isTrackAppExceptionEvents: false,
-    sessionTimeoutDuration: 100000,
     authCookie: "test cookie");
 ```
 
@@ -303,10 +344,11 @@ iOS: 参考 [Swift SDK 事件属性](./swift.md#_18)
 
 原生 SDK 版本依赖关系
 
-| Flutter SDK 版本  | Android SDK 版本 | Swift SDK 版本 |
-|-----------------|----------------|--------------|
-| 0.2.0           | 0.10.0         | 0.9.1        |
-| 0.1.0           | 0.9.0          | 0.8.0        |
+| Flutter SDK 版本 | Android SDK 版本 | Swift SDK 版本 |
+|----------------|----------------|--------------|
+| 0.3.0          | 0.12.0         | 0.11.0       |
+| 0.2.0          | 0.10.0         | 0.9.1        |
+| 0.1.0          | 0.9.0          | 0.8.0        |
 
 ## 参考链接
 

--- a/docs/zh/sdk-manual/react-native.md
+++ b/docs/zh/sdk-manual/react-native.md
@@ -172,8 +172,8 @@ ClickstreamAnalytics.record({
 无论是否启用预置的 `_screen_view` 事件，您都可以手动记录屏幕浏览事件。添加以下代码以记录带有如下两个属性的 `_screen_view`
 事件。
 
-* `SCREEN_NAME` 必需字段，屏幕的名称
-* `SCREEN_UNIQUE_ID` 可选字段，设置为您组件的 id。 如果不设置，SDK会以当前原生 Activity 或原生 ViewController 的 hashcode
+* `SCREEN_NAME` 必需字段，屏幕的名称。
+* `SCREEN_UNIQUE_ID` 可选字段，设置为您组件的 id。如果不设置，SDK会以当前原生 Activity 或原生 ViewController 的 hashcode
   作为默认值。
 
 ```typescript


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. add record screen view events in flutter SDK manual

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend