### PR TITLE
chore: calibrate refresh day when refreshing MVs

### DIFF
--- a/src/analytics/lambdas/load-data-workflow/refresh-views.ts
+++ b/src/analytics/lambdas/load-data-workflow/refresh-views.ts
@@ -43,8 +43,10 @@ export const handler = async (_e: any, _c: Context) => {
       || (refreshInfo !== undefined && Date.now() - refreshInfo.lastRefreshTime >= Number(REFRESH_INTERVAL_MINUTES) * 60 * 1000)) {
       const latestJobTimestamp = await getLatestEmrJobEndTime(pipelineS3BucketName, pipelineEmrStatusS3Prefix, projectId);
 
+      const triggerDate = subtractDayFromTimestamp(latestJobTimestamp);
+
       const input = JSON.stringify({
-        latestJobTimestamp: latestJobTimestamp,
+        latestJobTimestamp: triggerDate,
       });
 
       const startExecutionCommand = new StartExecutionCommand({
@@ -96,6 +98,12 @@ async function updateMVRefreshInfoToS3(lastRefreshTime: number, pipelineS3Prefix
     logger.error('Error when write mv refresh info data to s3:', { error });
     throw error;
   }
+}
+
+function subtractDayFromTimestamp(timestamp: number) {
+  const date = new Date(timestamp);
+  date.setDate(date.getDate() - 1);
+  return date.getTime();
 }
 
 export function getMVRefreshInfoKey(bucketPrefix: string) {

--- a/test/jestEnv.js
+++ b/test/jestEnv.js
@@ -60,6 +60,7 @@ process.env.APP_IDS = 'app1,app2'
 process.env.REDSHIFT_MODE = 'Serverless';
 process.env.REDSHIFT_SERVERLESS_WORKGROUP_NAME = 'workgroup-test';
 process.env.DATA_REFRESHNESS_IN_HOUR = '72';
+process.env.REFRESH_STATE_MACHINE_ARN = 'arn:aws:states:us-east-1:111122223333:workflow/abc'
 
 process.env.TIMEZONE_WITH_APPID_LIST = '[{"appId":"app1","timezone":"America/Noronha"},{"appId":"app2","timezone":"Asia/Shanghai"}]'
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

refresh date of previous day

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend