### PR TITLE
chore(schema): reporting/model stack supports timezone setting for app

### DIFF
--- a/src/analytics/analytics-on-redshift.ts
+++ b/src/analytics/analytics-on-redshift.ts
@@ -273,6 +273,7 @@ export class RedshiftAnalyticsStack extends NestedStack {
       codePath,
       functionEntry,
       workflowBucketInfo: props.workflowBucketInfo,
+      timeZoneWithAppId: props.timezoneWithAppId,
     });
 
     this.sqlExecutionWorkflow = this.applicationSchema.sqlExecutionStepFunctions;

--- a/src/analytics/lambdas/custom-resource/create-schemas.ts
+++ b/src/analytics/lambdas/custom-resource/create-schemas.ts
@@ -37,7 +37,7 @@ import { getFunctionTags } from '../../../common/lambda/tags';
 import { BIUserCredential } from '../../../common/model';
 import { logger } from '../../../common/powertools';
 import { aws_sdk_client_common_config } from '../../../common/sdk-client-config';
-import { generateRandomStr } from '../../../common/utils';
+import { generateRandomStr, timezonejsonArrayToDict } from '../../../common/utils';
 import { SQL_TEMPLATE_PARAMETER } from '../../private/constant';
 import { CreateDatabaseAndSchemas, MustacheParamType } from '../../private/model';
 import { getSqlContent, getSqlContents } from '../../private/utils';
@@ -305,6 +305,8 @@ function getCreateOrUpdateViewForReportingSQL(newAddedAppIdList: string[], props
 
   logger.info('createOrUpdateViewForReporting()', { newAddedAppIdList });
 
+  const timezoneDict = timezonejsonArrayToDict(JSON.parse(props.timezoneWithAppId));
+
   const sqlStatementsByApp = new Map<string, string[]>();
   for (const app of newAddedAppIdList) {
     const sqlStatements: string[] = [];
@@ -317,7 +319,7 @@ function getCreateOrUpdateViewForReportingSQL(newAddedAppIdList: string[], props
       table_user: odsTableNames.user,
       table_item: odsTableNames.item,
       ...SQL_TEMPLATE_PARAMETER,
-      timezone: 'UTC', //todo: get from props
+      timezone: timezoneDict[app] ?? 'UTC',
       baseView: CLICKSTREAM_EVENT_VIEW_NAME,
     };
 

--- a/src/analytics/lambdas/custom-resource/create-schemas.ts
+++ b/src/analytics/lambdas/custom-resource/create-schemas.ts
@@ -37,7 +37,7 @@ import { getFunctionTags } from '../../../common/lambda/tags';
 import { BIUserCredential } from '../../../common/model';
 import { logger } from '../../../common/powertools';
 import { aws_sdk_client_common_config } from '../../../common/sdk-client-config';
-import { generateRandomStr, timezonejsonArrayToDict } from '../../../common/utils';
+import { generateRandomStr, timezoneJsonArrayToDict } from '../../../common/utils';
 import { SQL_TEMPLATE_PARAMETER } from '../../private/constant';
 import { CreateDatabaseAndSchemas, MustacheParamType } from '../../private/model';
 import { getSqlContent, getSqlContents } from '../../private/utils';
@@ -305,7 +305,7 @@ function getCreateOrUpdateViewForReportingSQL(newAddedAppIdList: string[], props
 
   logger.info('createOrUpdateViewForReporting()', { newAddedAppIdList });
 
-  const timezoneDict = timezonejsonArrayToDict(JSON.parse(props.timezoneWithAppId));
+  const timezoneDict = timezoneJsonArrayToDict(JSON.parse(props.timezoneWithAppId));
 
   const sqlStatementsByApp = new Map<string, string[]>();
   for (const app of newAddedAppIdList) {

--- a/src/analytics/private/app-schema.ts
+++ b/src/analytics/private/app-schema.ts
@@ -35,6 +35,7 @@ export interface RedshiftSQLExecutionProps {
   readonly codePath: string;
   readonly functionEntry: string;
   readonly workflowBucketInfo: WorkflowBucketInfo;
+  readonly timeZoneWithAppId: string;
 }
 
 export abstract class RedshiftSQLExecution extends Construct {
@@ -220,6 +221,7 @@ export class ApplicationSchemasAndReporting extends RedshiftSQLExecution {
       redshiftBIUsernamePrefix: 'clickstream_bi_',
       reportingViewsDef,
       schemaDefs,
+      timezoneWithAppId: properties.timeZoneWithAppId,
     };
   }
 }

--- a/src/analytics/private/app-schema.ts
+++ b/src/analytics/private/app-schema.ts
@@ -35,7 +35,6 @@ export interface RedshiftSQLExecutionProps {
   readonly codePath: string;
   readonly functionEntry: string;
   readonly workflowBucketInfo: WorkflowBucketInfo;
-  readonly timeZoneWithAppId: string;
 }
 
 export abstract class RedshiftSQLExecution extends Construct {
@@ -165,6 +164,7 @@ export abstract class RedshiftSQLExecution extends Construct {
 export interface ApplicationSchemasAndReportingProps extends RedshiftSQLExecutionProps {
   readonly projectId: string;
   readonly appIds: string;
+  readonly timeZoneWithAppId: string;
   readonly databaseName: string;
   readonly odsTableNames: RedshiftOdsTables;
 }

--- a/src/analytics/private/model.ts
+++ b/src/analytics/private/model.ts
@@ -117,6 +117,7 @@ export type CreateDatabaseAndSchemas = CustomProperties & {
   readonly reportingViewsDef: SQLViewDef[];
   readonly schemaDefs: SQLDef[];
   readonly schemaHash: string;
+  readonly timezoneWithAppId: string;
 }
 export type CreateMappingRoleUser = Omit<CustomProperties, 'provisionedRedshiftProps'> & {
   readonly dataRoleName: string;

--- a/src/analytics/private/sqls/redshift/dashboard/clickstream_acquisition_day_user_view_cnt_mv.sql
+++ b/src/analytics/private/sqls/redshift/dashboard/clickstream_acquisition_day_user_view_cnt_mv.sql
@@ -4,7 +4,7 @@ SORTKEY(event_date, platform)
 AUTO REFRESH NO
 AS 
 SELECT 
-  DATE_TRUNC('day', CONVERT_TIMEZONE('{{timezone}}', event_timestamp)) AS event_date,
+  DATE_TRUNC('day', CONVERT_TIMEZONE('{{{timezone}}}', event_timestamp)) AS event_date,
   platform,
   merged_user_id as "Active users", 
   SUM(CASE WHEN event_name = '_first_open' THEN 1 ELSE 0 END) AS "New users",

--- a/src/analytics/private/sqls/redshift/dashboard/clickstream_lifecycle_view_v2.sql
+++ b/src/analytics/private/sqls/redshift/dashboard/clickstream_lifecycle_view_v2.sql
@@ -4,7 +4,7 @@ AUTO REFRESH NO
 AS
 select 
   user_pseudo_id, 
-  DATE_TRUNC('week', CONVERT_TIMEZONE('{{timezone}}', event_timestamp)) as time_period_week
+  DATE_TRUNC('week', CONVERT_TIMEZONE('{{{timezone}}}', event_timestamp)) as time_period_week
 from {{database_name}}.{{schema}}.event_v2
 where event_name = '_session_start' 
 group by 1,2

--- a/src/analytics/private/sqls/redshift/dashboard/clickstream_retention_base_view.sql
+++ b/src/analytics/private/sqls/redshift/dashboard/clickstream_retention_base_view.sql
@@ -5,8 +5,8 @@ AUTO REFRESH NO
 AS
 select
   user_pseudo_id,
-  DATE(CONVERT_TIMEZONE('{{timezone}}', TIMESTAMP 'epoch' + first_touch_time_msec/1000 * INTERVAL '1 second')) as first_date,
-  DATE_DIFF('day', DATE(CONVERT_TIMEZONE('{{timezone}}', TIMESTAMP 'epoch' + first_touch_time_msec/1000 * INTERVAL '1 second')), DATE(CONVERT_TIMEZONE('{{timezone}}', event_timestamp))) as day_diff
+  DATE(CONVERT_TIMEZONE('{{{timezone}}}', TIMESTAMP 'epoch' + first_touch_time_msec/1000 * INTERVAL '1 second')) as first_date,
+  DATE_DIFF('day', DATE(CONVERT_TIMEZONE('{{{timezone}}}', TIMESTAMP 'epoch' + first_touch_time_msec/1000 * INTERVAL '1 second')), DATE(CONVERT_TIMEZONE('{{{timezone}}}', event_timestamp))) as day_diff
 from {{database_name}}.{{schema}}.{{baseView}}
 where event_timestamp >= TIMESTAMP 'epoch' + first_touch_time_msec/1000 * INTERVAL '1 second'
 and day_diff <= 42 

--- a/src/analytics/private/sqls/redshift/dashboard/clickstream_retention_user_new_return_sp.sql
+++ b/src/analytics/private/sqls/redshift/dashboard/clickstream_retention_user_new_return_sp.sql
@@ -11,7 +11,7 @@ INSERT INTO {{database_name}}.{{schema}}.{{viewName}} (event_date, platform, use
 select 
   day::date as event_date,
   platform,
-  case when day = first_visit_date then 'NEW' else 'RETURNING' end as user_type,
+  case when day = DATE(CONVERT_TIMEZONE(timezone, TIMESTAMP 'epoch' + (first_touch_time_msec/1000) * INTERVAL '1 second')) as first_date, then 'NEW' else 'RETURNING' end as user_type,
   count(distinct merged_user_id) as user_count
 from {{database_name}}.{{schema}}.{{baseView}}
 where DATE_TRUNC('day', CONVERT_TIMEZONE(timezone, event_timestamp)) = day 

--- a/src/analytics/private/sqls/redshift/dashboard/clickstream_retention_user_new_return_sp.sql
+++ b/src/analytics/private/sqls/redshift/dashboard/clickstream_retention_user_new_return_sp.sql
@@ -11,7 +11,7 @@ INSERT INTO {{database_name}}.{{schema}}.{{viewName}} (event_date, platform, use
 select 
   day::date as event_date,
   platform,
-  case when day = DATE(CONVERT_TIMEZONE(timezone, TIMESTAMP 'epoch' + (first_touch_time_msec/1000) * INTERVAL '1 second')) as first_date, then 'NEW' else 'RETURNING' end as user_type,
+  case when day = DATE(CONVERT_TIMEZONE(timezone, TIMESTAMP 'epoch' + (first_touch_time_msec/1000) * INTERVAL '1 second')) then 'NEW' else 'RETURNING' end as user_type,
   count(distinct merged_user_id) as user_count
 from {{database_name}}.{{schema}}.{{baseView}}
 where DATE_TRUNC('day', CONVERT_TIMEZONE(timezone, event_timestamp)) = day 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -74,7 +74,7 @@ export interface TimezoneInfo {
   timezone: string;
 }
 
-export function timezonejsonArrayToDict(jsonArray: TimezoneInfo[]): { [key: string]: string } {
+export function timezoneJsonArrayToDict(jsonArray: TimezoneInfo[]): { [key: string]: string } {
   const dict: { [key: string]: string } = {};
   for (const item of jsonArray) {
     dict[item.appId] = item.timezone;

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -69,3 +69,16 @@ export function formatDate(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
+export interface TimezoneInfo {
+  appId: string;
+  timezone: string;
+}
+
+export function timezonejsonArrayToDict(jsonArray: TimezoneInfo[]): { [key: string]: string } {
+  const dict: { [key: string]: string } = {};
+  for (const item of jsonArray) {
+    dict[item.appId] = item.timezone;
+  }
+  return dict;
+}
+

--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -1352,6 +1352,7 @@ export class CReportingStack extends JSONObject {
   @JSONObject.custom( (stack:CReportingStack, _key:string, _value:any) => {
     return stack._resources?.quickSightUser?.publishUserArn ?? '';
   })
+  @supportVersions([SolutionVersion.ANY, SolutionVersion.V_1_1_5])
     QuickSightPrincipalParam?: string;
 
   @JSONObject.optional('')

--- a/src/control-plane/backend/lambda/api/test/api/workflow-version.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-version.test.ts
@@ -471,7 +471,11 @@ describe('Workflow test with pipeline version', () => {
                     States: {
                       DataProcessing: setTagsToStack(DataProcessingStack, Tags),
                       DataModelingRedshift: setTagsToStack(DataModelingRedshiftStack, Tags),
-                      Reporting: setTagsToStack(ReportingStack, Tags),
+                      Reporting: removeParametersFromStack(setTagsToStack(ReportingStack, Tags), [
+                        {
+                          ParameterKey: 'QuickSightPrincipalParam',
+                        },
+                      ]),
                     },
                   },
                   {
@@ -819,7 +823,11 @@ describe('Workflow test with pipeline version', () => {
                     States: {
                       DataProcessing: DataProcessingStack,
                       DataModelingRedshift: DataModelingRedshiftStack,
-                      Reporting: ReportingStack,
+                      Reporting: removeParametersFromStack(ReportingStack, [
+                        {
+                          ParameterKey: 'QuickSightPrincipalParam',
+                        },
+                      ]),
                     },
                   },
                   {
@@ -887,6 +895,18 @@ describe('Workflow test with pipeline version in China region', () => {
       region: 'cn-north-1',
     });
     const wf = await pipeline.generateWorkflow();
+    const reportingStackCn = mergeParametersFromStack(
+      setTagsToStack(ReportingStackCn, Tags),
+      [
+        {
+          ParameterKey: 'QuickSightUserParam',
+          ParameterValue: 'GCRUser',
+        },
+        {
+          ParameterKey: 'QuickSightOwnerPrincipalParam',
+          ParameterValue: 'arn:aws-cn:quicksight:cn-north-1:555555555555:user/default/GCRUser',
+        },
+      ]);
     const expected = {
       Version: '2022-03-15',
       Workflow: {
@@ -907,22 +927,11 @@ describe('Workflow test with pipeline version in China region', () => {
                     States: {
                       DataProcessing: setTagsToStack(DataProcessingStackCn, Tags),
                       DataModelingRedshift: setTagsToStack(DataModelingRedshiftStackCn, Tags),
-                      Reporting: mergeParametersFromStack(
-                        setTagsToStack(ReportingStackCn, Tags),
-                        [
-                          {
-                            ParameterKey: 'QuickSightUserParam',
-                            ParameterValue: 'GCRUser',
-                          },
-                          {
-                            ParameterKey: 'QuickSightPrincipalParam',
-                            ParameterValue: 'arn:aws-cn:quicksight:cn-north-1:555555555555:user/default/GCRUser',
-                          },
-                          {
-                            ParameterKey: 'QuickSightOwnerPrincipalParam',
-                            ParameterValue: 'arn:aws-cn:quicksight:cn-north-1:555555555555:user/default/GCRUser',
-                          },
-                        ]),
+                      Reporting: removeParametersFromStack(reportingStackCn, [
+                        {
+                          ParameterKey: 'QuickSightPrincipalParam',
+                        },
+                      ]),
                     },
                   },
                   {
@@ -1267,6 +1276,18 @@ describe('Workflow test with pipeline version in China region', () => {
       region: 'cn-north-1',
     });
     const wf = await pipeline.generateWorkflow();
+    const reportingStackCn = mergeParametersFromStack(
+      ReportingStackCn,
+      [
+        {
+          ParameterKey: 'QuickSightUserParam',
+          ParameterValue: 'GCRUser',
+        },
+        {
+          ParameterKey: 'QuickSightOwnerPrincipalParam',
+          ParameterValue: 'arn:aws-cn:quicksight:cn-north-1:555555555555:user/default/GCRUser',
+        },
+      ]);
     const expected = {
       Version: '2022-03-15',
       Workflow: {
@@ -1287,18 +1308,9 @@ describe('Workflow test with pipeline version in China region', () => {
                     States: {
                       DataProcessing: DataProcessingStackCn,
                       DataModelingRedshift: DataModelingRedshiftStackCn,
-                      Reporting: mergeParametersFromStack(ReportingStackCn, [
-                        {
-                          ParameterKey: 'QuickSightUserParam',
-                          ParameterValue: 'GCRUser',
-                        },
+                      Reporting: removeParametersFromStack(reportingStackCn, [
                         {
                           ParameterKey: 'QuickSightPrincipalParam',
-                          ParameterValue: 'arn:aws-cn:quicksight:cn-north-1:555555555555:user/default/GCRUser',
-                        },
-                        {
-                          ParameterKey: 'QuickSightOwnerPrincipalParam',
-                          ParameterValue: 'arn:aws-cn:quicksight:cn-north-1:555555555555:user/default/GCRUser',
                         },
                       ]),
                     },

--- a/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
@@ -97,6 +97,7 @@ import {
   REPORTING_WITH_NEW_REDSHIFT_PARAMETERS,
   REPORTING_WITH_PROVISIONED_REDSHIFT_PARAMETERS,
   mergeParameters,
+  removeParameters,
 } from './workflow-mock';
 import { FULL_SOLUTION_VERSION, dictionaryTableName } from '../../common/constants';
 // eslint-disable-next-line import/order
@@ -2348,10 +2349,16 @@ describe('Workflow test', () => {
                           Input: {
                             Action: 'Create',
                             Region: 'ap-southeast-1',
-                            Parameters: [
-                              ...REPORTING_WITH_PROVISIONED_REDSHIFT_PARAMETERS,
-                              APPREGISTRY_APPLICATION_ARN_PARAMETER,
-                            ],
+                            Parameters: removeParameters(
+                              [
+                                ...REPORTING_WITH_PROVISIONED_REDSHIFT_PARAMETERS,
+                                APPREGISTRY_APPLICATION_ARN_PARAMETER,
+                              ],
+                              [
+                                {
+                                  ParameterKey: 'QuickSightPrincipalParam',
+                                },
+                              ]),
                             StackName: `${getStackPrefix()}-Reporting-6666-6666`,
                             Tags: Tags,
                             TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/v1.0.0/default/data-reporting-quicksight-stack.template.json',
@@ -2701,10 +2708,16 @@ describe('Workflow test', () => {
                           Input: {
                             Action: 'Create',
                             Region: 'ap-southeast-1',
-                            Parameters: [
-                              ...REPORTING_WITH_NEW_REDSHIFT_PARAMETERS,
-                              APPREGISTRY_APPLICATION_ARN_PARAMETER,
-                            ],
+                            Parameters: removeParameters(
+                              [
+                                ...REPORTING_WITH_NEW_REDSHIFT_PARAMETERS,
+                                APPREGISTRY_APPLICATION_ARN_PARAMETER,
+                              ],
+                              [
+                                {
+                                  ParameterKey: 'QuickSightPrincipalParam',
+                                },
+                              ]),
                             StackName: `${getStackPrefix()}-Reporting-6666-6666`,
                             Tags: Tags,
                             TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/v1.0.0/default/data-reporting-quicksight-stack.template.json',

--- a/src/data-reporting-quicksight-stack.ts
+++ b/src/data-reporting-quicksight-stack.ts
@@ -164,7 +164,7 @@ export class DataReportingQuickSightStack extends Stack {
       quickSightProps: {
         userName: stackParams.quickSightUserParam.valueAsString,
         namespace: stackParams.quickSightNamespaceParam.valueAsString,
-        sharePrincipalArn: stackParams.quickSightPrincipalParam.valueAsString,
+        sharePrincipalArn: stackParams.quickSightOwnerPrincipalParam.valueAsString,
         ownerPrincipalArn: stackParams.quickSightOwnerPrincipalParam.valueAsString,
       },
       redshiftProps: {

--- a/src/data-reporting-quicksight-stack.ts
+++ b/src/data-reporting-quicksight-stack.ts
@@ -160,7 +160,7 @@ export class DataReportingQuickSightStack extends Stack {
       templateId: template.templateId,
       dataSourceArn: dataSource.attrArn,
       databaseName: stackParams.redshiftDBParam.valueAsString,
-      timezone: stackParams.timezoneWithAppIdParam.valueAsString,
+      timezone: stackParams.quickSightTimezoneParam.valueAsString,
       quickSightProps: {
         userName: stackParams.quickSightUserParam.valueAsString,
         namespace: stackParams.quickSightNamespaceParam.valueAsString,

--- a/src/data-reporting-quicksight-stack.ts
+++ b/src/data-reporting-quicksight-stack.ts
@@ -160,7 +160,7 @@ export class DataReportingQuickSightStack extends Stack {
       templateId: template.templateId,
       dataSourceArn: dataSource.attrArn,
       databaseName: stackParams.redshiftDBParam.valueAsString,
-      timezone: stackParams.quickSightTimezoneParam.valueAsString,
+      timezone: stackParams.timezoneWithAppIdParam.valueAsString,
       quickSightProps: {
         userName: stackParams.quickSightUserParam.valueAsString,
         namespace: stackParams.quickSightNamespaceParam.valueAsString,

--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -45,7 +45,7 @@ import Mustache from 'mustache';
 import { v4 as uuidv4 } from 'uuid';
 import { logger } from '../../../../common/powertools';
 import { aws_sdk_client_common_config } from '../../../../common/sdk-client-config';
-import { sleep, timezonejsonArrayToDict } from '../../../../common/utils';
+import { sleep, timezoneJsonArrayToDict } from '../../../../common/utils';
 import { getQuickSightFolderId, getQuickSightFolderName } from '../../../../control-plane/backend/lambda/api/store/aws/quicksight';
 import {
   QuicksightCustomResourceLambdaProps,
@@ -99,7 +99,7 @@ export const handler = async (event: ResourceEvent, _context: Context): Promise<
   const sharePrincipalArn = props.quickSightSharePrincipalArn;
   const ownerPrincipalArn = props.quickSightOwnerPrincipalArn;
 
-  const timezoneDict = timezonejsonArrayToDict(JSON.parse(props.timezone));
+  const timezoneDict = timezoneJsonArrayToDict(JSON.parse(props.timezone));
 
   if (event.RequestType === 'Create') {
     return _onCreate(quickSight, awsAccountId, sharePrincipalArn, ownerPrincipalArn, event, timezoneDict);

--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -95,11 +95,10 @@ export interface TimezoneInfo {
 export function timezonejsonArrayToDict(jsonArray: TimezoneInfo[]): { [key: string]: string } {
   const dict: { [key: string]: string } = {};
   for (const item of jsonArray) {
-      dict[item.appId] = item.timezone;
+    dict[item.appId] = item.timezone;
   }
   return dict;
 }
-
 
 export const handler = async (event: ResourceEvent, _context: Context): Promise<CdkCustomResourceResponse|void> => {
   const props = event.ResourceProperties as QuicksightCustomResourceLambdaPropsType;
@@ -128,8 +127,8 @@ export const handler = async (event: ResourceEvent, _context: Context): Promise<
 
 const _onCreate = async (quickSight: QuickSight, awsAccountId: string, sharePrincipalArn: string, ownerPrincipalArn: string,
   event: CloudFormationCustomResourceCreateEvent,
-  timezoneDict: { [key: string]: string }
-  ): Promise<CdkCustomResourceResponse> => {
+  timezoneDict: { [key: string]: string },
+): Promise<CdkCustomResourceResponse> => {
 
   const props = event.ResourceProperties as QuicksightCustomResourceLambdaPropsType;
   let dashboards = [];
@@ -193,8 +192,8 @@ const _onDelete = async (quickSight: QuickSight, awsAccountId: string, event: Cl
 
 const _onUpdate = async (quickSight: QuickSight, awsAccountId: string, sharePrincipalArn: string, ownerPrincipalArn: string,
   event: CloudFormationCustomResourceUpdateEvent,
-  timezoneDict: { [key: string]: string }
-  ): Promise<CdkCustomResourceResponse> => {
+  timezoneDict: { [key: string]: string },
+): Promise<CdkCustomResourceResponse> => {
   const props = event.ResourceProperties as QuicksightCustomResourceLambdaPropsType;
   const oldProps = event.OldResourceProperties as QuicksightCustomResourceLambdaPropsType;
 
@@ -432,8 +431,8 @@ const createQuickSightDashboard = async (quickSight: QuickSight,
   ownerPrincipalArn: string,
   schema: string,
   dashboardDef: QuickSightDashboardDefProps,
-  timezoneDict: { [key: string]: string }
-  )
+  timezoneDict: { [key: string]: string },
+)
 : Promise<CreateDashboardCommandOutput|undefined> => {
 
   const datasetRefs: DataSetReference[] = [];

--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -114,8 +114,6 @@ export const handler = async (event: ResourceEvent, _context: Context): Promise<
 
   const timezoneDict = timezonejsonArrayToDict(JSON.parse(props.timezone));
 
-  logger.warn('timezoneDict:', timezoneDict);
-
   if (event.RequestType === 'Create') {
     return _onCreate(quickSight, awsAccountId, sharePrincipalArn, ownerPrincipalArn, event, timezoneDict);
   } else if (event.RequestType === 'Update' ) {
@@ -791,7 +789,7 @@ const createDataSet = async (quickSight: QuickSight, commonParams: ResourceCommo
       timezone: commonParams.timezoneDict[commonParams.schema] ?? 'UTC',
     };
 
-    logger.info('SQL to run:', Mustache.render(props.customSql, mustacheParam, undefined, (value: string) => value ));
+    logger.info('SQL to run:', Mustache.render(props.customSql, mustacheParam));
 
     let colGroups: ColumnGroup[] = [];
     if (props.columnGroups !== undefined) {

--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -114,6 +114,8 @@ export const handler = async (event: ResourceEvent, _context: Context): Promise<
 
   const timezoneDict = timezonejsonArrayToDict(JSON.parse(props.timezone));
 
+  logger.warn('timezoneDict:', timezoneDict);
+
   if (event.RequestType === 'Create') {
     return _onCreate(quickSight, awsAccountId, sharePrincipalArn, ownerPrincipalArn, event, timezoneDict);
   } else if (event.RequestType === 'Update' ) {
@@ -789,7 +791,7 @@ const createDataSet = async (quickSight: QuickSight, commonParams: ResourceCommo
       timezone: commonParams.timezoneDict[commonParams.schema] ?? 'UTC',
     };
 
-    logger.info('SQL to run:', Mustache.render(props.customSql, mustacheParam));
+    logger.info('SQL to run:', Mustache.render(props.customSql, mustacheParam, undefined, (value: string) => value ));
 
     let colGroups: ColumnGroup[] = [];
     if (props.columnGroups !== undefined) {

--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -45,7 +45,7 @@ import Mustache from 'mustache';
 import { v4 as uuidv4 } from 'uuid';
 import { logger } from '../../../../common/powertools';
 import { aws_sdk_client_common_config } from '../../../../common/sdk-client-config';
-import { sleep } from '../../../../common/utils';
+import { sleep, timezonejsonArrayToDict } from '../../../../common/utils';
 import { getQuickSightFolderId, getQuickSightFolderName } from '../../../../control-plane/backend/lambda/api/store/aws/quicksight';
 import {
   QuicksightCustomResourceLambdaProps,
@@ -85,19 +85,6 @@ type ResourceCommonParams = {
 export type MustacheParamType = {
   schema: string;
   timezone: string;
-}
-
-export interface TimezoneInfo {
-  appId: string;
-  timezone: string;
-}
-
-export function timezonejsonArrayToDict(jsonArray: TimezoneInfo[]): { [key: string]: string } {
-  const dict: { [key: string]: string } = {};
-  for (const item of jsonArray) {
-    dict[item.appId] = item.timezone;
-  }
-  return dict;
 }
 
 export const handler = async (event: ResourceEvent, _context: Context): Promise<CdkCustomResourceResponse|void> => {

--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -143,8 +143,8 @@ const _onCreate = async (quickSight: QuickSight, awsAccountId: string, sharePrin
         });
 
         const dashboard = await createQuickSightDashboard(quickSight, awsAccountId, sharePrincipalArn, ownerPrincipalArn,
-        schemaName,
-        dashboardDefProps, timezoneDict);
+          schemaName,
+          dashboardDefProps, timezoneDict);
 
         dashboards.push({
           appId: schemaName,
@@ -266,7 +266,7 @@ const _onUpdate = async (quickSight: QuickSight, awsAccountId: string, sharePrin
       };
 
       const dashboard = await updateQuickSightDashboard(quickSight, commonParams,
-        dashboardDefProps, oldDashboardDefProps, 
+        dashboardDefProps, oldDashboardDefProps,
         createdQuickSightResources);
 
       dashboards.push({
@@ -284,7 +284,7 @@ const _onUpdate = async (quickSight: QuickSight, awsAccountId: string, sharePrin
       const dashboard = await createQuickSightDashboard(quickSight, awsAccountId, sharePrincipalArn, ownerPrincipalArn,
         schemaName,
         dashboardDefProps,
-        timezoneDict
+        timezoneDict,
       );
 
       logger.info('Creating schema', {
@@ -602,7 +602,7 @@ export type CreatedQuickSightResources = {
 const updateQuickSightDashboard = async (quickSight: QuickSight, commonParams: ResourceCommonParams,
   dashboardDef: QuickSightDashboardDefProps,
   oldDashboardDef: QuickSightDashboardDefProps,
-  createdQuickSightResources: CreatedQuickSightResources
+  createdQuickSightResources: CreatedQuickSightResources,
 )
 : Promise<UpdateDashboardCommandOutput|undefined> => {
 
@@ -614,7 +614,7 @@ const updateQuickSightDashboard = async (quickSight: QuickSight, commonParams: R
   await grantDataSourcePermission(quickSight, dashboardDef.dataSourceArn,
     commonParams.awsAccountId,
     commonParams.ownerPrincipalArn,
-    commonParams.sharePrincipalArn
+    commonParams.sharePrincipalArn,
   );
 
   const oldDataSetTableNames: string[] = [];

--- a/src/reporting/parameter.ts
+++ b/src/reporting/parameter.ts
@@ -80,15 +80,6 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
     default: 'QuickSight Owner Principal Arn',
   };
 
-  const quickSightPrincipalParam = new CfnParameter(scope, 'QuickSightPrincipalParam', {
-    description: 'Arn of the QuickSight principal, dashboard resource will be share to this principal',
-    type: 'String',
-    allowedPattern: QUICKSIGHT_USER_ARN_PATTERN,
-  });
-  labels[quickSightPrincipalParam.logicalId] = {
-    default: 'QuickSight Principal Arn',
-  };
-
   const quickSightTemplateArnParam = new CfnParameter(scope, 'QuickSightTemplateArnParam', {
     description: 'Arn of the QuickSight template.',
     type: 'String',
@@ -170,7 +161,6 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
       quickSightVpcConnectionSGParam.logicalId,
       quickSightVpcConnectionSubnetParam.logicalId,
       quickSightOwnerPrincipalParam.logicalId,
-      quickSightPrincipalParam.logicalId,
       quickSightTemplateArnParam.logicalId,
       quickSightTimezoneParam.logicalId,
     ],
@@ -194,7 +184,6 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
     quickSightVpcConnectionSGParam,
     quickSightVpcConnectionSubnetParam,
     quickSightOwnerPrincipalParam,
-    quickSightPrincipalParam,
     quickSightTemplateArnParam,
     quickSightTimezoneParam,
     redshiftEndpointParam,

--- a/src/reporting/parameter.ts
+++ b/src/reporting/parameter.ts
@@ -98,13 +98,13 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
     default: 'QuickSight Template Arn',
   };
 
-  const timezoneWithAppIdParam = new CfnParameter(scope, 'TimeZoneWithAppId', {
+  const quickSightTimezoneParam = new CfnParameter(scope, 'QuickSightTimezoneParam', {
     description: 'The time zone with app id',
     type: 'String',
-    default: '',
+    default: '[]',
   });
-  labels[timezoneWithAppIdParam.logicalId] = {
-    default: 'Dashboard Timezones',
+  labels[quickSightTimezoneParam.logicalId] = {
+    default: 'Dashboard Timezone Setting',
   };
 
   const redshiftDBParam = new CfnParameter(scope, 'RedshiftDBParam', {
@@ -172,7 +172,7 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
       quickSightOwnerPrincipalParam.logicalId,
       quickSightPrincipalParam.logicalId,
       quickSightTemplateArnParam.logicalId,
-      timezoneWithAppIdParam.logicalId,
+      quickSightTimezoneParam.logicalId,
     ],
   });
 
@@ -196,7 +196,7 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
     quickSightOwnerPrincipalParam,
     quickSightPrincipalParam,
     quickSightTemplateArnParam,
-    timezoneWithAppIdParam,
+    quickSightTimezoneParam,
     redshiftEndpointParam,
     redshiftDBParam,
     redshiftDefaultDBParam,

--- a/src/reporting/parameter.ts
+++ b/src/reporting/parameter.ts
@@ -98,15 +98,14 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
     default: 'QuickSight Template Arn',
   };
 
-  const quickSightTimezoneParam = new CfnParameter(scope, 'QuickSightTimezoneParam', {
-    description: 'Timezone of the builtin dashboard.',
+  const timezoneWithAppIdParam = new CfnParameter(scope, 'TimeZoneWithAppId', {
+    description: 'The time zone with app id',
     type: 'String',
-    default: 'UTC',
+    default: '',
   });
-  labels[quickSightTimezoneParam.logicalId] = {
-    default: 'Dashboard Timezone',
+  labels[timezoneWithAppIdParam.logicalId] = {
+    default: 'Dashboard Timezones',
   };
-
 
   const redshiftDBParam = new CfnParameter(scope, 'RedshiftDBParam', {
     description: 'Redshift database name.',
@@ -173,7 +172,7 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
       quickSightOwnerPrincipalParam.logicalId,
       quickSightPrincipalParam.logicalId,
       quickSightTemplateArnParam.logicalId,
-      quickSightTimezoneParam.logicalId,
+      timezoneWithAppIdParam.logicalId,
     ],
   });
 
@@ -197,7 +196,7 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
     quickSightOwnerPrincipalParam,
     quickSightPrincipalParam,
     quickSightTemplateArnParam,
-    quickSightTimezoneParam,
+    timezoneWithAppIdParam,
     redshiftEndpointParam,
     redshiftDBParam,
     redshiftDefaultDBParam,

--- a/src/reporting/private/dashboard.ts
+++ b/src/reporting/private/dashboard.ts
@@ -51,6 +51,7 @@ export interface QuicksightCustomResourceLambdaProps {
   readonly awsAccountId: string;
   readonly awsRegion: string;
   readonly awsPartition: string;
+  readonly timezone: string;
   readonly quickSightNamespace: string;
   readonly quickSightUser: string;
   readonly quickSightSharePrincipalArn: string;

--- a/src/reporting/quicksight-custom-resource.ts
+++ b/src/reporting/quicksight-custom-resource.ts
@@ -87,8 +87,8 @@ export function createQuicksightCustomResource(
 
   const eventViewColumns = `
     *, 
-    DATE_TRUNC('second', CONVERT_TIMEZONE('{{timezone}}', event_timestamp)) ::timestamp AS event_timestamp_local,
-    DATE_TRUNC('day', CONVERT_TIMEZONE('{{timezone}}', event_timestamp)) ::timestamp AS event_date
+    DATE_TRUNC('second', CONVERT_TIMEZONE('{{{timezone}}}', event_timestamp)) ::timestamp AS event_timestamp_local,
+    DATE_TRUNC('day', CONVERT_TIMEZONE('{{{timezone}}}', event_timestamp)) ::timestamp AS event_date
   `;
 
   const dashboardDefProps: QuickSightDashboardDefProps = {
@@ -107,8 +107,8 @@ export function createQuicksightCustomResource(
           select 
             ${eventViewColumns} 
           from {{schema}}.${CLICKSTREAM_EVENT_VIEW_NAME}
-          where DATE_TRUNC('day', CONVERT_TIMEZONE('{{timezone}}', event_timestamp)) >= <<$startDate01>>
-          and DATE_TRUNC('day', CONVERT_TIMEZONE('{{timezone}}', event_timestamp)) < DATEADD(DAY, 1, date_trunc('day', <<$endDate01>>))
+          where DATE_TRUNC('day', CONVERT_TIMEZONE('{{{timezone}}}', event_timestamp)) >= <<$startDate01>>
+          and DATE_TRUNC('day', CONVERT_TIMEZONE('{{{timezone}}}', event_timestamp)) < DATEADD(DAY, 1, date_trunc('day', <<$endDate01>>))
         `,
         columns: [
           ...clickstream_event_view_columns,
@@ -914,6 +914,7 @@ export function createQuicksightCustomResource(
       quickSightOwnerPrincipalArn: props.quickSightProps.ownerPrincipalArn,
       schemas: props.redshiftProps.databaseSchemaNames,
       dashboardDefProps,
+      timezone: props.timezone,
     },
   });
   return cr;

--- a/src/reporting/quicksight-custom-resource.ts
+++ b/src/reporting/quicksight-custom-resource.ts
@@ -87,8 +87,8 @@ export function createQuicksightCustomResource(
 
   const eventViewColumns = `
     *, 
-    DATE_TRUNC('second', CONVERT_TIMEZONE('${props.timezone}', event_timestamp)) ::timestamp AS event_timestamp_local,
-    DATE_TRUNC('day', CONVERT_TIMEZONE('${props.timezone}', event_timestamp)) ::timestamp AS event_date
+    DATE_TRUNC('second', CONVERT_TIMEZONE('{{timezone}}', event_timestamp)) ::timestamp AS event_timestamp_local,
+    DATE_TRUNC('day', CONVERT_TIMEZONE('{{timezone}}', event_timestamp)) ::timestamp AS event_date
   `;
 
   const dashboardDefProps: QuickSightDashboardDefProps = {
@@ -107,8 +107,8 @@ export function createQuicksightCustomResource(
           select 
             ${eventViewColumns} 
           from {{schema}}.${CLICKSTREAM_EVENT_VIEW_NAME}
-          where DATE_TRUNC('day', CONVERT_TIMEZONE('${props.timezone}', event_timestamp)) >= <<$startDate01>>
-          and DATE_TRUNC('day', CONVERT_TIMEZONE('${props.timezone}', event_timestamp)) < DATEADD(DAY, 1, date_trunc('day', <<$endDate01>>))
+          where DATE_TRUNC('day', CONVERT_TIMEZONE('{{timezone}}', event_timestamp)) >= <<$startDate01>>
+          and DATE_TRUNC('day', CONVERT_TIMEZONE('{{timezone}}', event_timestamp)) < DATEADD(DAY, 1, date_trunc('day', <<$endDate01>>))
         `,
         columns: [
           ...clickstream_event_view_columns,

--- a/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
@@ -31,10 +31,10 @@ import { ResourcePropertiesType, TABLES_VIEWS_FOR_REPORTING, handler, physicalId
 import 'aws-sdk-client-mock-jest';
 import { ProvisionedRedshiftProps } from '../../../../../src/analytics/private/model';
 import { reportingViewsDef, schemaDefs } from '../../../../../src/analytics/private/sql-def';
+import { logger } from '../../../../../src/common/powertools';
 import { getMockContext } from '../../../../common/lambda-context';
 import { basicCloudFormationEvent } from '../../../../common/lambda-events';
 import { loadSQLFromFS } from '../../../../fs-utils';
-import { logger } from '../../../../../src/common/powertools';
 
 describe('Custom resource - Create schemas for applications in Redshift database', () => {
 
@@ -311,8 +311,8 @@ describe('Custom resource - Create schemas for applications in Redshift database
 
     s3ClientMock.on(PutObjectCommand).callsFake((params) => {
       const body = params.Body as string;
-      if(body.includes(`CREATE MATERIALIZED VIEW project1.app1.${CLICKSTREAM_ACQUISITION_DAY_USER_VIEW_CNT_MV}`)) {
-        expect(body).toContain(`CONVERT_TIMEZONE('Asia/Shanghai'`);
+      if (body.includes(`CREATE MATERIALIZED VIEW project1.app1.${CLICKSTREAM_ACQUISITION_DAY_USER_VIEW_CNT_MV}`)) {
+        expect(body).toContain('CONVERT_TIMEZONE(\'Asia/Shanghai\'');
       }
       return {};
     });

--- a/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
@@ -74,30 +74,6 @@ describe('Custom resource - Create schemas for applications in Redshift database
     },
   };
 
-  const basicEventOneReportingView = {
-    ...basicCloudFormationEvent,
-    ResourceProperties: {
-      ...basicCloudFormationEvent.ResourceProperties,
-      ServiceToken: 'token-1',
-      projectId: 'project1',
-      odsTableNames,
-      databaseName: projectDBName,
-      dataAPIRole: `arn:aws:iam::1234567890:role/${roleName}`,
-      redshiftBIUserParameter: '/clickstream/report/user/1111',
-      redshiftBIUsernamePrefix: biUserNamePrefix,
-      reportingViewsDef: [
-        {
-          viewName: CLICKSTREAM_ACQUISITION_DAY_USER_VIEW_CNT_MV,
-          type: 'mv',
-          scheduleRefresh: 'true',
-          timezoneSensitive: 'true',
-        },
-      ],
-      schemaDefs: [],
-      schemaHash: '123456789',
-    },
-  };
-
   const workgroupName = 'demo';
   const defaultDBName = 'defaultDB';
   const createSchemaPropsInServerless: ResourcePropertiesType = {
@@ -112,11 +88,6 @@ describe('Custom resource - Create schemas for applications in Redshift database
   };
   const createServerlessEvent = {
     ...basicEvent,
-    ResourceProperties: createSchemaPropsInServerless,
-  };
-
-  const createServerlessOneReportingView = {
-    ...basicEventOneReportingView,
     ResourceProperties: createSchemaPropsInServerless,
   };
 

--- a/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
@@ -78,6 +78,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
   const createSchemaPropsInServerless: ResourcePropertiesType = {
     ...basicEvent.ResourceProperties,
     appIds: 'app1',
+    timezoneWithAppId: '[{"appId":"app1","timezone":"Asia/Shanghai"},{"appId":"app2","timezone":"Asia/Tokyo"}]',
     serverlessRedshiftProps: {
       workgroupName: workgroupName,
       databaseName: defaultDBName,
@@ -98,6 +99,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
     ResourceProperties: {
       ...createServerlessEvent.ResourceProperties,
       appIds: 'app2',
+      timezoneWithAppId: '[{"appId":"app2","timezone":"Asia/Tokyo"}]',
     },
     PhysicalResourceId: `${physicalIdPrefix}abcde`,
     RequestType: 'Update',
@@ -115,6 +117,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
     ResourceProperties: {
       ...basicEvent.ResourceProperties,
       appIds: 'app1',
+      timezoneWithAppId: '[{"appId":"app1","timezone":"Asia/Shanghai"}]',
       provisionedRedshiftProps,
     },
   };
@@ -125,6 +128,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
     ResourceProperties: {
       ...createProvisionedEvent.ResourceProperties,
       appIds: 'app1,app2',
+      timezoneWithAppId: '[{"appId":"app1","timezone":"Asia/Shanghai"},{"appId":"app2","timezone":"Asia/Tokyo"}]',
     },
     PhysicalResourceId: 'physical-resource-id',
     RequestType: 'Update',

--- a/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
+++ b/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
@@ -930,7 +930,7 @@ describe('DataReportingQuickSightStack resource test', () => {
           {
             tableName: 'Event_View',
             importMode: 'DIRECT_QUERY',
-            customSql: "\n          select \n            \n    *, \n    DATE_TRUNC('second', CONVERT_TIMEZONE('{{timezone}}', event_timestamp)) ::timestamp AS event_timestamp_local,\n    DATE_TRUNC('day', CONVERT_TIMEZONE('{{timezone}}', event_timestamp)) ::timestamp AS event_date\n   \n          from {{schema}}.clickstream_event_view_v3\n          where DATE_TRUNC('day', CONVERT_TIMEZONE('{{timezone}}', event_timestamp)) >= <<$startDate01>>\n          and DATE_TRUNC('day', CONVERT_TIMEZONE('{{timezone}}', event_timestamp)) < DATEADD(DAY, 1, date_trunc('day', <<$endDate01>>))\n        ",
+            customSql: "\n          select \n            \n    *, \n    DATE_TRUNC('second', CONVERT_TIMEZONE('{{{timezone}}}', event_timestamp)) ::timestamp AS event_timestamp_local,\n    DATE_TRUNC('day', CONVERT_TIMEZONE('{{{timezone}}}', event_timestamp)) ::timestamp AS event_date\n   \n          from {{schema}}.clickstream_event_view_v3\n          where DATE_TRUNC('day', CONVERT_TIMEZONE('{{{timezone}}}', event_timestamp)) >= <<$startDate01>>\n          and DATE_TRUNC('day', CONVERT_TIMEZONE('{{{timezone}}}', event_timestamp)) < DATEADD(DAY, 1, date_trunc('day', <<$endDate01>>))\n        ",
             columns: [
               {
                 Name: 'event_timestamp',

--- a/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
+++ b/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
@@ -53,12 +53,6 @@ describe('DataReportingQuickSightStack parameter test', () => {
     template.hasParameter('QuickSightVpcConnectionSubnetParam', {});
   });
 
-  test('Should has Parameter QuickSightPrincipalParam', () => {
-    template.hasParameter('QuickSightPrincipalParam', {
-      Type: 'String',
-    });
-  });
-
   test('Should has Parameter QuickSightOwnerPrincipalParam', () => {
     template.hasParameter('QuickSightOwnerPrincipalParam', {
       Type: 'String',
@@ -139,10 +133,6 @@ describe('DataReportingQuickSightStack parameter test', () => {
     const pattern = param.AllowedPattern;
     const regex = new RegExp(`${pattern}`);
 
-    const param2 = template.toJSON().Parameters.QuickSightPrincipalParam;
-    const pattern2 = param2.AllowedPattern;
-    const regex2 = new RegExp(`${pattern2}`);
-
     const validValues = [
       'arn:aws:quicksight:us-east-1:111111111111:user/default/clickstream',
       'arn:aws:quicksight:us-east-1:111111111111:user/default/Admin/testuser',
@@ -152,7 +142,6 @@ describe('DataReportingQuickSightStack parameter test', () => {
 
     for (const v of validValues) {
       expect(v).toMatch(regex);
-      expect(v).toMatch(regex2);
     }
 
     const invalidValues = [
@@ -163,7 +152,6 @@ describe('DataReportingQuickSightStack parameter test', () => {
     ];
     for (const v of invalidValues) {
       expect(v).not.toMatch(regex);
-      expect(v).not.toMatch(regex2);
     }
   });
 
@@ -878,9 +866,6 @@ describe('DataReportingQuickSightStack resource test', () => {
       },
       quickSightUser: {
         Ref: 'QuickSightUserParam',
-      },
-      quickSightSharePrincipalArn: {
-        Ref: 'QuickSightPrincipalParam',
       },
       quickSightOwnerPrincipalArn: {
         Ref: 'QuickSightOwnerPrincipalParam',

--- a/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
+++ b/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
@@ -65,6 +65,13 @@ describe('DataReportingQuickSightStack parameter test', () => {
     });
   });
 
+  test('Should has Parameter QuickSightTimezoneParam', () => {
+    template.hasParameter('QuickSightTimezoneParam', {
+      Type: 'String',
+      Default: '[]',
+    });
+  });
+
   test('Should has Parameter redshiftEndpointParam', () => {
     template.hasParameter('RedshiftEndpointParam', {
       Type: 'String',
@@ -938,30 +945,7 @@ describe('DataReportingQuickSightStack resource test', () => {
           {
             tableName: 'Event_View',
             importMode: 'DIRECT_QUERY',
-            customSql: {
-              'Fn::Join': [
-                '',
-                [
-                  "\n          select \n            \n    *, \n    DATE_TRUNC('second', CONVERT_TIMEZONE('",
-                  {
-                    Ref: 'QuickSightTimezoneParam',
-                  },
-                  "', event_timestamp)) ::timestamp AS event_timestamp_local,\n    DATE_TRUNC('day', CONVERT_TIMEZONE('",
-                  {
-                    Ref: 'QuickSightTimezoneParam',
-                  },
-                  "', event_timestamp)) ::timestamp AS event_date\n   \n          from {{schema}}.clickstream_event_view_v3\n          where DATE_TRUNC('day', CONVERT_TIMEZONE('",
-                  {
-                    Ref: 'QuickSightTimezoneParam',
-                  },
-                  "', event_timestamp)) >= <<$startDate01>>\n          and DATE_TRUNC('day', CONVERT_TIMEZONE('",
-                  {
-                    Ref: 'QuickSightTimezoneParam',
-                  },
-                  "', event_timestamp)) < DATEADD(DAY, 1, date_trunc('day', <<$endDate01>>))\n        ",
-                ],
-              ],
-            },
+            customSql: "\n          select \n            \n    *, \n    DATE_TRUNC('second', CONVERT_TIMEZONE('{{timezone}}', event_timestamp)) ::timestamp AS event_timestamp_local,\n    DATE_TRUNC('day', CONVERT_TIMEZONE('{{timezone}}', event_timestamp)) ::timestamp AS event_date\n   \n          from {{schema}}.clickstream_event_view_v3\n          where DATE_TRUNC('day', CONVERT_TIMEZONE('{{timezone}}', event_timestamp)) >= <<$startDate01>>\n          and DATE_TRUNC('day', CONVERT_TIMEZONE('{{timezone}}', event_timestamp)) < DATEADD(DAY, 1, date_trunc('day', <<$endDate01>>))\n        ",
             columns: [
               {
                 Name: 'event_timestamp',

--- a/test/reporting/quicksight/lambda/quicksight-resource.test.ts
+++ b/test/reporting/quicksight/lambda/quicksight-resource.test.ts
@@ -91,7 +91,6 @@ describe('QuickSight Lambda function', () => {
     databaseName: 'test-database',
     templateArn: 'test-template-arn',
     vpcConnectionArn: 'arn:aws:quicksight:ap-southeast-1:xxxxxxxxxx:vpcConnection/test',
-
     dashboardDefProps: {
       analysisName: 'Clickstream Analysis',
       dashboardName: 'Clickstream Dashboard',
@@ -1322,8 +1321,13 @@ describe('QuickSight Lambda function', () => {
       ...basicCloudFormationEvent.ResourceProperties,
       ...commonProps,
       schemas: 'test1',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        }
+      ]`,
     },
-
   };
 
   const oneQuickSightUserEvent = {
@@ -1340,6 +1344,7 @@ describe('QuickSight Lambda function', () => {
       ...basicCloudFormationEvent.ResourceProperties,
       ...commonProps,
       schemas: '',
+      timezone: '[]',
     },
   };
 
@@ -1349,6 +1354,16 @@ describe('QuickSight Lambda function', () => {
       ...basicCloudFormationEvent.ResourceProperties,
       ...commonProps,
       schemas: 'test1,zzzz',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        },
+        {
+          "appId": "zzzz",
+          "timezone": "Asia/Tokyo"
+        }
+      ]`,
     },
   };
 
@@ -1358,11 +1373,23 @@ describe('QuickSight Lambda function', () => {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...commonProps,
       schemas: 'test1',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        }
+      ]`,
     },
     OldResourceProperties: {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...commonProps,
       schemas: 'test1',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        }
+      ]`,
     },
   };
 
@@ -1372,11 +1399,23 @@ describe('QuickSight Lambda function', () => {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...testProps4,
       schemas: 'test1',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        }
+      ]`,
     },
     OldResourceProperties: {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...commonProps,
       schemas: 'test1',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        }
+      ]`,
     },
   };
 
@@ -1386,11 +1425,23 @@ describe('QuickSight Lambda function', () => {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...commonPropsUserChange,
       schemas: 'test1',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        }
+      ]`,
     },
     OldResourceProperties: {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...commonProps,
       schemas: 'test1',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        }
+      ]`,
     },
   };
 
@@ -1400,11 +1451,23 @@ describe('QuickSight Lambda function', () => {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...testProps2,
       schemas: 'test1',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        }
+      ]`,
     },
     OldResourceProperties: {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...testProps3,
       schemas: 'test1',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        }
+      ]`,
     },
   };
 
@@ -1414,6 +1477,12 @@ describe('QuickSight Lambda function', () => {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...commonProps,
       schemas: 'test1',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        }
+      ]`,
     },
     OldResourceProperties: {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
@@ -1428,11 +1497,31 @@ describe('QuickSight Lambda function', () => {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...commonProps,
       schemas: 'test1,zzzz',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        },
+        {
+          "appId": "zzzz",
+          "timezone": "Asia/Tokyo"
+        }
+      ]`,
     },
     OldResourceProperties: {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...commonProps,
       schemas: 'test1,zzzz',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        },
+        {
+          "appId": "zzzz",
+          "timezone": "Asia/Tokyo"
+        }
+      ]`,
     },
   };
 
@@ -1442,11 +1531,27 @@ describe('QuickSight Lambda function', () => {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...commonProps,
       schemas: 'test1',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        }
+      ]`,
     },
     OldResourceProperties: {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...commonProps,
       schemas: 'test1,tttt',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        },
+        {
+          "appId": "tttt",
+          "timezone": "Asia/Tokyo"
+        }
+      ]`,
     },
   };
 
@@ -1456,11 +1561,31 @@ describe('QuickSight Lambda function', () => {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...commonProps,
       schemas: 'test1,zzzz',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        },
+        {
+          "appId": "zzzz",
+          "timezone": "Asia/Tokyo"
+        }
+      ]`,
     },
     OldResourceProperties: {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...commonProps,
       schemas: 'test1,tttt',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        },
+        {
+          "appId": "tttt",
+          "timezone": "Asia/Tokyo"
+        }
+      ]`,
     },
   };
 
@@ -1470,11 +1595,27 @@ describe('QuickSight Lambda function', () => {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...commonProps,
       schemas: 'test1,zzzz',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        },
+        {
+          "appId": "zzzz",
+          "timezone": "Asia/Tokyo"
+        }
+      ]`,
     },
     OldResourceProperties: {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...commonProps,
       schemas: 'test1',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        }
+      ]`,
     },
   };
 
@@ -1498,6 +1639,12 @@ describe('QuickSight Lambda function', () => {
       ...basicCloudFormationDeleteEvent.ResourceProperties,
       ...commonProps,
       schemas: 'test1',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        }
+      ]`,
     },
   };
 
@@ -3051,10 +3198,7 @@ describe('QuickSight Lambda function', () => {
 
     quickSightClientMock.on(UpdateDataSourcePermissionsCommand).callsFakeOnce(input => {
       if ( input.GrantPermissions[0].Principal === 'test-owner-principal-arn'
-        && input.GrantPermissions[1].Principal === 'test-principal-arn'
         && input.GrantPermissions[0].Actions[5] === 'quicksight:UpdateDataSource'
-        && input.GrantPermissions[1].Actions[5] === 'quicksight:UpdateDataSource'
-
       ) {
         return {
           DataSourceArn: 'arn:aws:quicksight:us-east-1:xxxxxxxxxx:datasource/datasource_1',
@@ -3097,11 +3241,9 @@ describe('QuickSight Lambda function', () => {
     });
 
     quickSightClientMock.on(UpdateDataSetPermissionsCommand).callsFakeOnce(input => {
-      if ( input.GrantPermissions.length === 2
+      if ( input.GrantPermissions.length === 1
         && input.GrantPermissions[0].Principal === 'test-owner-principal-arn'
-        && input.GrantPermissions[1].Principal === 'test-principal-arn'
         && input.GrantPermissions[0].Actions[9] === 'quicksight:CancelIngestion'
-        && input.GrantPermissions[1].Actions[4] === 'quicksight:ListIngestions'
       ) {
         return {};
       } else {
@@ -3111,11 +3253,10 @@ describe('QuickSight Lambda function', () => {
 
 
     quickSightClientMock.on(UpdateDashboardPermissionsCommand).callsFakeOnce(input => {
-      if ( input.GrantPermissions.length === 2
+      if ( input.GrantPermissions.length === 1
         && input.GrantPermissions[0].Principal === 'test-owner-principal-arn'
-        && input.GrantPermissions[1].Principal === 'test-principal-arn'
         && input.GrantPermissions[0].Actions[0] === 'quicksight:DescribeDashboard'
-        && input.GrantPermissions[1].Actions[3] === 'quicksight:UpdateDashboard') {
+      ) {
         return {};
       } else {
         throw new Error('dashboard permission is not the expected one.');

--- a/test/reporting/quicksight/lambda/quicksight-resource.test.ts
+++ b/test/reporting/quicksight/lambda/quicksight-resource.test.ts
@@ -86,7 +86,7 @@ describe('QuickSight Lambda function', () => {
     awsPartition: 'aws',
     quickSightNamespace: 'default',
     quickSightUser: 'clickstream',
-    quickSightSharePrincipalArn: 'test-principal-arn',
+    quickSightSharePrincipalArn: 'test-owner-principal-arn',
     quickSightOwnerPrincipalArn: 'test-owner-principal-arn',
     databaseName: 'test-database',
     templateArn: 'test-template-arn',
@@ -572,7 +572,7 @@ describe('QuickSight Lambda function', () => {
     awsPartition: 'aws',
     quickSightNamespace: 'default',
     quickSightUser: 'clickstream',
-    quickSightSharePrincipalArn: 'test-principal-arn',
+    quickSightSharePrincipalArn: 'test-owner-principal-arn',
     quickSightOwnerPrincipalArn: 'test-owner-principal-arn',
     databaseName: 'test-database',
     templateArn: 'test-template-arn',
@@ -933,7 +933,7 @@ describe('QuickSight Lambda function', () => {
     awsPartition: 'aws',
     quickSightNamespace: 'default',
     quickSightUser: 'clickstream',
-    quickSightSharePrincipalArn: 'test-principal-arn',
+    quickSightSharePrincipalArn: 'test-owner-principal-arn',
     quickSightOwnerPrincipalArn: 'test-owner-principal-arn',
     databaseName: 'changed-database',
     templateArn: 'test-template-arn',
@@ -1625,11 +1625,27 @@ describe('QuickSight Lambda function', () => {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...commonPropsWithNewDataSet,
       schemas: 'test1,zzzz',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        },
+        {
+          "appId": "zzzz",
+          "timezone": "Asia/Shanghai"
+        }
+      ]`,
     },
     OldResourceProperties: {
       ...basicCloudFormationUpdateEvent.ResourceProperties,
       ...commonProps,
       schemas: 'test1',
+      timezone: `[
+        {
+          "appId": "test1",
+          "timezone": "Asia/Shanghai"
+        }
+      ]`,
     },
   };
 
@@ -3020,9 +3036,7 @@ describe('QuickSight Lambda function', () => {
 
     quickSightClientMock.on(CreateDataSetCommand).callsFakeOnce(input => {
       if ( input.Permissions[0].Principal === 'test-owner-principal-arn'
-        && input.Permissions[1].Principal === 'test-principal-arn'
         && input.Permissions[0].Actions[9] === 'quicksight:CancelIngestion'
-        && input.Permissions[1].Actions[4] === 'quicksight:ListIngestions'
       ) {
         return {
           Arn: 'arn:aws:quicksight:us-east-1:xxxxxxxxxx:dataset/dataset_0',
@@ -3037,8 +3051,7 @@ describe('QuickSight Lambda function', () => {
     });
 
     quickSightClientMock.on(UpdateDataSourcePermissionsCommand).callsFakeOnce(input => {
-      if ( input.GrantPermissions[0].Principal === 'test-owner-principal-arn'
-        && input.GrantPermissions[1].Principal === 'test-principal-arn') {
+      if ( input.GrantPermissions[0].Principal === 'test-owner-principal-arn') {
         return {
           DataSourceArn: 'arn:aws:quicksight:us-east-1:xxxxxxxxxx:datasource/datasource_1',
           DataSourceId: 'datasource_1',
@@ -3054,11 +3067,9 @@ describe('QuickSight Lambda function', () => {
     });
 
     quickSightClientMock.on(CreateDashboardCommand).callsFakeOnce(input => {
-      if ( input.Permissions.length === 2
+      if ( input.Permissions.length === 1
         && input.Permissions[0].Principal === 'test-owner-principal-arn'
-        && input.Permissions[1].Principal === 'test-principal-arn'
         && input.Permissions[0].Actions[0] === 'quicksight:DescribeDashboard'
-        && input.Permissions[1].Actions[3] === 'quicksight:UpdateDashboard'
       ) {
         return {
           DashboardId: 'dashboard_0',
@@ -3241,6 +3252,8 @@ describe('QuickSight Lambda function', () => {
     });
 
     quickSightClientMock.on(UpdateDataSetPermissionsCommand).callsFakeOnce(input => {
+
+      console.log(input);
       if ( input.GrantPermissions.length === 1
         && input.GrantPermissions[0].Principal === 'test-owner-principal-arn'
         && input.GrantPermissions[0].Actions[9] === 'quicksight:CancelIngestion'


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [x] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend