### PR TITLE
fix: version range of ClickstreamMetadataDdbArn

### DIFF
--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -1252,7 +1252,7 @@ export class CDataModelingStack extends JSONObject {
     const partition = awsRegion?.startsWith('cn') ? 'aws-cn' : 'aws';
     return `arn:${partition}:dynamodb:${awsRegion}:${awsAccountId}:table/${clickStreamTableName}`;
   })
-  @supportVersions([SolutionVersion.V_1_1_6, SolutionVersion.ANY])
+  @supportVersions([SolutionVersion.V_1_1_0, SolutionVersion.ANY])
     ClickstreamMetadataDdbArn?: string;
 
   @JSONObject.optional('')

--- a/src/control-plane/backend/lambda/api/test/api/workflow-version.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-version.test.ts
@@ -657,9 +657,6 @@ describe('Workflow test with pipeline version', () => {
                         DataModelingRedshiftStack,
                         [
                           {
-                            ParameterKey: 'ClickstreamMetadataDdbArn',
-                          },
-                          {
                             ParameterKey: 'SegmentsS3Prefix',
                           },
                           {
@@ -745,9 +742,6 @@ describe('Workflow test with pipeline version', () => {
                       DataModelingRedshift: removeParametersFromStack(
                         DataModelingRedshiftStack,
                         [
-                          {
-                            ParameterKey: 'ClickstreamMetadataDdbArn',
-                          },
                           {
                             ParameterKey: 'SegmentsS3Prefix',
                           },
@@ -1122,9 +1116,6 @@ describe('Workflow test with pipeline version in China region', () => {
                             ParameterKey: 'SegmentsS3Prefix',
                           },
                           {
-                            ParameterKey: 'ClickstreamMetadataDdbArn',
-                          },
-                          {
                             ParameterKey: 'TimeZoneWithAppId',
                           },
                           {
@@ -1202,9 +1193,6 @@ describe('Workflow test with pipeline version in China region', () => {
                         [
                           {
                             ParameterKey: 'SegmentsS3Prefix',
-                          },
-                          {
-                            ParameterKey: 'ClickstreamMetadataDdbArn',
                           },
                           {
                             ParameterKey: 'TimeZoneWithAppId',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend