### PR TITLE
fix(schema): redshift stack fail due to missing timezone

### DIFF
--- a/src/analytics/lambdas/custom-resource/create-schemas.ts
+++ b/src/analytics/lambdas/custom-resource/create-schemas.ts
@@ -304,8 +304,12 @@ function getCreateOrUpdateViewForReportingSQL(newAddedAppIdList: string[], props
   const odsTableNames = props.odsTableNames;
 
   logger.info('createOrUpdateViewForReporting()', { newAddedAppIdList });
-
-  const timezoneDict = timezoneJsonArrayToDict(JSON.parse(props.timezoneWithAppId));
+  let timezoneWithAppId = props.timezoneWithAppId;
+  if (timezoneWithAppId === undefined || timezoneWithAppId === '') {
+    logger.info('timezoneWithAppId is empty, set to \'[]\'');
+    timezoneWithAppId = '[]';
+  }
+  const timezoneDict = timezoneJsonArrayToDict(JSON.parse(timezoneWithAppId));
 
   const sqlStatementsByApp = new Map<string, string[]>();
   for (const app of newAddedAppIdList) {

--- a/src/analytics/parameter.ts
+++ b/src/analytics/parameter.ts
@@ -622,7 +622,7 @@ export function createStackParameters(scope: Construct): {
   const timezoneWithAppIdParam = new CfnParameter(scope, 'TimeZoneWithAppId', {
     description: 'The time zone with app id as json string',
     type: 'String',
-    default: '',
+    default: '[]',
   });
 
   const dataProcessingCronOrRateExpressionParam = new CfnParameter(scope, 'DataProcessingCronOrRateExpression', {

--- a/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
+++ b/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
@@ -313,6 +313,13 @@ describe('DataAnalyticsRedshiftStack common parameter test', () => {
     });
   });
 
+  test('Should has parameter TimeZoneWithAppId', () => {
+    template.hasParameter('TimeZoneWithAppId', {
+      Type: 'String',
+      Default: '[]',
+    });
+  });
+
   test('Should has parameter MaxFilesLimit', () => {
     template.hasParameter('MaxFilesLimit', {
       Type: 'Number',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend