### PR TITLE
fix(schema): QuickSight stack deployment fail due to missing timeozone

### DIFF
--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -99,7 +99,11 @@ export const handler = async (event: ResourceEvent, _context: Context): Promise<
   const sharePrincipalArn = props.quickSightSharePrincipalArn;
   const ownerPrincipalArn = props.quickSightOwnerPrincipalArn;
 
-  const timezoneDict = timezoneJsonArrayToDict(JSON.parse(props.timezone));
+  let timezone = props.timezone;
+  if(timezone === undefined || timezone === '') {
+    timezone = '[]'
+  }
+  const timezoneDict = timezoneJsonArrayToDict(JSON.parse(timezone));
 
   if (event.RequestType === 'Create') {
     return _onCreate(quickSight, awsAccountId, sharePrincipalArn, ownerPrincipalArn, event, timezoneDict);

--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -100,8 +100,8 @@ export const handler = async (event: ResourceEvent, _context: Context): Promise<
   const ownerPrincipalArn = props.quickSightOwnerPrincipalArn;
 
   let timezone = props.timezone;
-  if(timezone === undefined || timezone === '') {
-    timezone = '[]'
+  if (timezone === undefined || timezone === '') {
+    timezone = '[]';
   }
   const timezoneDict = timezoneJsonArrayToDict(JSON.parse(timezone));
 

--- a/test/reporting/quicksight/lambda/quicksight-resource.test.ts
+++ b/test/reporting/quicksight/lambda/quicksight-resource.test.ts
@@ -1507,6 +1507,15 @@ describe('QuickSight Lambda function', () => {
     },
   };
 
+  const basicEventWithoutTimezone = {
+    ...basicCloudFormationEvent,
+    ResourceProperties: {
+      ...basicCloudFormationEvent.ResourceProperties,
+      ...commonProps,
+      schemas: '',
+    },
+  };
+
   const eventForTimezoneCheck = {
     ...basicCloudFormationEvent,
     ResourceProperties: {
@@ -4623,6 +4632,12 @@ describe('QuickSight Lambda function', () => {
     expect(JSON.parse(resp.Data?.dashboards)).toHaveLength(1);
     logger.info(`#dashboards#:${resp.Data?.dashboards}`);
     expect(JSON.parse(resp.Data?.dashboards)[0].dashboardId).toEqual('dashboard_0');
+
+  });
+
+  test('Timezone check - without timezone', async () => {
+    await handler(basicEventWithoutTimezone, context) as CdkCustomResourceResponse;
+    expect(quickSightClientMock).toHaveReceivedCommandTimes(DescribeDataSetCommand, 0);
 
   });
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [x] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend