### PR TITLE
chore: optimize local testing performance

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,6 +1,8 @@
 version: 0.2
 
 env:
+  variables:
+    CI: true
   shell: bash
   exported-variables:
     - BSS_IMAGE_ASSET_REPOSITORY_NAME

--- a/deployment/run-unit-tests.sh
+++ b/deployment/run-unit-tests.sh
@@ -8,6 +8,8 @@ cp src/common/model.ts src/control-plane/backend/lambda/api/common/model-ln.ts
 rm src/control-plane/backend/lambda/api/service/quicksight/dashboard-ln.ts
 cp src/reporting/private/dashboard.ts src/control-plane/backend/lambda/api/service/quicksight/dashboard-ln.ts
 
+export CI=true
+
 echo "pnpm install"
 npm install -g pnpm@8.15.3
 pnpm install
@@ -18,7 +20,6 @@ pnpm nx run-many --target=build
 echo "pnpm run test"
 pnpm run test
 
-export CI=true
 pnpm install --frozen-lockfile --dir frontend
 pnpm --dir frontend run test
 

--- a/src/common/s3-asset.ts
+++ b/src/common/s3-asset.ts
@@ -61,12 +61,7 @@ export function uploadBuiltInJarsAndRemoteFiles(
   };
 
   const deployment = new BucketDeployment(scope, 'JarsAndFiles', {
-    sources: [
-      Source.asset(props.sourcePath, {
-        assetHashType: AssetHashType.SOURCE,
-        bundling,
-      }),
-    ],
+    sources: getSourceAsset(props, bundling),
     destinationBucket: props.destinationBucket,
     destinationKeyPrefix: props.destinationKeyPrefix,
     memoryLimit: 1024, // Increase the memory limit to 1 gigabytes
@@ -86,6 +81,19 @@ export function uploadBuiltInJarsAndRemoteFiles(
     jars: entryPointJar,
     deployment,
   };
+}
+
+function getSourceAsset(props: BuildJarProps, bundling: BundlingOptions) {
+  if (process.env.IS_SKIP_ASSET_BUNDLE === 'true') {
+    return [Source.data('test', 'test')];
+  } else {
+    return [
+      Source.asset(props.sourcePath, {
+        assetHashType: AssetHashType.SOURCE,
+        bundling,
+      }),
+    ];
+  }
 }
 
 function extractFilenameFromUrl(url: string): string {

--- a/src/common/s3-asset.ts
+++ b/src/common/s3-asset.ts
@@ -84,7 +84,7 @@ export function uploadBuiltInJarsAndRemoteFiles(
 }
 
 function getSourceAsset(props: BuildJarProps, bundling: BundlingOptions) {
-  if (process.env.IS_SKIP_ASSET_BUNDLE === 'true') {
+  if (process.env.CI === 'true') {
     return [Source.data('test', 'test')];
   } else {
     return [

--- a/src/common/s3-asset.ts
+++ b/src/common/s3-asset.ts
@@ -84,7 +84,7 @@ export function uploadBuiltInJarsAndRemoteFiles(
 }
 
 function getSourceAsset(props: BuildJarProps, bundling: BundlingOptions) {
-  if (process.env.CI === 'true') {
+  if (process.env.CI !== 'true') {
     return [Source.data('test', 'test')];
   } else {
     return [

--- a/src/control-plane/backend/click-stream-api.ts
+++ b/src/control-plane/backend/click-stream-api.ts
@@ -368,7 +368,7 @@ export class ClickStreamApiConstruct extends Construct {
   }
 
   private getLambdaCode() {
-    if (process.env.IS_SKIP_ASSET_BUNDLE === 'true') {
+    if (process.env.CI === 'true') {
       return Code.fromAsset('./src/control-plane/backend/lambda/api/');
     } else {
       return Code.fromDockerBuild(path.join(__dirname, '../../../'), {

--- a/src/control-plane/backend/click-stream-api.ts
+++ b/src/control-plane/backend/click-stream-api.ts
@@ -315,12 +315,7 @@ export class ClickStreamApiConstruct extends Construct {
   private createApiFunction(props: ClickStreamApiProps, lambdaFunctionNetwork: any, role: Role): LambdaFunction {
     const fn = new LambdaFunction(this, 'ApiFunction', {
       description: 'Lambda function for api of solution Clickstream Analytics on AWS',
-      code: Code.fromDockerBuild(path.join(__dirname, '../../../'), {
-        file: './src/control-plane/backend/Dockerfile',
-        buildArgs: {
-          REACT_APP_SOLUTION_VERSION: SolutionInfo.SOLUTION_VERSION,
-        },
-      }),
+      code: this.getLambdaCode(),
       handler: 'run.sh',
       runtime: Runtime.NODEJS_18_X,
       architecture: Architecture.ARM_64,
@@ -370,6 +365,19 @@ export class ClickStreamApiConstruct extends Construct {
     ]);
 
     return fn;
+  }
+
+  private getLambdaCode() {
+    if (process.env.IS_SKIP_ASSET_BUNDLE === 'true') {
+      return Code.fromAsset('./src/control-plane/backend/lambda/api/');
+    } else {
+      return Code.fromDockerBuild(path.join(__dirname, '../../../'), {
+        file: './src/control-plane/backend/Dockerfile',
+        buildArgs: {
+          REACT_APP_SOLUTION_VERSION: SolutionInfo.SOLUTION_VERSION,
+        },
+      });
+    }
   }
 
   private getLambdaNetworkConfig(props: ClickStreamApiProps) {

--- a/src/control-plane/backend/click-stream-api.ts
+++ b/src/control-plane/backend/click-stream-api.ts
@@ -368,7 +368,7 @@ export class ClickStreamApiConstruct extends Construct {
   }
 
   private getLambdaCode() {
-    if (process.env.CI === 'true') {
+    if (process.env.CI !== 'true') {
       return Code.fromAsset('./src/control-plane/backend/lambda/api/');
     } else {
       return Code.fromDockerBuild(path.join(__dirname, '../../../'), {

--- a/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
+++ b/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
@@ -26,14 +26,22 @@ export class LambdaAdapterLayer extends LayerVersion {
     const defaultArch = props?.arch ?? 'x86_64';
 
     super(scope, id, {
-      code: Code.fromDockerBuild(path.join(__dirname, '.'), {
-        file: 'Dockerfile',
-        buildArgs: {
-          ARCH: defaultArch,
-          ADAPTER_VERSION: defaultVersion,
-        },
-      }),
+      code: getLambdaCode(defaultArch, defaultVersion),
       compatibleRuntimes: [Runtime.NODEJS_16_X, Runtime.NODEJS_18_X, Runtime.NODEJS_20_X, Runtime.NODEJS_LATEST],
+    });
+  }
+}
+
+function getLambdaCode(defaultArch: string, defaultVersion: string) {
+  if (process.env.IS_SKIP_ASSET_BUNDLE === 'true') {
+    return Code.fromAsset('./src/control-plane/backend/layer/lambda-web-adapter');
+  } else {
+    return Code.fromDockerBuild(path.join(__dirname, '.'), {
+      file: 'Dockerfile',
+      buildArgs: {
+        ARCH: defaultArch,
+        ADAPTER_VERSION: defaultVersion,
+      },
     });
   }
 }

--- a/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
+++ b/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
@@ -33,7 +33,7 @@ export class LambdaAdapterLayer extends LayerVersion {
 }
 
 function getLambdaCode(defaultArch: string, defaultVersion: string) {
-  if (process.env.IS_SKIP_ASSET_BUNDLE === 'true') {
+  if (process.env.CI === 'true') {
     return Code.fromAsset('./src/control-plane/backend/layer/lambda-web-adapter');
   } else {
     return Code.fromDockerBuild(path.join(__dirname, '.'), {

--- a/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
+++ b/src/control-plane/backend/layer/lambda-web-adapter/layer.ts
@@ -33,7 +33,7 @@ export class LambdaAdapterLayer extends LayerVersion {
 }
 
 function getLambdaCode(defaultArch: string, defaultVersion: string) {
-  if (process.env.CI === 'true') {
+  if (process.env.CI !== 'true') {
     return Code.fromAsset('./src/control-plane/backend/layer/lambda-web-adapter');
   } else {
     return Code.fromDockerBuild(path.join(__dirname, '.'), {

--- a/src/control-plane/cloudfront-s3-portal.ts
+++ b/src/control-plane/cloudfront-s3-portal.ts
@@ -199,7 +199,7 @@ export class CloudFrontS3Portal extends Construct {
   }
 
   private getWebAssets(props: CloudFrontS3PortalProps, excludeIndexHtml: boolean) {
-    if (process.env.IS_SKIP_ASSET_BUNDLE === 'true') {
+    if (process.env.CI === 'true') {
       return Source.data('test', 'test');
     } else {
       const commands = [...props.frontendProps.buildCommands];

--- a/src/control-plane/cloudfront-s3-portal.ts
+++ b/src/control-plane/cloudfront-s3-portal.ts
@@ -199,7 +199,7 @@ export class CloudFrontS3Portal extends Construct {
   }
 
   private getWebAssets(props: CloudFrontS3PortalProps, excludeIndexHtml: boolean) {
-    if (process.env.CI === 'true') {
+    if (process.env.CI !== 'true') {
       return Source.data('test', 'test');
     } else {
       const commands = [...props.frontendProps.buildCommands];

--- a/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
+++ b/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
@@ -34,6 +34,7 @@ import { BuiltInTagKeys, MetricsNamespace, REDSHIFT_MODE } from '../../../src/co
 import { getExistVpc } from '../../../src/common/vpc-utils';
 import { DataAnalyticsRedshiftStack } from '../../../src/data-analytics-redshift-stack';
 import { WIDGETS_ORDER } from '../../../src/metrics/settings';
+import { MOCK_LAMBDA_CODE_S3_BUCKET, MOCK_LAMBDA_CODE_S3_KEY } from '../../cdk-lambda-nodejs-mock';
 import { CFN_FN } from '../../constants';
 import { validateSubnetsRule } from '../../rules';
 import {
@@ -45,6 +46,9 @@ import {
   RefAnyValue,
   RefGetAtt,
 } from '../../utils';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
 
 describe('DataAnalyticsRedshiftStack common parameter test', () => {
   const app = new App();
@@ -884,10 +888,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
     for (const nestedTemplate of allNestedTemplates) {
       nestedTemplate.hasResourceProperties('AWS::Lambda::Function', {
         Code: {
-          S3Bucket: {
-            'Fn::Sub': Match.anyValue(),
-          },
-          S3Key: Match.anyValue(),
+          S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
+          S3Key: MOCK_LAMBDA_CODE_S3_KEY,
         },
         Role: {
           'Fn::GetAtt': [
@@ -925,10 +927,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
     for (const nestedTemplate of allNestedTemplates) {
       nestedTemplate.hasResourceProperties('AWS::Lambda::Function', {
         Code: {
-          S3Bucket: {
-            'Fn::Sub': Match.anyValue(),
-          },
-          S3Key: Match.anyValue(),
+          S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
+          S3Key: MOCK_LAMBDA_CODE_S3_KEY,
         },
         Role: {
           'Fn::GetAtt': [
@@ -1337,10 +1337,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
     for (const nestedTemplate of allNestedTemplates) {
       nestedTemplate.hasResourceProperties('AWS::Lambda::Function', {
         Code: {
-          S3Bucket: {
-            'Fn::Sub': Match.anyValue(),
-          },
-          S3Key: Match.anyValue(),
+          S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
+          S3Key: MOCK_LAMBDA_CODE_S3_KEY,
         },
         Role: {
           'Fn::GetAtt': [
@@ -1480,10 +1478,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
   test('Check LoadODSEventToRedshiftWorkflowLoadManifestToRedshiftFn', () => {
     newServerlessTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: {
-          'Fn::Sub': Match.anyValue(),
-        },
-        S3Key: Match.anyValue(),
+        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
+        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
       },
       Role: {
         'Fn::GetAtt': [
@@ -1539,10 +1535,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
     });
     provisionedTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: {
-          'Fn::Sub': Match.anyValue(),
-        },
-        S3Key: Match.anyValue(),
+        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
+        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
       },
       Role: {
         'Fn::GetAtt': [
@@ -1697,10 +1691,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
   test('Check LoadODSEventToRedshiftWorkflowCheckLoadJobStatusFn', () => {
     newServerlessTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: {
-          'Fn::Sub': Match.anyValue(),
-        },
-        S3Key: Match.anyValue(),
+        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
+        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
       },
       Role: {
         'Fn::GetAtt': [
@@ -1750,10 +1742,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
 
     provisionedTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: {
-          'Fn::Sub': Match.anyValue(),
-        },
-        S3Key: Match.anyValue(),
+        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
+        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
       },
       Role: {
         'Fn::GetAtt': [
@@ -2155,10 +2145,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
   test('Check ClearExpiredEventsWorkflowClearExpiredEventsFn', () => {
     newServerlessTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: {
-          'Fn::Sub': Match.anyValue(),
-        },
-        S3Key: Match.anyValue(),
+        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
+        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
       },
       Role: {
         'Fn::GetAtt': [
@@ -2206,10 +2194,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
 
     provisionedTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: {
-          'Fn::Sub': Match.anyValue(),
-        },
-        S3Key: Match.anyValue(),
+        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
+        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
       },
       Role: {
         'Fn::GetAtt': [
@@ -2311,10 +2297,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
   test('Check ClearExpiredEventsWorkflowCheckClearJobStatusFn', () => {
     newServerlessTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: {
-          'Fn::Sub': Match.anyValue(),
-        },
-        S3Key: Match.anyValue(),
+        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
+        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
       },
       Role: {
         'Fn::GetAtt': [
@@ -2362,10 +2346,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
 
     provisionedTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: {
-          'Fn::Sub': Match.anyValue(),
-        },
-        S3Key: Match.anyValue(),
+        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
+        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
       },
       Role: {
         'Fn::GetAtt': [
@@ -2511,10 +2493,8 @@ describe('DataAnalyticsRedshiftStack serverless custom resource test', () => {
     const nestedTemplate = Template.fromStack(stack.nestedStacks.redshiftServerlessStack);
     nestedTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: {
-          'Fn::Sub': Match.anyValue(),
-        },
-        S3Key: Match.anyValue(),
+        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
+        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
       },
       Role: {
         'Fn::GetAtt': [

--- a/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
+++ b/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
@@ -34,7 +34,6 @@ import { BuiltInTagKeys, MetricsNamespace, REDSHIFT_MODE } from '../../../src/co
 import { getExistVpc } from '../../../src/common/vpc-utils';
 import { DataAnalyticsRedshiftStack } from '../../../src/data-analytics-redshift-stack';
 import { WIDGETS_ORDER } from '../../../src/metrics/settings';
-import { MOCK_LAMBDA_CODE_S3_BUCKET, MOCK_LAMBDA_CODE_S3_KEY } from '../../cdk-lambda-nodejs-mock';
 import { CFN_FN } from '../../constants';
 import { validateSubnetsRule } from '../../rules';
 import {
@@ -47,8 +46,10 @@ import {
   RefGetAtt,
 } from '../../utils';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+if (process.env.CI !== 'true') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+}
 
 describe('DataAnalyticsRedshiftStack common parameter test', () => {
   const app = new App();
@@ -888,7 +889,7 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
     for (const nestedTemplate of allNestedTemplates) {
       nestedTemplate.hasResourceProperties('AWS::Lambda::Function', {
         Code: {
-          S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
+          S3Bucket: Match.anyValue(),
           S3Key: MOCK_LAMBDA_CODE_S3_KEY,
         },
         Role: {
@@ -927,8 +928,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
     for (const nestedTemplate of allNestedTemplates) {
       nestedTemplate.hasResourceProperties('AWS::Lambda::Function', {
         Code: {
-          S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
-          S3Key: MOCK_LAMBDA_CODE_S3_KEY,
+          S3Bucket: Match.anyValue(),
+          S3Key: Match.anyValue(),
         },
         Role: {
           'Fn::GetAtt': [
@@ -1337,8 +1338,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
     for (const nestedTemplate of allNestedTemplates) {
       nestedTemplate.hasResourceProperties('AWS::Lambda::Function', {
         Code: {
-          S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
-          S3Key: MOCK_LAMBDA_CODE_S3_KEY,
+          S3Bucket: Match.anyValue(),
+          S3Key: Match.anyValue(),
         },
         Role: {
           'Fn::GetAtt': [
@@ -1478,8 +1479,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
   test('Check LoadODSEventToRedshiftWorkflowLoadManifestToRedshiftFn', () => {
     newServerlessTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
-        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
+        S3Bucket: Match.anyValue(),
+        S3Key: Match.anyValue(),
       },
       Role: {
         'Fn::GetAtt': [
@@ -1535,8 +1536,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
     });
     provisionedTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
-        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
+        S3Bucket: Match.anyValue(),
+        S3Key: Match.anyValue(),
       },
       Role: {
         'Fn::GetAtt': [
@@ -1691,8 +1692,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
   test('Check LoadODSEventToRedshiftWorkflowCheckLoadJobStatusFn', () => {
     newServerlessTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
-        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
+        S3Bucket: Match.anyValue(),
+        S3Key: Match.anyValue(),
       },
       Role: {
         'Fn::GetAtt': [
@@ -1742,8 +1743,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
 
     provisionedTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
-        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
+        S3Bucket: Match.anyValue(),
+        S3Key: Match.anyValue(),
       },
       Role: {
         'Fn::GetAtt': [
@@ -2145,8 +2146,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
   test('Check ClearExpiredEventsWorkflowClearExpiredEventsFn', () => {
     newServerlessTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
-        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
+        S3Bucket: Match.anyValue(),
+        S3Key: Match.anyValue(),
       },
       Role: {
         'Fn::GetAtt': [
@@ -2194,8 +2195,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
 
     provisionedTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
-        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
+        S3Bucket: Match.anyValue(),
+        S3Key: Match.anyValue(),
       },
       Role: {
         'Fn::GetAtt': [
@@ -2297,8 +2298,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
   test('Check ClearExpiredEventsWorkflowCheckClearJobStatusFn', () => {
     newServerlessTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
-        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
+        S3Bucket: Match.anyValue(),
+        S3Key: Match.anyValue(),
       },
       Role: {
         'Fn::GetAtt': [
@@ -2346,8 +2347,8 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
 
     provisionedTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
-        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
+        S3Bucket: Match.anyValue(),
+        S3Key: Match.anyValue(),
       },
       Role: {
         'Fn::GetAtt': [
@@ -2493,8 +2494,8 @@ describe('DataAnalyticsRedshiftStack serverless custom resource test', () => {
     const nestedTemplate = Template.fromStack(stack.nestedStacks.redshiftServerlessStack);
     nestedTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
-        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
+        S3Bucket: Match.anyValue(),
+        S3Key: Match.anyValue(),
       },
       Role: {
         'Fn::GetAtt': [

--- a/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
+++ b/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
@@ -890,7 +890,7 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
       nestedTemplate.hasResourceProperties('AWS::Lambda::Function', {
         Code: {
           S3Bucket: Match.anyValue(),
-          S3Key: MOCK_LAMBDA_CODE_S3_KEY,
+          S3Key: Match.anyValue(),
         },
         Role: {
           'Fn::GetAtt': [

--- a/test/analytics/modeling-on-athena/data-modeliing-athena-stack.test.ts
+++ b/test/analytics/modeling-on-athena/data-modeliing-athena-stack.test.ts
@@ -15,8 +15,10 @@ import { App } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { DataModelingAthenaStack } from '../../../src/data-modeling-athena-stack';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+if (process.env.CI !== 'true') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+}
 
 describe('Athena built-in query test', () => {
   const app = new App();

--- a/test/analytics/modeling-on-athena/data-modeliing-athena-stack.test.ts
+++ b/test/analytics/modeling-on-athena/data-modeliing-athena-stack.test.ts
@@ -15,6 +15,9 @@ import { App } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { DataModelingAthenaStack } from '../../../src/data-modeling-athena-stack';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+
 describe('Athena built-in query test', () => {
   const app = new App();
   const stack = new DataModelingAthenaStack(app, 'testAthenaStack', {});

--- a/test/cdk-lambda-nodejs-mock.ts
+++ b/test/cdk-lambda-nodejs-mock.ts
@@ -35,7 +35,6 @@ export class NodejsFunction extends Function {
       `arn:aws:s3:::${MOCK_LAMBDA_CODE_S3_BUCKET}`,
     );
 
-    // https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-lambda-nodejs/lib/function.ts#L116C16-L116C79
     const handler = props.handler ?? 'handler';
     // Create a Lambda Function without the real code generated using Parcel/Docker
     super(scope, id, {
@@ -43,6 +42,7 @@ export class NodejsFunction extends Function {
       ...props,
       // Required values if not set for LambdaFunction
       runtime: props.runtime ?? Runtime.NODEJS_18_X,
+      // https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-lambda-nodejs/lib/function.ts#L116C16-L116C79
       handler: handler.indexOf('.') !== -1 ? `${handler}` : `index.${handler}`,
       // Set code with mock s3 location
       code: Code.fromBucket(bucket, MOCK_LAMBDA_CODE_S3_KEY),

--- a/test/cdk-lambda-nodejs-mock.ts
+++ b/test/cdk-lambda-nodejs-mock.ts
@@ -1,0 +1,56 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+import { Function, Runtime, Code } from 'aws-cdk-lib/aws-lambda';
+import { NodejsFunctionProps } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { Construct } from 'constructs';
+
+
+export const MOCK_LAMBDA_CODE_S3_BUCKET = 'example-bucket';
+export const MOCK_LAMBDA_CODE_S3_KEY = 'mock-index.ts';
+
+/**
+ * NodejsFunction Mock
+ *
+ * Running NodejsFunction for CDK tests is extremely slow, as it requires Parcel Bundler to run inside docker. Instead
+ * we use the Lambda Function class that it is based on, with code from a fake
+ * S3 bucket.
+ */
+export class NodejsFunction extends Function {
+  constructor(scope: Construct, id: string, props: NodejsFunctionProps) {
+    // Mock bucket
+    const bucket = Bucket.fromBucketArn(
+      scope,
+      `${id}MockBucket`,
+      `arn:aws:s3:::${MOCK_LAMBDA_CODE_S3_BUCKET}`,
+    );
+
+    // https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-lambda-nodejs/lib/function.ts#L116C16-L116C79
+    const handler = props.handler ?? 'handler';
+    // Create a Lambda Function without the real code generated using Parcel/Docker
+    super(scope, id, {
+      // Use other props
+      ...props,
+      // Required values if not set for LambdaFunction
+      runtime: props.runtime ?? Runtime.NODEJS_18_X,
+      handler: handler.indexOf('.') !== -1 ? `${handler}` : `index.${handler}`,
+      // Set code with mock s3 location
+      code: Code.fromBucket(bucket, MOCK_LAMBDA_CODE_S3_KEY),
+      environment: {
+        ...props.environment,
+        AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
+      },
+
+    });
+  }
+}

--- a/test/control-plane/alb-control-plane-stack.test.ts
+++ b/test/control-plane/alb-control-plane-stack.test.ts
@@ -22,8 +22,10 @@ import { SOLUTION_CONFIG_PATH } from '../../src/control-plane/private/solution-c
 import { TestApp, removeFolder } from '../common/jest';
 import { validateSubnetsRule } from '../rules';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+if (process.env.CI !== 'true') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+}
 
 function getParameter(template: Template, param: string) {
   return template.toJSON().Parameters[param];

--- a/test/control-plane/alb-control-plane-stack.test.ts
+++ b/test/control-plane/alb-control-plane-stack.test.ts
@@ -22,6 +22,9 @@ import { SOLUTION_CONFIG_PATH } from '../../src/control-plane/private/solution-c
 import { TestApp, removeFolder } from '../common/jest';
 import { validateSubnetsRule } from '../rules';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+
 function getParameter(template: Template, param: string) {
   return template.toJSON().Parameters[param];
 }

--- a/test/control-plane/alb-lambda-portal.test.ts
+++ b/test/control-plane/alb-lambda-portal.test.ts
@@ -26,8 +26,10 @@ import { TestEnv, TestStack, findResourcesName, findResources } from './test-uti
 import { Constant } from '../../src/control-plane/private/constant';
 import { TestApp, removeFolder } from '../common/jest';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+if (process.env.CI !== 'true') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+}
 
 describe('ApplicationLoadBalancerLambdaPortal', () => {
 

--- a/test/control-plane/alb-lambda-portal.test.ts
+++ b/test/control-plane/alb-lambda-portal.test.ts
@@ -26,6 +26,9 @@ import { TestEnv, TestStack, findResourcesName, findResources } from './test-uti
 import { Constant } from '../../src/control-plane/private/constant';
 import { TestApp, removeFolder } from '../common/jest';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+
 describe('ApplicationLoadBalancerLambdaPortal', () => {
 
   afterAll(() => {

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -16,8 +16,10 @@ import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { findResourcesName, TestEnv } from './test-utils';
 import { removeFolder } from '../common/jest';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+if (process.env.CI !== 'true') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+}
 
 describe('Click Stream Api ALB deploy Construct Test', () => {
   afterAll(() => {

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -16,6 +16,9 @@ import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { findResourcesName, TestEnv } from './test-utils';
 import { removeFolder } from '../common/jest';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+
 describe('Click Stream Api ALB deploy Construct Test', () => {
   afterAll(() => {
     removeFolder(cdkOut);

--- a/test/control-plane/cloudfront-control-plane-stack.test.ts
+++ b/test/control-plane/cloudfront-control-plane-stack.test.ts
@@ -15,9 +15,13 @@ import { OUTPUT_CONTROL_PLANE_URL, OUTPUT_CONTROL_PLANE_BUCKET } from '@aws/clic
 import { Capture, Match, Template } from 'aws-cdk-lib/assertions';
 import { findResourcesName } from './test-utils';
 import { CloudFrontControlPlaneStack } from '../../src/cloudfront-control-plane-stack';
+import { MOCK_LAMBDA_CODE_S3_BUCKET, MOCK_LAMBDA_CODE_S3_KEY } from '../cdk-lambda-nodejs-mock';
 import { TestApp, removeFolder } from '../common/jest';
 import { CFN_FN } from '../constants';
 import { findFirstResourceByKeyPrefix } from '../utils';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
 
 describe('CloudFrontS3PortalStack - Default stack props for common features', () => {
 
@@ -260,10 +264,8 @@ describe('CloudFrontS3PortalStack - Default stack props for common features', ()
   test('Function for user authentication', () => {
     commonTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: {
-          'Fn::Sub': Match.anyValue(),
-        },
-        S3Key: Match.anyValue(),
+        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
+        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
       },
       Role: {
         'Fn::GetAtt': [
@@ -273,6 +275,10 @@ describe('CloudFrontS3PortalStack - Default stack props for common features', ()
       },
       Environment: {
         Variables: {
+          POWERTOOLS_SERVICE_NAME: 'ClickStreamAnalyticsOnAWS',
+          POWERTOOLS_LOGGER_SAMPLE_RATE: '1',
+          POWERTOOLS_LOGGER_LOG_EVENT: 'true',
+          LOG_LEVEL: 'WARN',
           ISSUER: {
             'Fn::Join': [
               '',
@@ -534,10 +540,8 @@ describe('CloudFrontS3PortalStack - Default stack props for common features', ()
 
     commonTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: {
-          'Fn::Sub': Match.anyValue(),
-        },
-        S3Key: Match.anyValue(),
+        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
+        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
       },
       Role: {
         'Fn::GetAtt': [
@@ -547,6 +551,10 @@ describe('CloudFrontS3PortalStack - Default stack props for common features', ()
       },
       Environment: {
         Variables: {
+          POWERTOOLS_SERVICE_NAME: 'ClickStreamAnalyticsOnAWS',
+          POWERTOOLS_LOGGER_SAMPLE_RATE: '1',
+          POWERTOOLS_LOGGER_LOG_EVENT: 'true',
+          LOG_LEVEL: 'WARN',
           ISSUER: {
             'Fn::Join': [
               '',
@@ -893,10 +901,8 @@ describe('CloudFrontS3PortalStack - China region', () => {
 
     template.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: {
-          'Fn::Sub': Match.anyValue(),
-        },
-        S3Key: Match.anyValue(),
+        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
+        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
       },
       Role: {
         'Fn::GetAtt': [

--- a/test/control-plane/cloudfront-control-plane-stack.test.ts
+++ b/test/control-plane/cloudfront-control-plane-stack.test.ts
@@ -15,13 +15,14 @@ import { OUTPUT_CONTROL_PLANE_URL, OUTPUT_CONTROL_PLANE_BUCKET } from '@aws/clic
 import { Capture, Match, Template } from 'aws-cdk-lib/assertions';
 import { findResourcesName } from './test-utils';
 import { CloudFrontControlPlaneStack } from '../../src/cloudfront-control-plane-stack';
-import { MOCK_LAMBDA_CODE_S3_BUCKET, MOCK_LAMBDA_CODE_S3_KEY } from '../cdk-lambda-nodejs-mock';
 import { TestApp, removeFolder } from '../common/jest';
 import { CFN_FN } from '../constants';
 import { findFirstResourceByKeyPrefix } from '../utils';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+if (process.env.CI !== 'true') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+}
 
 describe('CloudFrontS3PortalStack - Default stack props for common features', () => {
 
@@ -264,8 +265,8 @@ describe('CloudFrontS3PortalStack - Default stack props for common features', ()
   test('Function for user authentication', () => {
     commonTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
-        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
+        S3Bucket: Match.anyValue(),
+        S3Key: Match.anyValue(),
       },
       Role: {
         'Fn::GetAtt': [
@@ -540,8 +541,8 @@ describe('CloudFrontS3PortalStack - Default stack props for common features', ()
 
     commonTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
-        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
+        S3Bucket: Match.anyValue(),
+        S3Key: Match.anyValue(),
       },
       Role: {
         'Fn::GetAtt': [
@@ -901,8 +902,8 @@ describe('CloudFrontS3PortalStack - China region', () => {
 
     template.hasResourceProperties('AWS::Lambda::Function', {
       Code: {
-        S3Bucket: MOCK_LAMBDA_CODE_S3_BUCKET,
-        S3Key: MOCK_LAMBDA_CODE_S3_KEY,
+        S3Bucket: Match.anyValue(),
+        S3Key: Match.anyValue(),
       },
       Role: {
         'Fn::GetAtt': [

--- a/test/control-plane/cloudfront-s3-portal.test.ts
+++ b/test/control-plane/cloudfront-s3-portal.test.ts
@@ -31,6 +31,9 @@ import { CloudFrontS3Portal } from '../../src/control-plane/cloudfront-s3-portal
 import { Constant } from '../../src/control-plane/private/constant';
 import { TestApp, removeFolder } from '../common/jest';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+
 const cdkOut = '/tmp/cloudfront-s3-portal-test';
 const commonApp = new TestApp(cdkOut);
 const frontendProps = {

--- a/test/control-plane/cloudfront-s3-portal.test.ts
+++ b/test/control-plane/cloudfront-s3-portal.test.ts
@@ -42,7 +42,8 @@ const frontendProps = {
   assetPath: 'frontend',
   dockerImage: DockerImage.fromRegistry(Constant.NODE_IMAGE_V18),
   buildCommands: [
-    'echo test > /asset-output/test',
+    'echo index > /asset-output/index.html',
+    'echo test > /asset-output/test.json',
   ],
   autoInvalidFilePaths: ['/index.html'],
 };

--- a/test/control-plane/cloudfront-s3-portal.test.ts
+++ b/test/control-plane/cloudfront-s3-portal.test.ts
@@ -31,8 +31,10 @@ import { CloudFrontS3Portal } from '../../src/control-plane/cloudfront-s3-portal
 import { Constant } from '../../src/control-plane/private/constant';
 import { TestApp, removeFolder } from '../common/jest';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+if (process.env.CI !== 'true') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+}
 
 const cdkOut = '/tmp/cloudfront-s3-portal-test';
 const commonApp = new TestApp(cdkOut);

--- a/test/data-pipeline/data-pipeline-stack.test.ts
+++ b/test/data-pipeline/data-pipeline-stack.test.ts
@@ -19,6 +19,9 @@ import { WIDGETS_ORDER } from '../../src/metrics/settings';
 import { validateSubnetsRule } from '../rules';
 import { genString, getResourceById } from '../utils';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+
 const c63Str = genString(63);
 const c64Str = genString(64);
 const c127Str = genString(127);

--- a/test/data-pipeline/data-pipeline-stack.test.ts
+++ b/test/data-pipeline/data-pipeline-stack.test.ts
@@ -19,8 +19,10 @@ import { WIDGETS_ORDER } from '../../src/metrics/settings';
 import { validateSubnetsRule } from '../rules';
 import { genString, getResourceById } from '../utils';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+if (process.env.CI !== 'true') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+}
 
 const c63Str = genString(63);
 const c64Str = genString(64);

--- a/test/ingestion-server/server/ingestion-server-stack.test.ts
+++ b/test/ingestion-server/server/ingestion-server-stack.test.ts
@@ -17,8 +17,10 @@ import { WIDGETS_ORDER } from '../../../src/metrics/settings';
 import { validateSubnetsRule } from '../../rules';
 import { findResourceByCondition, getParameter, getParameterNamesFromParameterObject } from '../../utils';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+if (process.env.CI !== 'true') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+}
 
 const app = new App();
 

--- a/test/ingestion-server/server/ingestion-server-stack.test.ts
+++ b/test/ingestion-server/server/ingestion-server-stack.test.ts
@@ -17,6 +17,9 @@ import { WIDGETS_ORDER } from '../../../src/metrics/settings';
 import { validateSubnetsRule } from '../../rules';
 import { findResourceByCondition, getParameter, getParameterNamesFromParameterObject } from '../../utils';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+
 const app = new App();
 
 const kafkaStack = new IngestionServerStack(app, 'test-kafka-stack', {

--- a/test/ingestion-server/server/ingestion-server-v2-stack.test.ts
+++ b/test/ingestion-server/server/ingestion-server-v2-stack.test.ts
@@ -17,6 +17,9 @@ import { WIDGETS_ORDER } from '../../../src/metrics/settings';
 import { validateSubnetsRule } from '../../rules';
 import { findResourceByCondition, getParameter, getParameterNamesFromParameterObject } from '../../utils';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+
 const app = new App();
 
 const v2Stack = new IngestionServerStackV2(app, 'test-v2-stack', {});

--- a/test/ingestion-server/server/ingestion-server-v2-stack.test.ts
+++ b/test/ingestion-server/server/ingestion-server-v2-stack.test.ts
@@ -17,8 +17,10 @@ import { WIDGETS_ORDER } from '../../../src/metrics/settings';
 import { validateSubnetsRule } from '../../rules';
 import { findResourceByCondition, getParameter, getParameterNamesFromParameterObject } from '../../utils';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+if (process.env.CI !== 'true') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+}
 
 const app = new App();
 

--- a/test/ingestion-server/server/ingestion-server-v2.test.ts
+++ b/test/ingestion-server/server/ingestion-server-v2.test.ts
@@ -18,6 +18,9 @@ import { TestStack, TestStackProps } from './TestTask-v2';
 import { WIDGETS_ORDER } from '../../../src/metrics/settings';
 import { findConditionByName, findFirstResource, findResources } from '../../utils';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+
 function generateCommonTestStackProps() {
   const commonTestStackProps: TestStackProps = {
     withMskConfig: false,

--- a/test/ingestion-server/server/ingestion-server-v2.test.ts
+++ b/test/ingestion-server/server/ingestion-server-v2.test.ts
@@ -18,8 +18,10 @@ import { TestStack, TestStackProps } from './TestTask-v2';
 import { WIDGETS_ORDER } from '../../../src/metrics/settings';
 import { findConditionByName, findFirstResource, findResources } from '../../utils';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+if (process.env.CI !== 'true') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+}
 
 function generateCommonTestStackProps() {
   const commonTestStackProps: TestStackProps = {

--- a/test/ingestion-server/server/ingestion-server.test.ts
+++ b/test/ingestion-server/server/ingestion-server.test.ts
@@ -19,8 +19,10 @@ import { TestStack } from './TestTask';
 import { WIDGETS_ORDER } from '../../../src/metrics/settings';
 import { findConditionByName, findFirstResource, findResources } from '../../utils';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+if (process.env.CI !== 'true') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+}
 
 test('Has one autoscaling group', () => {
   const app = new App();

--- a/test/ingestion-server/server/ingestion-server.test.ts
+++ b/test/ingestion-server/server/ingestion-server.test.ts
@@ -19,6 +19,9 @@ import { TestStack } from './TestTask';
 import { WIDGETS_ORDER } from '../../../src/metrics/settings';
 import { findConditionByName, findFirstResource, findResources } from '../../utils';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+
 test('Has one autoscaling group', () => {
   const app = new App();
   const stack = new TestStack(app, 'test', {

--- a/test/jestEnv.js
+++ b/test/jestEnv.js
@@ -36,7 +36,7 @@ process.env.TEMPLATE_FILE = 'cloudfront-s3-control-plane-stack-global.template.j
 process.env.SOLUTION_VERSION = 'v1.1.5-202403071513'
 
 // web console bundling
-process.env.IS_SKIP_ASSET_BUNDLE = 'true'
+process.env.CI = 'true'
 
 // env variables for analytics stack
 process.env.PROJECT_ID='project1'

--- a/test/jestEnv.js
+++ b/test/jestEnv.js
@@ -35,9 +35,6 @@ process.env.IAM_ROLE_BOUNDARY_ARN = ''
 process.env.TEMPLATE_FILE = 'cloudfront-s3-control-plane-stack-global.template.json'
 process.env.SOLUTION_VERSION = 'v1.1.5-202403071513'
 
-// web console bundling
-process.env.CI = 'true'
-
 // env variables for analytics stack
 process.env.PROJECT_ID='project1'
 process.env.DYNAMODB_TABLE_NAME='project1_ods_events_trigger'

--- a/test/metrics/metrics-stack.test.ts
+++ b/test/metrics/metrics-stack.test.ts
@@ -17,8 +17,10 @@ import { Match, Template } from 'aws-cdk-lib/assertions';
 import { PARAMETERS_DESCRIPTION } from '../../src/metrics/settings';
 import { MetricsStack } from '../../src/metrics-stack';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+if (process.env.CI !== 'true') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+}
 
 const app = new App();
 const stack = new MetricsStack(app, 'test-stack');

--- a/test/metrics/metrics-stack.test.ts
+++ b/test/metrics/metrics-stack.test.ts
@@ -17,6 +17,9 @@ import { Match, Template } from 'aws-cdk-lib/assertions';
 import { PARAMETERS_DESCRIPTION } from '../../src/metrics/settings';
 import { MetricsStack } from '../../src/metrics-stack';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+
 const app = new App();
 const stack = new MetricsStack(app, 'test-stack');
 const template = Template.fromStack(stack);

--- a/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
+++ b/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
@@ -16,8 +16,10 @@ import { App } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { DataReportingQuickSightStack } from '../../../src/data-reporting-quicksight-stack';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+if (process.env.CI !== 'true') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+}
 
 describe('DataReportingQuickSightStack parameter test', () => {
   const app = new App();

--- a/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
+++ b/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
@@ -16,6 +16,9 @@ import { App } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { DataReportingQuickSightStack } from '../../../src/data-reporting-quicksight-stack';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../../cdk-lambda-nodejs-mock'));
+
 describe('DataReportingQuickSightStack parameter test', () => {
   const app = new App();
   const testId = 'test-1';

--- a/test/service-catalog-appregistry/service-catalog-appregistry-stack.test.ts
+++ b/test/service-catalog-appregistry/service-catalog-appregistry-stack.test.ts
@@ -16,6 +16,9 @@ import { App } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { ServiceCatalogAppregistryStack } from '../../src/service-catalog-appregistry-stack';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+
 const app = new App();
 const stack = new ServiceCatalogAppregistryStack(app, 'test-service-catalog-appregistry-stack');
 const template = Template.fromStack(stack);

--- a/test/service-catalog-appregistry/service-catalog-appregistry-stack.test.ts
+++ b/test/service-catalog-appregistry/service-catalog-appregistry-stack.test.ts
@@ -16,8 +16,10 @@ import { App } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { ServiceCatalogAppregistryStack } from '../../src/service-catalog-appregistry-stack';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+if (process.env.CI !== 'true') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+}
 
 const app = new App();
 const stack = new ServiceCatalogAppregistryStack(app, 'test-service-catalog-appregistry-stack');

--- a/test/streaming-ingestion/streaming-ingestion-stack.test.ts
+++ b/test/streaming-ingestion/streaming-ingestion-stack.test.ts
@@ -20,6 +20,9 @@ import { StreamingIngestionStack } from '../../src/streaming-ingestion-stack';
 import { CFN_FN } from '../constants';
 import { RefAnyValue, findConditionByName, findFirstResourceByKeyPrefix } from '../utils';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+
 const app = new App();
 const testId = 'test-stack';
 const stack = new StreamingIngestionStack(app, testId+'-StreamingIngestionStack', {});

--- a/test/streaming-ingestion/streaming-ingestion-stack.test.ts
+++ b/test/streaming-ingestion/streaming-ingestion-stack.test.ts
@@ -20,8 +20,10 @@ import { StreamingIngestionStack } from '../../src/streaming-ingestion-stack';
 import { CFN_FN } from '../constants';
 import { RefAnyValue, findConditionByName, findFirstResourceByKeyPrefix } from '../utils';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+if (process.env.CI !== 'true') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  jest.mock('aws-cdk-lib/aws-lambda-nodejs', () => require('../cdk-lambda-nodejs-mock'));
+}
 
 const app = new App();
 const testId = 'test-stack';


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Skip all assets build in local test environments:
- **BucketDeployment** asset build
- **NodejsFunction** code build
- **Backend** api docker build

**Local testing time(`pnpm test`): 1070s --> 180s**

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend