### PR TITLE
chore: add tags to kafka connector

### DIFF
--- a/src/ingestion-server/kafka-s3-connector/custom-resource.ts
+++ b/src/ingestion-server/kafka-s3-connector/custom-resource.ts
@@ -21,6 +21,7 @@ import { Provider } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 import { createRoleForS3SinkConnectorCustomResourceLambda } from './iam';
 import { addCfnNagSuppressRules, rulesToSuppressForLambdaVPCAndReservedConcurrentExecutions } from '../../common/cfn-nag';
+import { attachListTagsPolicyForFunction } from '../../common/lambda/tags';
 import { getShortIdOfStack } from '../../common/stack';
 import { SolutionNodejsFunction } from '../../private/function';
 
@@ -109,7 +110,8 @@ function createS3SinkConnectorLambda(
     connectorRole: props.connectorRole,
   });
 
-  const fn = new SolutionNodejsFunction(scope, 's3SinkConnectorCustomResourceLambda', {
+  const fnId = 's3SinkConnectorCustomResourceLambda';
+  const fn = new SolutionNodejsFunction(scope, fnId, {
     entry: join(
       __dirname,
       'custom-resource',
@@ -124,6 +126,7 @@ function createS3SinkConnectorLambda(
     },
     role,
   });
+  attachListTagsPolicyForFunction(scope, fnId, fn);
   fn.node.addDependency(role);
   addCfnNagSuppressRules(fn.node.defaultChild as CfnResource,
     rulesToSuppressForLambdaVPCAndReservedConcurrentExecutions('KafkaS3ConnectorCR'),

--- a/src/ingestion-server/kafka-s3-connector/iam.ts
+++ b/src/ingestion-server/kafka-s3-connector/iam.ts
@@ -131,6 +131,7 @@ export function createRoleForS3SinkConnectorCustomResourceLambda(
         'kafkaconnect:ListCustomPlugins',
         'kafkaconnect:DeleteCustomPlugin',
         'kafkaconnect:UpdateConnector',
+        'kafkaconnect:TagResource',
       ],
       conditions: {
         StringEquals: {

--- a/src/ingestion-server/kafka-s3-connector/iam.ts
+++ b/src/ingestion-server/kafka-s3-connector/iam.ts
@@ -132,6 +132,8 @@ export function createRoleForS3SinkConnectorCustomResourceLambda(
         'kafkaconnect:DeleteCustomPlugin',
         'kafkaconnect:UpdateConnector',
         'kafkaconnect:TagResource',
+        'kafkaconnect:ListTagsForResource',
+        'kafkaconnect:UntagResource',
       ],
       conditions: {
         StringEquals: {

--- a/test/ingestion-server/kafka-s3-connector/kafka-s3-connector-stack.test.ts
+++ b/test/ingestion-server/kafka-s3-connector/kafka-s3-connector-stack.test.ts
@@ -303,6 +303,8 @@ test('IAM policy for custom resource lambda role has a specified resource and re
       'kafkaconnect:DeleteCustomPlugin',
       'kafkaconnect:UpdateConnector',
       'kafkaconnect:TagResource',
+      'kafkaconnect:ListTagsForResource',
+      'kafkaconnect:UntagResource',
     ],
     Condition: {
       StringEquals: {

--- a/test/ingestion-server/kafka-s3-connector/kafka-s3-connector-stack.test.ts
+++ b/test/ingestion-server/kafka-s3-connector/kafka-s3-connector-stack.test.ts
@@ -302,6 +302,7 @@ test('IAM policy for custom resource lambda role has a specified resource and re
       'kafkaconnect:ListCustomPlugins',
       'kafkaconnect:DeleteCustomPlugin',
       'kafkaconnect:UpdateConnector',
+      'kafkaconnect:TagResource',
     ],
     Condition: {
       StringEquals: {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

add tags to kafka connector

## Implementation highlights

add tags to kafka connector

## Test checklist

- [x] add new test cases
- [x] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [x] deploy ingestion server
    - [x] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend