### PR TITLE
fix: stack information callback error when stack had been deleted

### DIFF
--- a/src/control-plane/backend/lambda/sfn-workflow/index.ts
+++ b/src/control-plane/backend/lambda/sfn-workflow/index.ts
@@ -12,10 +12,10 @@
  */
 
 import { CloudFormationClient, DescribeStacksCommand, Output, Parameter, Tag } from '@aws-sdk/client-cloudformation';
-import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { JSONPath } from 'jsonpath-plus';
 import { logger } from '../../../../common/powertools';
 import { aws_sdk_client_common_config } from '../../../../common/sdk-client-config';
+import { putStringToS3, readS3ObjectAsJson } from '../api/store/aws/s3';
 
 export interface WorkFlowStack {
   Name: string;
@@ -94,26 +94,12 @@ export const callback = async (event: SfnStackEvent) => {
   }
 
   const stack = await describe(event.Input.Region, event.Input.StackName);
-  if (!stack) {
-    throw Error('Describe Stack failed.');
-  }
-
-  try {
-    const s3Client = new S3Client({
-      ...aws_sdk_client_common_config,
-    });
-    const input = {
-      Body: JSON.stringify({ [event.Input.StackName]: stack }),
-      Bucket: event.Callback.BucketName,
-      Key: `${event.Callback.BucketPrefix}/${event.Input.StackName}/output.json`,
-      ContentType: 'application/json',
-    };
-    const command = new PutObjectCommand(input);
-    await s3Client.send(command);
-  } catch (err) {
-    logger.error((err as Error).message, { error: err, event: event });
-    throw Error((err as Error).message);
-  }
+  await putStringToS3(
+    JSON.stringify({ [event.Input.StackName]: stack ?? {} }),
+    event.Input.Region,
+    event.Callback.BucketName,
+    `${event.Callback.BucketPrefix}/${event.Input.StackName}/output.json`,
+  );
   return event;
 };
 
@@ -142,14 +128,15 @@ async function stackParametersResolve(stack: WorkFlowStack) {
   if (stack.Data.Callback.BucketName && stack.Data.Callback.BucketPrefix) {
     const bucket = stack.Data.Callback.BucketName;
     const prefix = stack.Data.Callback.BucketPrefix;
+    const region = stack.Data.Input.Region;
     for (let param of stack.Data.Input.Parameters) {
       let key = param.ParameterKey;
       let value = param.ParameterValue;
       // Find the value in output accurately through JSONPath
       if (param.ParameterKey?.endsWith('.$') && param.ParameterValue?.startsWith('$.')) {
-        ({ key, value } = await _getParameterKeyAndValueByJSONPath(param.ParameterKey, param.ParameterValue, bucket, prefix));
+        ({ key, value } = await _getParameterKeyAndValueByJSONPath(param.ParameterKey, param.ParameterValue, region, bucket, prefix));
       } else if (param.ParameterKey?.endsWith('.#') && param.ParameterValue?.startsWith('#.')) { // Find the value in output by suffix
-        ({ key, value } = await _getParameterKeyAndValueByStackOutput(param.ParameterKey, param.ParameterValue, bucket, prefix));
+        ({ key, value } = await _getParameterKeyAndValueByStackOutput(param.ParameterKey, param.ParameterValue, region, bucket, prefix));
       }
       param.ParameterKey = key;
       param.ParameterValue = value;
@@ -161,6 +148,7 @@ async function stackTagsResolve(stack: WorkFlowStack) {
   const tags = stack.Data.Input.Tags;
   const bucket = stack.Data.Callback.BucketName;
   const prefix = stack.Data.Callback.BucketPrefix;
+  const region = stack.Data.Input.Region;
 
   // When the tag Key or Value starts with '#.', resolve the tag using the pattern '#.{stackName}.{outputKeySuffix}'
   // e.g. origin = '#.Clickstream-ServiceCatalogAppRegistry-249f84aa8dd044c2a7294cb04cebe88b.ServiceCatalogAppRegistryApplicationTagKey'
@@ -173,21 +161,9 @@ async function stackTagsResolve(stack: WorkFlowStack) {
     const splitValues = origin.split('.');
     const stackName = splitValues[1];
     const outputKeySuffix = splitValues[2];
-    const s3ObjectKey = `${prefix}/${stackName}/output.json`;
-    let outputs;
-    try {
-      const content = await getObject(bucket, s3ObjectKey);
-      outputs = JSON.parse(content as string)[stackName].Outputs as Output[];
-    } catch (err) {
-      logger.error('Stack workflow cannot retrieve stack output upon resolving tags ', { error: err, s3ObjectKey });
-      return undefined;
-    }
-    if (outputs) {
-      const stackOutput = outputs.find(output => output.OutputKey?.endsWith(outputKeySuffix));
-      return stackOutput?.OutputValue;
-    }
-
-    return undefined;
+    const outputs = await _getOutputsFromS3(region, bucket, prefix, stackName);
+    const stackOutput = outputs.find(output => output.OutputKey?.endsWith(outputKeySuffix));
+    return stackOutput?.OutputValue;
   };
 
   if (tags && bucket && prefix) {
@@ -206,53 +182,28 @@ async function stackTagsResolve(stack: WorkFlowStack) {
   }
 }
 
-async function _getParameterKeyAndValueByStackOutput(paramKey: string, paramValue: string, bucket: string, prefix: string) {
+async function _getParameterKeyAndValueByStackOutput(paramKey: string, paramValue: string, region: string, bucket: string, prefix: string) {
   // get stack name
   const splitValues = paramValue.split('.');
   const stackName = splitValues[1];
   // get output from s3
-  let stackOutputs;
-  try {
-    const output = await getObject(bucket, `${prefix}/${stackName}/output.json`);
-    stackOutputs = JSON.parse(output as string)[stackName].Outputs;
-  } catch (err) {
-    logger.error('Stack workflow output error.', {
-      error: err,
-      output: `${prefix}/${stackName}/output.json`,
-    });
-  }
-  let value = '';
-  if (stackOutputs) {
-    for (let out of stackOutputs as Output[]) {
-      if (out.OutputKey?.endsWith(splitValues[2])) {
-        value = out.OutputValue ?? '';
-        break;
-      }
-    }
-  }
+  const outputs = await _getOutputsFromS3(region, bucket, prefix, stackName);
+  const stackOutput = outputs.find(output => output.OutputKey?.endsWith(splitValues[2]));
   return {
     key: paramKey.substring(0, paramKey.length - 2),
-    value: value ?? '',
+    value: stackOutput?.OutputValue ?? '',
   };
 }
 
-async function _getParameterKeyAndValueByJSONPath(paramKey: string, paramValue: string, bucket: string, prefix: string) {
+async function _getParameterKeyAndValueByJSONPath(paramKey: string, paramValue: string, region: string, bucket: string, prefix: string) {
   const splitValues = paramValue.split('.');
   const stackName = splitValues[1];
-  // get output from s3
-  let stackOutputs;
-  try {
-    const output = await getObject(bucket, `${prefix}/${stackName}/output.json`);
-    stackOutputs = JSON.parse(output as string);
-  } catch (err) {
-    logger.error('Stack workflow output error.', {
-      error: err,
-      output: `${prefix}/${stackName}/output.json`,
-    });
-  }
+  // get stack from s3
+  const stackJson = await _getStackFromS3(region, bucket, prefix, stackName);
   let value = '';
-  if (stackOutputs) {
-    const values = JSONPath({ path: paramValue, json: stackOutputs });
+  if (stackJson) {
+    const values = JSONPath({ path: paramValue, json: stackJson });
+    console.log(values);
     if (Array.prototype.isPrototypeOf(values) && values.length > 0) {
       value = values[0] as string;
     }
@@ -263,27 +214,34 @@ async function _getParameterKeyAndValueByJSONPath(paramKey: string, paramValue: 
   };
 }
 
-async function getObject(bucket: string, key: string) {
-  const streamToString = (stream: any) => new Promise((resolve, reject) => {
-    const chunks: any = [];
-    stream.on('data', (chunk: any) => chunks.push(chunk));
-    stream.on('error', reject);
-    stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
-  });
-
-  const command = new GetObjectCommand({
-    Bucket: bucket,
-    Key: key,
-  });
-
+async function _getStackFromS3(region: string, bucket: string, prefix: string, stackName: string) {
+  const fileKey = `${prefix}/${stackName}/output.json`;
   try {
-    const s3Client = new S3Client({
-      ...aws_sdk_client_common_config,
+    return await readS3ObjectAsJson(region, bucket, fileKey);
+  } catch (err) {
+    logger.error('read empty content error.', {
+      region, bucket, key: fileKey,
     });
-    const { Body } = await s3Client.send(command);
-    const bodyContents = await streamToString(Body);
-    return bodyContents;
-  } catch (error) {
     return undefined;
+  }
+}
+
+async function _getOutputsFromS3(region: string, bucket: string, prefix: string, stackName: string) {
+  const fileKey = `${prefix}/${stackName}/output.json`;
+  try {
+    const content = await _getStackFromS3(region, bucket, fileKey, stackName);
+    if (!content) {
+      logger.warn('read empty outputs.', {
+        region, bucket, key: fileKey,
+      });
+      return [];
+    }
+    const outputs = content[stackName].Outputs as Output[];
+    return outputs;
+  } catch (err) {
+    logger.error('read outputs error.', {
+      region, bucket, key: fileKey,
+    });
+    return [];
   }
 }

--- a/src/control-plane/backend/lambda/sfn-workflow/index.ts
+++ b/src/control-plane/backend/lambda/sfn-workflow/index.ts
@@ -203,7 +203,6 @@ async function _getParameterKeyAndValueByJSONPath(paramKey: string, paramValue: 
   let value = '';
   if (stackJson) {
     const values = JSONPath({ path: paramValue, json: stackJson });
-    console.log(values);
     if (Array.prototype.isPrototypeOf(values) && values.length > 0) {
       value = values[0] as string;
     }

--- a/test/control-plane/lambda/sfn-workflow.test.ts
+++ b/test/control-plane/lambda/sfn-workflow.test.ts
@@ -64,6 +64,14 @@ describe('SFN workflow Lambda Function', () => {
     Name: 'DataProcessing',
   };
 
+  const baseMapInput = {
+    MapRun: true,
+    Token: 'TOKEN',
+    Data: {
+      ...baseStackWorkflowEvent,
+    },
+  };
+
   beforeEach(() => {
     s3Mock.reset();
     cloudFormationMock.reset();
@@ -273,6 +281,98 @@ describe('SFN workflow Lambda Function', () => {
       Type: 'Pass',
     });
     expect(s3Mock).toHaveReceivedCommandTimes(PutObjectCommand, 1);
+  });
+
+  test('Run pass stack in map', async () => {
+    const event = {
+      ...baseMapInput,
+      Data: {
+        ...baseStackWorkflowEvent,
+        Type: 'Pass',
+      },
+    };
+
+    cloudFormationMock.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackName: 'xxx',
+          Outputs: [
+            {
+              OutputKey: 'ObservabilityDashboardName',
+              OutputValue: 'clickstream_dashboard_notepad_mtzfsocy',
+            },
+          ],
+          StackStatus: StackStatus.CREATE_COMPLETE,
+          CreationTime: new Date(),
+        },
+      ],
+    });
+    const resp = await handler(event) as CdkCustomResourceResponse;
+    expect(resp).toEqual({
+      Data: {
+        Callback: {
+          BucketName: 'click-stream-control-pla-clickstreamsolutiondatab-tn5qj1l1w3e',
+          BucketPrefix: 'clickstream/workflow/main-d1f8f94d-09ae-4b08-9758-98d21b84c2bb',
+        },
+        Input: {
+          Action: 'Create',
+          Parameters: [
+            { ParameterKey: 'VpcId', ParameterValue: 'vpc-099adfb13a6ba6821' },
+            { ParameterKey: 'PrivateSubnetIds', ParameterValue: 'subnet-02b1c74d310e29d66,subnet-0f4d44b0cb5898403,subnet-02b77ab42fb6f6210' },
+            { ParameterKey: 'ProjectId', ParameterValue: 'demo_ervv' },
+            { ParameterKey: 'AppIds', ParameterValue: '' },
+          ],
+          Region: 'ap-northeast-1',
+          StackName: 'Clickstream-DataProcessing-f00b00bdbabb4ea9a00e8e66f0f372fa',
+          TemplateURL: 'https://aws-gcr-solutions.s3.us-east-1.amazonaws.com/clickstream-branch-main/v1.1.0-dev-main-202309261209-a1094814/default/data-pipeline-stack.template.json',
+        },
+      },
+      Name: 'DataProcessing',
+      Type: 'Pass',
+    });
+    expect(s3Mock).toHaveReceivedCommandTimes(PutObjectCommand, 1);
+  });
+
+  test('Run pass stack in map and stack has been deleted', async () => {
+    const event = {
+      ...baseMapInput,
+      Data: {
+        ...baseStackWorkflowEvent,
+        Type: 'Pass',
+      },
+    };
+
+    cloudFormationMock.on(DescribeStacksCommand).rejects(
+      new Error('Stack not found'),
+    );
+    const resp = await handler(event) as CdkCustomResourceResponse;
+    expect(resp).toEqual({
+      Data: {
+        Callback: {
+          BucketName: 'click-stream-control-pla-clickstreamsolutiondatab-tn5qj1l1w3e',
+          BucketPrefix: 'clickstream/workflow/main-d1f8f94d-09ae-4b08-9758-98d21b84c2bb',
+        },
+        Input: {
+          Action: 'Create',
+          Parameters: [
+            { ParameterKey: 'VpcId', ParameterValue: 'vpc-099adfb13a6ba6821' },
+            { ParameterKey: 'PrivateSubnetIds', ParameterValue: 'subnet-02b1c74d310e29d66,subnet-0f4d44b0cb5898403,subnet-02b77ab42fb6f6210' },
+            { ParameterKey: 'ProjectId', ParameterValue: 'demo_ervv' },
+            { ParameterKey: 'AppIds', ParameterValue: '' },
+          ],
+          Region: 'ap-northeast-1',
+          StackName: 'Clickstream-DataProcessing-f00b00bdbabb4ea9a00e8e66f0f372fa',
+          TemplateURL: 'https://aws-gcr-solutions.s3.us-east-1.amazonaws.com/clickstream-branch-main/v1.1.0-dev-main-202309261209-a1094814/default/data-pipeline-stack.template.json',
+        },
+      },
+      Name: 'DataProcessing',
+      Type: 'Pass',
+    });
+    expect(s3Mock).toHaveReceivedNthSpecificCommandWith(1, PutObjectCommand, {
+      Body: '{"Clickstream-DataProcessing-f00b00bdbabb4ea9a00e8e66f0f372fa":{}}',
+      Bucket: 'click-stream-control-pla-clickstreamsolutiondatab-tn5qj1l1w3e',
+      Key: 'clickstream/workflow/main-d1f8f94d-09ae-4b08-9758-98d21b84c2bb/Clickstream-DataProcessing-f00b00bdbabb4ea9a00e8e66f0f372fa/output.json',
+    });
   });
 
 });


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend