### PR TITLE
fix: edge cases of refresh view and improve stability

### DIFF
--- a/src/analytics/lambdas/refresh-materialized-views-workflow/check-next-refresh-view.ts
+++ b/src/analytics/lambdas/refresh-materialized-views-workflow/check-next-refresh-view.ts
@@ -14,7 +14,7 @@
 import { RefreshWorkflowSteps } from '../../private/constant';
 import { reportingViewsDef, schemaDefs } from '../../private/sql-def';
 
-interface RefreshViewOrSp {
+export interface RefreshViewOrSp {
   name: string;
   type: string;
   timezoneSensitive: string;

--- a/src/analytics/lambdas/refresh-materialized-views-workflow/check-refresh-sp-status.ts
+++ b/src/analytics/lambdas/refresh-materialized-views-workflow/check-refresh-sp-status.ts
@@ -88,7 +88,7 @@ export const _handler = async (event: CheckRefreshSpStatusEvent, context: Contex
       detail: {
         queryId: queryId,
         status: response.Status,
-        taskName: spName,
+        spName: spName,
         message: `Error: ${response.Error}`,
       },
     };
@@ -97,7 +97,7 @@ export const _handler = async (event: CheckRefreshSpStatusEvent, context: Contex
     return {
       detail: {
         queryId: queryId,
-        taskName: spName,
+        spName: spName,
         refreshDate: refreshDate,
         status: response.Status,
       },

--- a/src/analytics/lambdas/refresh-materialized-views-workflow/check-refresh-workflow-start.ts
+++ b/src/analytics/lambdas/refresh-materialized-views-workflow/check-refresh-workflow-start.ts
@@ -1,0 +1,79 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { aws_sdk_client_common_config, logger } from '@aws/clickstream-base-lib';
+import { SFNClient, ListExecutionsCommand, ListExecutionsCommandOutput } from '@aws-sdk/client-sfn';
+import { WorkflowStatus } from '../../private/constant';
+
+const REGION = process.env.AWS_REGION; //e.g. "us-east-1"
+
+const sfnClient = new SFNClient({
+  region: REGION,
+  ...aws_sdk_client_common_config,
+});
+
+export interface CheckRefreshWorkflowEvent {
+  executionId: string;
+}
+
+/**
+ * The lambda function to check refresh workflow should be start or not
+ */
+export const handler = async (event: CheckRefreshWorkflowEvent) => {
+  try {
+    const hasRunningExecution: boolean = await hasOtherRunningExecutions(event.executionId);
+    if (!hasRunningExecution) {
+      return {
+        status: WorkflowStatus.CONTINUE,
+      };
+    } else {
+      return {
+        status: WorkflowStatus.SKIP,
+      };
+    }
+  } catch (err) {
+    if (err instanceof Error) {
+      logger.error('Error when check refresh workflow start or not.', err);
+    }
+    throw err;
+  }
+};
+
+async function hasOtherRunningExecutions(executionArn: string) {
+  const tempArr: string[] = executionArn.split(':');
+  tempArr.pop();
+  const stateMachineArn = tempArr.join(':').replace(':execution:', ':stateMachine:');
+
+  logger.info('ListExecutionsCommand, stateMachineArn=' + stateMachineArn);
+  const res: ListExecutionsCommandOutput = await sfnClient.send(new ListExecutionsCommand({
+    stateMachineArn,
+    statusFilter: 'RUNNING',
+  }));
+
+  let otherRunningExecutionsCount = 0;
+
+  let hasRunningWorkflow = false;
+  if (res.executions) {
+    logger.info('totalExecutionsCount=' + res.executions.length);
+    otherRunningExecutionsCount = res.executions.filter(e => e.executionArn != executionArn).length;
+  }
+
+  logger.info('otherRunningExecutionsCount=' + otherRunningExecutionsCount);
+
+  if (otherRunningExecutionsCount > 0) {
+    hasRunningWorkflow = true;
+  }
+
+  return hasRunningWorkflow;
+
+}

--- a/src/analytics/private/refresh-materialized-views-workflow.ts
+++ b/src/analytics/private/refresh-materialized-views-workflow.ts
@@ -299,9 +299,6 @@ export class RefreshMaterializedViewsWorkflow extends Construct {
       handler: 'handler',
       memorySize: 128,
       timeout: Duration.minutes(3),
-      logConf: {
-        retention: RetentionDays.ONE_WEEK,
-      },
       logGroup,
       reservedConcurrentExecutions: 1,
       role: createLambdaRole(this, 'ParseTimeZoneWithAppIdListRule', true, []),
@@ -326,10 +323,7 @@ export class RefreshMaterializedViewsWorkflow extends Construct {
       ),
       handler: 'handler',
       memorySize: 128,
-      timeout: Duration.minutes(3),
-      logConf: {
-        retention: RetentionDays.ONE_WEEK,
-      },
+      timeout: Duration.seconds(30),
       logGroup,
       reservedConcurrentExecutions: 1,
       role: createLambdaRole(this, 'CheckRefreshWorkflowStartRule', true, []),
@@ -354,9 +348,6 @@ export class RefreshMaterializedViewsWorkflow extends Construct {
       handler: 'handler',
       memorySize: 128,
       timeout: Duration.minutes(3),
-      logConf: {
-        retention: RetentionDays.ONE_WEEK,
-      },
       logGroup,
       reservedConcurrentExecutions: 1,
       role: createLambdaRole(this, 'CheckNextRefreshSpRole', true, []),
@@ -384,9 +375,6 @@ export class RefreshMaterializedViewsWorkflow extends Construct {
       handler: 'handler',
       memorySize: 128,
       timeout: Duration.minutes(3),
-      logConf: {
-        retention: RetentionDays.ONE_WEEK,
-      },
       logGroup,
       reservedConcurrentExecutions: 1,
       role: createLambdaRole(this, 'CheckNextRefreshViewRole', true, []),
@@ -412,9 +400,6 @@ export class RefreshMaterializedViewsWorkflow extends Construct {
       handler: 'handler',
       memorySize: 128,
       timeout: Duration.minutes(3),
-      logConf: {
-        retention: RetentionDays.ONE_WEEK,
-      },
       logGroup,
       reservedConcurrentExecutions: 1,
       role: createLambdaRole(this, 'RefreshBasicViewRole', true, []),
@@ -442,9 +427,6 @@ export class RefreshMaterializedViewsWorkflow extends Construct {
       handler: 'handler',
       memorySize: 128,
       timeout: Duration.minutes(3),
-      logConf: {
-        retention: RetentionDays.ONE_WEEK,
-      },
       logGroup,
       reservedConcurrentExecutions: 1,
       role: createLambdaRole(this, 'CheckStartSpRefreshRole', true, []),
@@ -473,9 +455,6 @@ export class RefreshMaterializedViewsWorkflow extends Construct {
       handler: 'handler',
       memorySize: 128,
       timeout: Duration.minutes(3),
-      logConf: {
-        retention: RetentionDays.ONE_WEEK,
-      },
       logGroup,
       reservedConcurrentExecutions: 1,
       role: createLambdaRole(this, 'CheckRefreshMvStatusRole', true, []),
@@ -502,9 +481,6 @@ export class RefreshMaterializedViewsWorkflow extends Construct {
       handler: 'handler',
       memorySize: 128,
       timeout: Duration.minutes(3),
-      logConf: {
-        retention: RetentionDays.ONE_WEEK,
-      },
       logGroup,
       reservedConcurrentExecutions: 1,
       role: createLambdaRole(this, 'CheckRefreshSpStatusRole', true, []),
@@ -532,9 +508,6 @@ export class RefreshMaterializedViewsWorkflow extends Construct {
       handler: 'handler',
       memorySize: 128,
       timeout: Duration.minutes(3),
-      logConf: {
-        retention: RetentionDays.ONE_WEEK,
-      },
       logGroup,
       reservedConcurrentExecutions: 1,
       role: createLambdaRole(this, 'RefreshSpRole', true, []),

--- a/test/analytics/analytics-on-redshift/lambda/refresh-materialized-views-workflow/check-refresh-workflow-start.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/refresh-materialized-views-workflow/check-refresh-workflow-start.test.ts
@@ -1,0 +1,64 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { SFNClient, ListExecutionsCommand } from '@aws-sdk/client-sfn';
+import { mockClient } from 'aws-sdk-client-mock';
+import { handler, CheckRefreshWorkflowEvent } from '../../../../../src/analytics/lambdas/refresh-materialized-views-workflow/check-refresh-workflow-start';
+import 'aws-sdk-client-mock-jest';
+
+
+describe('Lambda - check next refresh task', () => {
+  const sfnClientMock = mockClient(SFNClient);
+
+  let checkRefreshWorkflowEvent: CheckRefreshWorkflowEvent = {
+    executionId: 'id-1',
+  };
+
+  beforeEach(() => {
+    sfnClientMock.reset();
+  });
+
+  test('There is no existing running execution', async () => {
+    sfnClientMock.on(ListExecutionsCommand).resolves({
+      executions: [
+        //@ts-ignore
+        {
+          executionArn: checkRefreshWorkflowEvent.executionId,
+        },
+      ],
+    });
+    const resp = await handler(checkRefreshWorkflowEvent);
+    expect(resp).toEqual({
+      status: 'CONTINUE',
+    });
+  });
+
+  test('There is an existing running execution', async () => {
+    sfnClientMock.on(ListExecutionsCommand).resolves({
+      executions: [
+        //@ts-ignore
+        {
+          executionArn: 'id-2',
+        },
+        //@ts-ignore
+        {
+          executionArn: checkRefreshWorkflowEvent.executionId,
+        },
+      ],
+    });
+    const resp = await handler(checkRefreshWorkflowEvent);
+    expect(resp).toEqual({
+      status: 'SKIP',
+    });
+  });
+});


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

fix refresh view issues
1. Add lambda TooManyRequestsException retry
2. fix issue of code checking
3. fix issue of check-refresh-sp-status.ts response
4. Checking existing workflow running
5. check max refresh date for each sp

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend