### PR TITLE
chore: reorder the parameters of web console stacks

### DIFF
--- a/src/alb-control-plane-stack.ts
+++ b/src/alb-control-plane-stack.ts
@@ -85,11 +85,6 @@ export class ApplicationLoadBalancerControlPlaneStack extends Stack {
 
     this.templateOptions.description = SolutionInfo.DESCRIPTION + `- Control Plane within VPC (${props.internetFacing ? 'Public' : 'Private'})`;
 
-    const {
-      iamRolePrefixParam,
-      iamRoleBoundaryArnParam,
-    } = Parameters.createIAMRolePrefixAndBoundaryParameters(this, this.paramGroups, this.paramLabels);
-
     let vpc:IVpc|undefined = undefined;
 
     if (props.existingVpc) {
@@ -220,6 +215,11 @@ export class ApplicationLoadBalancerControlPlaneStack extends Stack {
     const healthCheckPath = '/';
 
     const pluginPrefix = 'plugins/';
+
+    const {
+      iamRolePrefixParam,
+      iamRoleBoundaryArnParam,
+    } = Parameters.createIAMRolePrefixAndBoundaryParameters(this, this.paramGroups, this.paramLabels);
 
     const isEmptyRolePrefixCondition = new CfnCondition(
       this,

--- a/src/base-lib/src/constant/constant.ts
+++ b/src/base-lib/src/constant/constant.ts
@@ -307,8 +307,8 @@ export const PARAMETER_LABEL_OIDC_ISSUER = 'OpenID Connector Issuer';
 export const PARAMETER_LABEL_OIDC_CLIENT_ID = 'OpenID Connector Client Id';
 export const PARAMETER_LABEL_OIDC_JWKS_SUFFIX =
   'OpenID Connector Jwks Uri Suffix';
-export const PARAMETER_LABEL_IAM_ROLE_PREFIX = 'IAM Role Prefix';
-export const PARAMETER_LABEL_IAM_ROLE_BOUNDARY_ARN = 'IAM Role Boundary ARN';
+export const PARAMETER_LABEL_IAM_ROLE_PREFIX = 'IAM Role Prefix(Optional)';
+export const PARAMETER_LABEL_IAM_ROLE_BOUNDARY_ARN = 'IAM Role Boundary ARN(Optional)';
 
 export const KDS_ON_DEMAND_MODE = 'ON_DEMAND';
 export const KDS_PROVISIONED_MODE = 'PROVISIONED';

--- a/src/cloudfront-control-plane-stack.ts
+++ b/src/cloudfront-control-plane-stack.ts
@@ -100,11 +100,6 @@ export class CloudFrontControlPlaneStack extends Stack {
 
     this.templateOptions.description = SolutionInfo.DESCRIPTION + '- Control Plane';
 
-    const {
-      iamRolePrefixParam,
-      iamRoleBoundaryArnParam,
-    } = Parameters.createIAMRolePrefixAndBoundaryParameters(this, this.paramGroups, this.paramLabels);
-
     let domainProps: DomainProps | undefined = undefined;
     let cnCloudFrontS3PortalProps: CNCloudFrontS3PortalProps | undefined;
     const solutionBucket = new SolutionBucket(this, 'ClickstreamSolution');
@@ -250,6 +245,11 @@ export class CloudFrontControlPlaneStack extends Stack {
     const oidcInfo = this.oidcInfo(createCognitoUserPool ? controlPlane.controlPlaneUrl : undefined);
     const authorizer = this.createAuthorizer(oidcInfo);
     const pluginPrefix = 'plugins/';
+
+    const {
+      iamRolePrefixParam,
+      iamRoleBoundaryArnParam,
+    } = Parameters.createIAMRolePrefixAndBoundaryParameters(this, this.paramGroups, this.paramLabels);
 
     const isEmptyRolePrefixCondition = new CfnCondition(
       this,

--- a/src/common/parameters.ts
+++ b/src/common/parameters.ts
@@ -660,7 +660,7 @@ export class Parameters {
     const labels: any = paramLabels ?? {};
 
     const iamRolePrefixParam = new CfnParameter(scope, 'IamRolePrefix', {
-      description: 'The prefix of all IAM Roles.',
+      description: 'The prefix of the IAM Roles created in the solution.',
       type: 'String',
       allowedPattern: IAM_ROLE_PREFIX_PATTERN,
       default: '',
@@ -670,7 +670,7 @@ export class Parameters {
     };
 
     const iamRoleBoundaryArnParam = new CfnParameter(scope, 'IamRoleBoundaryArn', {
-      description: 'Set permissions boundaries for IAM Roles.',
+      description: 'Set permissions boundaries for the IAM Roles created in the solution.',
       type: 'String',
       default: '',
     });


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend