### PR TITLE
fix: limit sql to less than 100K

### DIFF
--- a/src/analytics/private/sqls/redshift/fn-parse-utm-from-url.sql
+++ b/src/analytics/private/sqls/redshift/fn-parse-utm-from-url.sql
@@ -174,2311 +174,2311 @@ def parse_utm_from_url(page_url, referrer, latest_referrer):
     get_umt_from_url(page_url, "page_url")
 
     referrer_url_source_category_list = [
-    {
-        "url": "lang-8.com",
-        "source": "lang-8",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "43things.com",
-        "source": "43things",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "hatena.com",
-        "source": "Hatena",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "activerain.com",
-        "source": "activerain",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "linkedin.com",
-        "source": "linkedin",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "51.com",
-        "source": "51",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "activeworlds.com",
-        "source": "activeworlds",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "avg.com",
-        "source": "avg",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "alibaba.com",
-        "source": "alibaba",
-        "category": "Shopping",
-        "params": []
-    },
-    {
-        "url": "babylon.com",
-        "source": "babylon",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "bebo.com",
-        "source": "Bebo",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "searchya.com",
-        "source": "InfoSpace",
-        "category": "Search",
-        "params": [
+        {
+          "category": "Search",
+          "params": [
+            "search_term"
+          ],
+          "source": "123people",
+          "url": "123people.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "43things",
+          "url": "43things.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "51",
+          "url": "51.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "q"
-        ]
-    },
-    {
-        "url": "imageshack.com",
-        "source": "imageshack",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "addthis.com",
-        "source": "addthis",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "igshopping.com",
-        "source": "IGShopping",
-        "category": "Shopping",
-        "params": []
-    },
-    {
-        "url": "livejournal.com",
-        "source": "livejournal",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "blogspot.com",
-        "source": "blogspot",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "cellufun.com",
-        "source": "cellufun",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "doostang.com",
-        "source": "doostang",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "alumniclass.com",
-        "source": "alumniclass",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "artstation.com",
-        "source": "artstation",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "askubuntu.com",
-        "source": "askubuntu",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "americantowns.com",
-        "source": "americantowns",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "anobii.com",
-        "source": "anobii",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "daemon-search.com",
-        "source": "Daemon search",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "Alexa",
+          "url": "alexa.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "q"
-        ]
-    },
-    {
-        "url": "multiply.com",
-        "source": "Multiply",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "myheritage.com",
-        "source": "myheritage",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "myspace.com",
-        "source": "myspace",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "myyearbook.com",
-        "source": "myYearbook",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "ixquick.com",
-        "source": "IxQuick",
-        "category": "Search",
-        "params": [
-            "query"
-        ]
-    },
-    {
-        "url": "ask.com",
-        "source": "Ask",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "AlohaFind",
+          "url": "alohafind.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "q"
+          ],
+          "source": "AltaVista",
+          "url": "altavista.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "q"
+          ],
+          "source": "Arama",
+          "url": "arama.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "ask",
             "q",
             "searchfor"
-        ]
-    },
-    {
-        "url": "bing.com",
-        "source": "Bing",
-        "category": "Search",
-        "params": [
-            "q"
-        ]
-    },
-    {
-        "url": "blackcareernetwork.com",
-        "source": "blackcareernetwork",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "blackplanet.com",
-        "source": "blackplanet",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "blogster.com",
-        "source": "blogster",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "google.com",
-        "source": "google",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "etsy.com",
-        "source": "etsy",
-        "category": "Shopping",
-        "params": []
-    },
-    {
-        "url": "excite.com",
-        "source": "excite",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "feedspot.com",
-        "source": "feedspot",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "filmaffinity.com",
-        "source": "filmaffinity",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "flipboard.com",
-        "source": "flipboard",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "foursquare.com",
-        "source": "Foursquare",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "getpocket.com",
-        "source": "getpocket",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "goodreads.com",
-        "source": "goodreads",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "incredimail.com",
-        "source": "incredimail",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "intherooms.com",
-        "source": "intherooms",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "digg.com",
-        "source": "digg",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "netlog.com",
-        "source": "Netlog",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "orkut.com",
-        "source": "Orkut",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "peepeth.com",
-        "source": "Peepeth",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "pinterest.com",
-        "source": "pinterest",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "plaxo.com",
-        "source": "Plaxo",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "reddit.com",
-        "source": "reddit",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "renren.com",
-        "source": "renren",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "skyrock.com",
-        "source": "skyrock",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "snapchat.com",
-        "source": "snapchat",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "sonico.com",
-        "source": "Sonico.com",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "stackoverflow.com",
-        "source": "stackoverflow",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "wwwgoogle.com",
-        "source": "Google",
-        "category": "Search",
-        "params": [
-            "q"
-        ]
-    },
-    {
-        "url": "gogole.com",
-        "source": "Google",
-        "category": "Search",
-        "params": [
-            "q"
-        ]
-    },
-    {
-        "url": "gppgle.com",
-        "source": "Google",
-        "category": "Search",
-        "params": [
-            "q"
-        ]
-    },
-    {
-        "url": "ancestry.com",
-        "source": "ancestry",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "baby-gaga.com",
-        "source": "baby-gaga",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "badoo.com",
-        "source": "Badoo",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "baidu.com",
-        "source": "Baidu",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "Ask",
+          "url": "ask.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "ask",
+            "q",
+            "searchfor"
+          ],
+          "source": "Ask",
+          "url": "qbyrd.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "ask",
+            "q",
+            "searchfor"
+          ],
+          "source": "Ask",
+          "url": "searchqu.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Badoo",
+          "url": "badoo.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "kw",
             "wd",
             "word"
-        ]
-    },
-    {
-        "url": "disqus.com",
-        "source": "disqus",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "dogster.com",
-        "source": "dogster",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "elftown.com",
-        "source": "elftown",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "fark.com",
-        "source": "fark",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "foodservice.com",
-        "source": "foodservice",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "geni.com",
-        "source": "geni",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "glassdoor.com",
-        "source": "glassdoor",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "globo.com",
-        "source": "globo",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "gowalla.com",
-        "source": "gowalla",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "kakaocorp.com",
-        "source": "kakaocorp",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "listal.com",
-        "source": "listal",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "junglekey.com",
-        "source": "Jungle Key",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "Baidu",
+          "url": "baidu.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Bebo",
+          "url": "bebo.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "q"
+          ],
+          "source": "Bing",
+          "url": "bing.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Buzznet",
+          "url": "buzznet.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "q"
+          ],
+          "source": "Claro Search",
+          "url": "claro-search.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Classmates.com",
+          "url": "classmates.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "query"
-        ]
-    },
-    {
-        "url": "k9safesearch.com",
-        "source": "K9 Safe Search",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "C\u1ed1c C\u1ed1c",
+          "url": "coccoc.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "q"
-        ]
-    },
-    {
-        "url": "lycos.com",
-        "source": "lycos",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "bloggang.com",
-        "source": "bloggang",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "blogher.com",
-        "source": "blogher",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "buzzfeed.com",
-        "source": "buzzfeed",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "camospace.com",
-        "source": "camospace",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "classquest.com",
-        "source": "classquest",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "conduit.com",
-        "source": "conduit",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "allrecipes.com",
-        "source": "allrecipes",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "duckduckgo.com",
-        "source": "duckduckgo",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "crunchyroll.com",
-        "source": "crunchyroll",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "fubar.com",
-        "source": "fubar",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "google-play.com",
-        "source": "google-play",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "googlegroups.com",
-        "source": "googlegroups",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "hubculture.com",
-        "source": "hubculture",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "aolanswers.com",
-        "source": "aolanswers",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "bharatstudent.com",
-        "source": "bharatstudent",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "bloglines.com",
-        "source": "bloglines",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "amazon.com",
-        "source": "amazon",
-        "category": "Shopping",
-        "params": []
-    },
-    {
-        "url": "answerbag.com",
-        "source": "answerbag",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "plusnetwork.com",
-        "source": "PlusNetwork",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "Daemon search",
+          "url": "daemon-search.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Douban",
+          "url": "douban.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Dribbble",
+          "url": "dribbble.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Facebook",
+          "url": "facebook.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Fetlife",
+          "url": "fetlife.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Flixster",
+          "url": "flixster.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Fotolog",
+          "url": "fotolog.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Foursquare",
+          "url": "foursquare.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Friends Reunited",
+          "url": "friendsreunited.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Friendster",
+          "url": "friendster.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Gaia Online",
+          "url": "gaiaonline.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "q"
-        ]
-    },
-    {
-        "url": "blogsome.com",
-        "source": "blogsome",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "brightkite.com",
-        "source": "brightkite",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "fanpop.com",
-        "source": "fanpop",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "brizzly.com",
-        "source": "brizzly",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "canalblog.com",
-        "source": "canalblog",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "curiositystream.com",
-        "source": "curiositystream",
-        "category": "Video",
-        "params": []
-    },
-    {
-        "url": "dailymotion.com",
-        "source": "dailymotion",
-        "category": "Video",
-        "params": []
-    },
-    {
-        "url": "dianping.com",
-        "source": "dianping",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "douban.com",
-        "source": "Douban",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "feministing.com",
-        "source": "feministing",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "friendfeed.com",
-        "source": "friendfeed",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "imvu.com",
-        "source": "imvu",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "mix.com",
-        "source": "mix",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "ning.com",
-        "source": "ning",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "screenrant.com",
-        "source": "screenrant",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "seznam.com",
-        "source": "seznam",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "shopify.com",
-        "source": "shopify",
-        "category": "Shopping",
-        "params": []
-    },
-    {
-        "url": "shopzilla.com",
-        "source": "shopzilla",
-        "category": "Shopping",
-        "params": []
-    },
-    {
-        "url": "smartnews.com",
-        "source": "smartnews",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "ssense.com",
-        "source": "ssense",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "stackexchange.com",
-        "source": "stackexchange",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "toolbox.com",
-        "source": "toolbox",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "vimeo.com",
-        "source": "vimeo",
-        "category": "Video",
-        "params": []
-    },
-    {
-        "url": "vk.com",
-        "source": "Vkontakte",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "webshots.com",
-        "source": "webshots",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "weibo.com",
-        "source": "Weibo",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "gibiru.com",
-        "source": "Gibiru",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "Gibiru",
+          "url": "gibiru.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "GitHub",
+          "url": "github.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "q"
-        ]
-    },
-    {
-        "url": "weread.com",
-        "source": "weread",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "wistia.com",
-        "source": "wistia",
-        "category": "Video",
-        "params": []
-    },
-    {
-        "url": "zooppa.com",
-        "source": "zooppa",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "blog.com",
-        "source": "blog",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "blogs.com",
-        "source": "blogs",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "buzznet.com",
-        "source": "Buzznet",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "disneyplus.com",
-        "source": "disneyplus",
-        "category": "Video",
-        "params": []
-    },
-    {
-        "url": "dzone.com",
-        "source": "dzone",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "everforo.com",
-        "source": "everforo",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "facebook.com",
-        "source": "Facebook",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "goldstar.com",
-        "source": "goldstar",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "godtube.com",
-        "source": "godtube",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "gulli.com",
-        "source": "gulli",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "hi5.com",
-        "source": "hi5",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "hootsuite.com",
-        "source": "hootsuite",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "ryze.com",
-        "source": "ryze",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "simplycodes.com",
-        "source": "simplycodes",
-        "category": "Shopping",
-        "params": []
-    },
-    {
-        "url": "superuser.com",
-        "source": "superuser",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "tuenti.com",
-        "source": "Tuenti",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "woot.com",
-        "source": "woot",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "yammer.com",
-        "source": "yammer",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "gamerdna.com",
-        "source": "gamerdna",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "hoverspot.com",
-        "source": "hoverspot",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "gooblog.com",
-        "source": "gooblog",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "govloop.com",
-        "source": "govloop",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "ibibo.com",
-        "source": "ibibo",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "ig.com",
-        "source": "ig",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "iq.com",
-        "source": "iq",
-        "category": "Video",
-        "params": []
-    },
-    {
-        "url": "jammerdirect.com",
-        "source": "jammerdirect",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "kaneva.com",
-        "source": "kaneva",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "livedoor.com",
-        "source": "livedoor",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "menuism.com",
-        "source": "menuism",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "librarything.com",
-        "source": "librarything",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "blurtit.com",
-        "source": "blurtit",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "cnn.com",
-        "source": "cnn",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "cocolog-nifty.com",
-        "source": "cocolog-nifty",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "cyworld.com",
-        "source": "cyworld",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "deluxe.com",
-        "source": "deluxe",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "mubi.com",
-        "source": "mubi",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "netvibes.com",
-        "source": "netvibes",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "photobucket.com",
-        "source": "photobucket",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "sharethis.com",
-        "source": "sharethis",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "shvoong.com",
-        "source": "shvoong",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "stickam.com",
-        "source": "stickam",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "stripe.com",
-        "source": "stripe",
-        "category": "Shopping",
-        "params": []
-    },
-    {
-        "url": "ted.com",
-        "source": "ted",
-        "category": "Video",
-        "params": []
-    },
-    {
-        "url": "twitter.com",
-        "source": "twitter",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "ushareit.com",
-        "source": "ushareit",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "veoh.com",
-        "source": "veoh",
-        "category": "Video",
-        "params": []
-    },
-    {
-        "url": "walmart.com",
-        "source": "walmart",
-        "category": "Shopping",
-        "params": []
-    },
-    {
-        "url": "wikihow.com",
-        "source": "wikihow",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "athlinks.com",
-        "source": "athlinks",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "xanga.com",
-        "source": "xanga",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "youku.com",
-        "source": "youku",
-        "category": "Video",
-        "params": []
-    },
-    {
-        "url": "messenger.com",
-        "source": "messenger",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "qapacity.com",
-        "source": "qapacity",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "quechup.com",
-        "source": "quechup",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "quora.com",
-        "source": "quora",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "scvngr.com",
-        "source": "scvngr",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "serverfault.com",
-        "source": "serverfault",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "spoke.com",
-        "source": "spoke",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "stackapps.com",
-        "source": "stackapps",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "tencent.com",
-        "source": "tencent",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "travellerspoint.com",
-        "source": "travellerspoint",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "trombi.com",
-        "source": "trombi",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "urbanspoon.com",
-        "source": "urbanspoon",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "wattpad.com",
-        "source": "wattpad",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "diigo.com",
-        "source": "diigo",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "dogpile.com",
-        "source": "InfoSpace",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "Google",
+          "url": "wwwgoogle.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "q"
-        ]
-    },
-    {
-        "url": "dopplr.com",
-        "source": "dopplr",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "fb.com",
-        "source": "fb",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "houzz.com",
-        "source": "houzz",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "hulu.com",
-        "source": "hulu",
-        "category": "Video",
-        "params": []
-    },
-    {
-        "url": "nightlifelink.com",
-        "source": "nightlifelink",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "overblog.com",
-        "source": "overblog",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "plurk.com",
-        "source": "plurk",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "reverbnation.com",
-        "source": "reverbnation",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "startsiden.com",
-        "source": "startsiden",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "talkbiznow.com",
-        "source": "talkbiznow",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "tripadvisor.com",
-        "source": "tripadvisor",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "trustpilot.com",
-        "source": "trustpilot",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "tudou.com",
-        "source": "tudou",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "scour.com",
-        "source": "Scour.com",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "searchalot.com",
-        "source": "Searchalot",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "Google",
+          "url": "gogole.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "q"
-        ]
-    },
-    {
-        "url": "searchlock.com",
-        "source": "SearchLock",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "Google",
+          "url": "gppgle.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "q"
-        ]
-    },
-    {
-        "url": "setooz.com",
-        "source": "Setooz",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "Google",
+          "url": "googel.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "query"
-        ]
-    },
-    {
-        "url": "blogger.com",
-        "source": "blogger",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "care2.com",
-        "source": "care2",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "classmates.com",
-        "source": "Classmates.com",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "wordpress.com",
-        "source": "wordpress",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "deviantart.com",
-        "source": "deviantart",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "extole.com",
-        "source": "extole",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "faceparty.com",
-        "source": "faceparty",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "flickr.com",
-        "source": "flickr",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "gaiaonline.com",
-        "source": "Gaia Online",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "habbo.com",
-        "source": "Haboo",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "insanejournal.com",
-        "source": "insanejournal",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "mouthshut.com",
-        "source": "mouthshut",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "netflix.com",
-        "source": "netflix",
-        "category": "Video",
-        "params": []
-    },
-    {
-        "url": "pingsta.com",
-        "source": "pingsta",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "redux.com",
-        "source": "redux",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "sweeva.com",
-        "source": "sweeva",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "sogou.com",
-        "source": "sogou",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "kaboodle.com",
-        "source": "kaboodle",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "mercadolibre.com",
-        "source": "mercadolibre",
-        "category": "Shopping",
-        "params": []
-    },
-    {
-        "url": "newsshowcase.com",
-        "source": "newsshowcase",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "onstartups.com",
-        "source": "onstartups",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "reunion.com",
-        "source": "reunion",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "scribd.com",
-        "source": "scribd",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "shareit.com",
-        "source": "shareit",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "spruz.com",
-        "source": "spruz",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "techmeme.com",
-        "source": "techmeme",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "terra.com",
-        "source": "terra",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "tinyurl.com",
-        "source": "tinyurl",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "twitch.com",
-        "source": "twitch",
-        "category": "Video",
-        "params": []
-    },
-    {
-        "url": "typepad.com",
-        "source": "typepad",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "vampirerave.com",
-        "source": "vampirerave",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "virgilio.com",
-        "source": "virgilio",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "tiktok.com",
-        "source": "TikTok",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "xing.com",
-        "source": "XING",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "yahoo.com",
-        "source": "yahoo",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "youtube.com",
-        "source": "youtube",
-        "category": "Video",
-        "params": []
-    },
-    {
-        "url": "kakao.com",
-        "source": "kakao",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "livedoorblog.com",
-        "source": "livedoorblog",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "nexopia.com",
-        "source": "nexopia",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "niconico.com",
-        "source": "niconico",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "ravelry.com",
-        "source": "ravelry",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "tagged.com",
-        "source": "tagged",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "twoo.com",
-        "source": "twoo",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "utreon.com",
-        "source": "utreon",
-        "category": "Video",
-        "params": []
-    },
-    {
-        "url": "mymodernmet.com",
-        "source": "mymodernmet",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "over-blog.com",
-        "source": "over-blog",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "so.com",
-        "source": "so",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "taggedmail.com",
-        "source": "taggedmail",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "ukr.com",
-        "source": "ukr",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "weebly.com",
-        "source": "weebly",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "tumblr.com",
-        "source": "tumblr",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "stumbleupon.com",
-        "source": "StumbleUpon",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "v2ex.com",
-        "source": "V2EX",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "viadeo.com",
-        "source": "Viadeo",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "wayn.com",
-        "source": "WAYN",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "weeworld.com",
-        "source": "WeeWorld",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "workplace.com",
-        "source": "Workplace",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "googel.com",
-        "source": "Google",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "Google",
+          "url": "darkoogle.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "q"
-        ]
-    },
-    {
-        "url": "darkoogle.com",
-        "source": "Google",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "Google",
+          "url": "wow.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "q"
+          ],
+          "source": "Google",
+          "url": "gfsoso.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "q"
+          ],
+          "source": "Google",
+          "url": "monumentbrowser.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "q"
+          ],
+          "source": "Google syndicated search",
+          "url": "googlesyndicatedsearch.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Haboo",
+          "url": "habbo.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Hatena",
+          "url": "hatena.com"
+        },
+        {
+          "category": "Shopping",
+          "params": [],
+          "source": "IGShopping",
+          "url": "igshopping.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "q"
+          ],
+          "source": "InfoSpace",
+          "url": "searchya.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "q"
+          ],
+          "source": "InfoSpace",
+          "url": "dogpile.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "q"
+          ],
+          "source": "InfoSpace",
+          "url": "infospace.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "q"
+          ],
+          "source": "InfoSpace",
+          "url": "tattoodle.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "q"
+          ],
+          "source": "InfoSpace",
+          "url": "metacrawler.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "q"
+          ],
+          "source": "InfoSpace",
+          "url": "webfetch.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "q"
+          ],
+          "source": "InfoSpace",
+          "url": "webcrawler.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "query"
-        ]
-    },
-    {
-        "url": "wow.com",
-        "source": "Google",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "IxQuick",
+          "url": "ixquick.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "query"
+          ],
+          "source": "Jungle Key",
+          "url": "junglekey.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "q"
-        ]
-    },
-    {
-        "url": "gfsoso.com",
-        "source": "Google",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "K9 Safe Search",
+          "url": "k9safesearch.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Multiply",
+          "url": "multiply.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Netlog",
+          "url": "netlog.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Orkut",
+          "url": "orkut.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Peepeth",
+          "url": "peepeth.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Plaxo",
+          "url": "plaxo.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "q"
-        ]
-    },
-    {
-        "url": "monumentbrowser.com",
-        "source": "Google",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "PlusNetwork",
+          "url": "plusnetwork.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "Scour.com",
+          "url": "scour.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "q"
-        ]
-    },
-    {
-        "url": "googlesyndicatedsearch.com",
-        "source": "Google syndicated search",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "SearchLock",
+          "url": "searchlock.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "q"
-        ]
-    },
-    {
-        "url": "infospace.com",
-        "source": "InfoSpace",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "Searchalot",
+          "url": "searchalot.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "query"
+          ],
+          "source": "Setooz",
+          "url": "setooz.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Sonico.com",
+          "url": "sonico.com"
+        },
+        {
+          "category": "Search",
+          "params": [
+            "query"
+          ],
+          "source": "StartPage",
+          "url": "startpage.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "StumbleUpon",
+          "url": "stumbleupon.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "q"
-        ]
-    },
-    {
-        "url": "tattoodle.com",
-        "source": "InfoSpace",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "Surf Canyon",
+          "url": "surfcanyon.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "q"
-        ]
-    },
-    {
-        "url": "metacrawler.com",
-        "source": "InfoSpace",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "Tarmot",
+          "url": "tarmot.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "q"
-        ]
-    },
-    {
-        "url": "webfetch.com",
-        "source": "InfoSpace",
-        "category": "Search",
-        "params": [
-            "q"
-        ]
-    },
-    {
-        "url": "webcrawler.com",
-        "source": "InfoSpace",
-        "category": "Search",
-        "params": [
-            "q"
-        ]
-    },
-    {
-        "url": "aol.com",
-        "source": "aol",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "asmallworld.com",
-        "source": "asmallworld",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "cafemom.com",
-        "source": "cafemom",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "care.com",
-        "source": "care",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "chegg.com",
-        "source": "chegg",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "chicagonow.com",
-        "source": "chicagonow",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "crackle.com",
-        "source": "crackle",
-        "category": "Video",
-        "params": []
-    },
-    {
-        "url": "ebay.com",
-        "source": "ebay",
-        "category": "Shopping",
-        "params": []
-    },
-    {
-        "url": "exalead.com",
-        "source": "exalead",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "fandom.com",
-        "source": "fandom",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "folkdirect.com",
-        "source": "folkdirect",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "gather.com",
-        "source": "gather",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "googleplus.com",
-        "source": "googleplus",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "hr.com",
-        "source": "hr",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "instagram.com",
-        "source": "instagram",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "line.com",
-        "source": "line",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "mocospace.com",
-        "source": "mocospace",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "opendiary.com",
-        "source": "opendiary",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "qwant.com",
-        "source": "qwant",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "socialvibe.com",
-        "source": "socialvibe",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "tweetdeck.com",
-        "source": "tweetdeck",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "whatsapp.com",
-        "source": "whatsapp",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "yandex.com",
-        "source": "Yandex",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "Technorati",
+          "url": "technorati.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "TikTok",
+          "url": "tiktok.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Tuenti",
+          "url": "tuenti.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "V2EX",
+          "url": "v2ex.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Viadeo",
+          "url": "viadeo.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Vkontakte",
+          "url": "vk.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "WAYN",
+          "url": "wayn.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "WeeWorld",
+          "url": "weeworld.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Weibo",
+          "url": "weibo.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "Workplace",
+          "url": "workplace.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "XING",
+          "url": "xing.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "text"
-        ]
-    },
-    {
-        "url": "allnurses.com",
-        "source": "allnurses",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "cozycot.com",
-        "source": "cozycot",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "epicurious.com",
-        "source": "epicurious",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "glassboard.com",
-        "source": "glassboard",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "jappy.com",
-        "source": "jappy",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "meetup.com",
-        "source": "meetup",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "yelp.com",
-        "source": "yelp",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "alice.com",
-        "source": "alice",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "beforeitsnews.com",
-        "source": "beforeitsnews",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "biglobe.com",
-        "source": "biglobe",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "daum.com",
-        "source": "daum",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "drugs-forum.com",
-        "source": "drugs-forum",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "eniro.com",
-        "source": "eniro",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "fc2.com",
-        "source": "fc2",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "fotolog.com",
-        "source": "Fotolog",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "google+.com",
-        "source": "google+",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "instapaper.com",
-        "source": "instapaper",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "iqiyi.com",
-        "source": "iqiyi",
-        "category": "Video",
-        "params": []
-    },
-    {
-        "url": "kvasir.com",
-        "source": "kvasir",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "najdi.com",
-        "source": "najdi",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "naver.com",
-        "source": "naver",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "onet.com",
-        "source": "onet",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "pinboard.com",
-        "source": "pinboard",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "posterous.com",
-        "source": "posterous",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "rambler.com",
-        "source": "rambler",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "skype.com",
-        "source": "skype",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "social.com",
-        "source": "social",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "stardoll.com",
-        "source": "stardoll",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "vampirefreaks.com",
-        "source": "vampirefreaks",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "zalo.com",
-        "source": "zalo",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "123people.com",
-        "source": "123people",
-        "category": "Search",
-        "params": [
-            "search_term"
-        ]
-    },
-    {
-        "url": "alexa.com",
-        "source": "Alexa",
-        "category": "Search",
-        "params": [
-            "q"
-        ]
-    },
-    {
-        "url": "alohafind.com",
-        "source": "AlohaFind",
-        "category": "Search",
-        "params": [
-            "q"
-        ]
-    },
-    {
-        "url": "altavista.com",
-        "source": "AltaVista",
-        "category": "Search",
-        "params": [
-            "q"
-        ]
-    },
-    {
-        "url": "arama.com",
-        "source": "Arama",
-        "category": "Search",
-        "params": [
-            "q"
-        ]
-    },
-    {
-        "url": "qbyrd.com",
-        "source": "Ask",
-        "category": "Search",
-        "params": [
-            "ask",
-            "q",
-            "searchfor"
-        ]
-    },
-    {
-        "url": "search-results.com",
-        "source": "search-results",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "searchqu.com",
-        "source": "Ask",
-        "category": "Search",
-        "params": [
-            "ask",
-            "q",
-            "searchfor"
-        ]
-    },
-    {
-        "url": "blekko.com",
-        "source": "blekko",
-        "category": "Search",
-        "params": [
-            "q"
-        ]
-    },
-    {
-        "url": "claro-search.com",
-        "source": "Claro Search",
-        "category": "Search",
-        "params": [
-            "q"
-        ]
-    },
-    {
-        "url": "coccoc.com",
-        "source": "C\u1ed1c C\u1ed1c",
-        "category": "Search",
-        "params": [
-            "query"
-        ]
-    },
-    {
-        "url": "zapmeta.com",
-        "source": "Zapmeta",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "Yandex",
+          "url": "yandex.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "q",
             "query"
-        ]
-    },
-    {
-        "url": "github.com",
-        "source": "GitHub",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "dribbble.com",
-        "source": "Dribbble",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "fetlife.com",
-        "source": "Fetlife",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "flixster.com",
-        "source": "Flixster",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "friendsreunited.com",
-        "source": "Friends Reunited",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "friendster.com",
-        "source": "Friendster",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "italki.com",
-        "source": "italki",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "msn.com",
-        "source": "msn",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "mylife.com",
-        "source": "mylife",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "secondlife.com",
-        "source": "secondlife",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "catster.com",
-        "source": "catster",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "fotki.com",
-        "source": "fotki",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "movabletype.com",
-        "source": "movabletype",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "salespider.com",
-        "source": "salespider",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "startpage.com",
-        "source": "StartPage",
-        "category": "Search",
-        "params": [
-            "query"
-        ]
-    },
-    {
-        "url": "surfcanyon.com",
-        "source": "Surf Canyon",
-        "category": "Search",
-        "params": [
+          ],
+          "source": "Zapmeta",
+          "url": "zapmeta.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "activerain",
+          "url": "activerain.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "activeworlds",
+          "url": "activeworlds.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "addthis",
+          "url": "addthis.com"
+        },
+        {
+          "category": "Shopping",
+          "params": [],
+          "source": "alibaba",
+          "url": "alibaba.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "alice",
+          "url": "alice.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "allnurses",
+          "url": "allnurses.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "allrecipes",
+          "url": "allrecipes.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "alumniclass",
+          "url": "alumniclass.com"
+        },
+        {
+          "category": "Shopping",
+          "params": [],
+          "source": "amazon",
+          "url": "amazon.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "americantowns",
+          "url": "americantowns.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "ancestry",
+          "url": "ancestry.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "anobii",
+          "url": "anobii.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "answerbag",
+          "url": "answerbag.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "aol",
+          "url": "aol.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "aolanswers",
+          "url": "aolanswers.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "artstation",
+          "url": "artstation.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "askubuntu",
+          "url": "askubuntu.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "asmallworld",
+          "url": "asmallworld.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "athlinks",
+          "url": "athlinks.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "avg",
+          "url": "avg.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "baby-gaga",
+          "url": "baby-gaga.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "babylon",
+          "url": "babylon.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "beforeitsnews",
+          "url": "beforeitsnews.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "bharatstudent",
+          "url": "bharatstudent.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "biglobe",
+          "url": "biglobe.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "blackcareernetwork",
+          "url": "blackcareernetwork.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "blackplanet",
+          "url": "blackplanet.com"
+        },
+        {
+          "category": "Search",
+          "params": [
             "q"
-        ]
-    },
-    {
-        "url": "tarmot.com",
-        "source": "Tarmot",
-        "category": "Search",
-        "params": [
-            "q"
-        ]
-    },
-    {
-        "url": "technorati.com",
-        "source": "Technorati",
-        "category": "Search",
-        "params": [
-            "q"
-        ]
-    },
-    {
-        "url": "comcast.com",
-        "source": "comcast",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "dol2day.com",
-        "source": "dol2day",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "listography.com",
-        "source": "listography",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "rakuten.com",
-        "source": "rakuten",
-        "category": "Search",
-        "params": []
-    },
-    {
-        "url": "wakoopa.com",
-        "source": "wakoopa",
-        "category": "Social",
-        "params": []
-    },
-    {
-        "url": "wechat.com",
-        "source": "wechat",
-        "category": "Social",
-        "params": []
-    }
+          ],
+          "source": "blekko",
+          "url": "blekko.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "blog",
+          "url": "blog.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "bloggang",
+          "url": "bloggang.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "blogger",
+          "url": "blogger.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "blogher",
+          "url": "blogher.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "bloglines",
+          "url": "bloglines.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "blogs",
+          "url": "blogs.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "blogsome",
+          "url": "blogsome.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "blogspot",
+          "url": "blogspot.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "blogster",
+          "url": "blogster.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "blurtit",
+          "url": "blurtit.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "brightkite",
+          "url": "brightkite.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "brizzly",
+          "url": "brizzly.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "buzzfeed",
+          "url": "buzzfeed.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "cafemom",
+          "url": "cafemom.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "camospace",
+          "url": "camospace.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "canalblog",
+          "url": "canalblog.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "care",
+          "url": "care.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "care2",
+          "url": "care2.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "catster",
+          "url": "catster.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "cellufun",
+          "url": "cellufun.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "chegg",
+          "url": "chegg.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "chicagonow",
+          "url": "chicagonow.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "classquest",
+          "url": "classquest.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "cnn",
+          "url": "cnn.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "cocolog-nifty",
+          "url": "cocolog-nifty.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "comcast",
+          "url": "comcast.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "conduit",
+          "url": "conduit.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "cozycot",
+          "url": "cozycot.com"
+        },
+        {
+          "category": "Video",
+          "params": [],
+          "source": "crackle",
+          "url": "crackle.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "crunchyroll",
+          "url": "crunchyroll.com"
+        },
+        {
+          "category": "Video",
+          "params": [],
+          "source": "curiositystream",
+          "url": "curiositystream.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "cyworld",
+          "url": "cyworld.com"
+        },
+        {
+          "category": "Video",
+          "params": [],
+          "source": "dailymotion",
+          "url": "dailymotion.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "daum",
+          "url": "daum.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "deluxe",
+          "url": "deluxe.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "deviantart",
+          "url": "deviantart.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "dianping",
+          "url": "dianping.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "digg",
+          "url": "digg.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "diigo",
+          "url": "diigo.com"
+        },
+        {
+          "category": "Video",
+          "params": [],
+          "source": "disneyplus",
+          "url": "disneyplus.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "disqus",
+          "url": "disqus.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "dogster",
+          "url": "dogster.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "dol2day",
+          "url": "dol2day.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "doostang",
+          "url": "doostang.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "dopplr",
+          "url": "dopplr.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "drugs-forum",
+          "url": "drugs-forum.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "duckduckgo",
+          "url": "duckduckgo.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "dzone",
+          "url": "dzone.com"
+        },
+        {
+          "category": "Shopping",
+          "params": [],
+          "source": "ebay",
+          "url": "ebay.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "elftown",
+          "url": "elftown.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "eniro",
+          "url": "eniro.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "epicurious",
+          "url": "epicurious.com"
+        },
+        {
+          "category": "Shopping",
+          "params": [],
+          "source": "etsy",
+          "url": "etsy.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "everforo",
+          "url": "everforo.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "exalead",
+          "url": "exalead.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "excite",
+          "url": "excite.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "extole",
+          "url": "extole.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "faceparty",
+          "url": "faceparty.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "fandom",
+          "url": "fandom.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "fanpop",
+          "url": "fanpop.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "fark",
+          "url": "fark.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "fb",
+          "url": "fb.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "fc2",
+          "url": "fc2.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "feedspot",
+          "url": "feedspot.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "feministing",
+          "url": "feministing.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "filmaffinity",
+          "url": "filmaffinity.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "flickr",
+          "url": "flickr.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "flipboard",
+          "url": "flipboard.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "folkdirect",
+          "url": "folkdirect.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "foodservice",
+          "url": "foodservice.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "fotki",
+          "url": "fotki.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "friendfeed",
+          "url": "friendfeed.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "fubar",
+          "url": "fubar.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "gamerdna",
+          "url": "gamerdna.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "gather",
+          "url": "gather.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "geni",
+          "url": "geni.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "getpocket",
+          "url": "getpocket.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "glassboard",
+          "url": "glassboard.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "glassdoor",
+          "url": "glassdoor.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "globo",
+          "url": "globo.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "godtube",
+          "url": "godtube.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "goldstar",
+          "url": "goldstar.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "gooblog",
+          "url": "gooblog.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "goodreads",
+          "url": "goodreads.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "google",
+          "url": "google.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "google+",
+          "url": "google+.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "google-play",
+          "url": "google-play.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "googlegroups",
+          "url": "googlegroups.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "googleplus",
+          "url": "googleplus.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "govloop",
+          "url": "govloop.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "gowalla",
+          "url": "gowalla.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "gulli",
+          "url": "gulli.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "hi5",
+          "url": "hi5.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "hootsuite",
+          "url": "hootsuite.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "houzz",
+          "url": "houzz.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "hoverspot",
+          "url": "hoverspot.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "hr",
+          "url": "hr.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "hubculture",
+          "url": "hubculture.com"
+        },
+        {
+          "category": "Video",
+          "params": [],
+          "source": "hulu",
+          "url": "hulu.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "ibibo",
+          "url": "ibibo.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "ig",
+          "url": "ig.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "imageshack",
+          "url": "imageshack.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "imvu",
+          "url": "imvu.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "incredimail",
+          "url": "incredimail.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "insanejournal",
+          "url": "insanejournal.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "instagram",
+          "url": "instagram.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "instapaper",
+          "url": "instapaper.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "intherooms",
+          "url": "intherooms.com"
+        },
+        {
+          "category": "Video",
+          "params": [],
+          "source": "iq",
+          "url": "iq.com"
+        },
+        {
+          "category": "Video",
+          "params": [],
+          "source": "iqiyi",
+          "url": "iqiyi.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "italki",
+          "url": "italki.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "jammerdirect",
+          "url": "jammerdirect.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "jappy",
+          "url": "jappy.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "kaboodle",
+          "url": "kaboodle.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "kakao",
+          "url": "kakao.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "kakaocorp",
+          "url": "kakaocorp.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "kaneva",
+          "url": "kaneva.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "kvasir",
+          "url": "kvasir.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "lang-8",
+          "url": "lang-8.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "librarything",
+          "url": "librarything.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "line",
+          "url": "line.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "linkedin",
+          "url": "linkedin.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "listal",
+          "url": "listal.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "listography",
+          "url": "listography.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "livedoor",
+          "url": "livedoor.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "livedoorblog",
+          "url": "livedoorblog.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "livejournal",
+          "url": "livejournal.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "lycos",
+          "url": "lycos.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "meetup",
+          "url": "meetup.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "menuism",
+          "url": "menuism.com"
+        },
+        {
+          "category": "Shopping",
+          "params": [],
+          "source": "mercadolibre",
+          "url": "mercadolibre.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "messenger",
+          "url": "messenger.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "mix",
+          "url": "mix.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "mocospace",
+          "url": "mocospace.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "mouthshut",
+          "url": "mouthshut.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "movabletype",
+          "url": "movabletype.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "msn",
+          "url": "msn.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "mubi",
+          "url": "mubi.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "myYearbook",
+          "url": "myyearbook.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "myheritage",
+          "url": "myheritage.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "mylife",
+          "url": "mylife.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "mymodernmet",
+          "url": "mymodernmet.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "myspace",
+          "url": "myspace.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "najdi",
+          "url": "najdi.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "naver",
+          "url": "naver.com"
+        },
+        {
+          "category": "Video",
+          "params": [],
+          "source": "netflix",
+          "url": "netflix.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "netvibes",
+          "url": "netvibes.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "newsshowcase",
+          "url": "newsshowcase.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "nexopia",
+          "url": "nexopia.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "niconico",
+          "url": "niconico.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "nightlifelink",
+          "url": "nightlifelink.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "ning",
+          "url": "ning.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "onet",
+          "url": "onet.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "onstartups",
+          "url": "onstartups.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "opendiary",
+          "url": "opendiary.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "over-blog",
+          "url": "over-blog.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "overblog",
+          "url": "overblog.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "photobucket",
+          "url": "photobucket.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "pinboard",
+          "url": "pinboard.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "pingsta",
+          "url": "pingsta.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "pinterest",
+          "url": "pinterest.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "plurk",
+          "url": "plurk.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "posterous",
+          "url": "posterous.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "qapacity",
+          "url": "qapacity.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "quechup",
+          "url": "quechup.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "quora",
+          "url": "quora.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "qwant",
+          "url": "qwant.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "rakuten",
+          "url": "rakuten.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "rambler",
+          "url": "rambler.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "ravelry",
+          "url": "ravelry.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "reddit",
+          "url": "reddit.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "redux",
+          "url": "redux.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "renren",
+          "url": "renren.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "reunion",
+          "url": "reunion.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "reverbnation",
+          "url": "reverbnation.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "ryze",
+          "url": "ryze.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "salespider",
+          "url": "salespider.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "screenrant",
+          "url": "screenrant.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "scribd",
+          "url": "scribd.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "scvngr",
+          "url": "scvngr.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "search-results",
+          "url": "search-results.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "secondlife",
+          "url": "secondlife.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "serverfault",
+          "url": "serverfault.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "seznam",
+          "url": "seznam.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "shareit",
+          "url": "shareit.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "sharethis",
+          "url": "sharethis.com"
+        },
+        {
+          "category": "Shopping",
+          "params": [],
+          "source": "shopify",
+          "url": "shopify.com"
+        },
+        {
+          "category": "Shopping",
+          "params": [],
+          "source": "shopzilla",
+          "url": "shopzilla.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "shvoong",
+          "url": "shvoong.com"
+        },
+        {
+          "category": "Shopping",
+          "params": [],
+          "source": "simplycodes",
+          "url": "simplycodes.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "skype",
+          "url": "skype.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "skyrock",
+          "url": "skyrock.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "smartnews",
+          "url": "smartnews.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "snapchat",
+          "url": "snapchat.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "so",
+          "url": "so.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "social",
+          "url": "social.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "socialvibe",
+          "url": "socialvibe.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "sogou",
+          "url": "sogou.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "spoke",
+          "url": "spoke.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "spruz",
+          "url": "spruz.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "ssense",
+          "url": "ssense.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "stackapps",
+          "url": "stackapps.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "stackexchange",
+          "url": "stackexchange.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "stackoverflow",
+          "url": "stackoverflow.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "stardoll",
+          "url": "stardoll.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "startsiden",
+          "url": "startsiden.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "stickam",
+          "url": "stickam.com"
+        },
+        {
+          "category": "Shopping",
+          "params": [],
+          "source": "stripe",
+          "url": "stripe.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "superuser",
+          "url": "superuser.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "sweeva",
+          "url": "sweeva.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "tagged",
+          "url": "tagged.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "taggedmail",
+          "url": "taggedmail.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "talkbiznow",
+          "url": "talkbiznow.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "techmeme",
+          "url": "techmeme.com"
+        },
+        {
+          "category": "Video",
+          "params": [],
+          "source": "ted",
+          "url": "ted.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "tencent",
+          "url": "tencent.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "terra",
+          "url": "terra.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "tinyurl",
+          "url": "tinyurl.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "toolbox",
+          "url": "toolbox.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "travellerspoint",
+          "url": "travellerspoint.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "tripadvisor",
+          "url": "tripadvisor.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "trombi",
+          "url": "trombi.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "trustpilot",
+          "url": "trustpilot.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "tudou",
+          "url": "tudou.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "tumblr",
+          "url": "tumblr.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "tweetdeck",
+          "url": "tweetdeck.com"
+        },
+        {
+          "category": "Video",
+          "params": [],
+          "source": "twitch",
+          "url": "twitch.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "twitter",
+          "url": "twitter.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "twoo",
+          "url": "twoo.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "typepad",
+          "url": "typepad.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "ukr",
+          "url": "ukr.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "urbanspoon",
+          "url": "urbanspoon.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "ushareit",
+          "url": "ushareit.com"
+        },
+        {
+          "category": "Video",
+          "params": [],
+          "source": "utreon",
+          "url": "utreon.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "vampirefreaks",
+          "url": "vampirefreaks.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "vampirerave",
+          "url": "vampirerave.com"
+        },
+        {
+          "category": "Video",
+          "params": [],
+          "source": "veoh",
+          "url": "veoh.com"
+        },
+        {
+          "category": "Video",
+          "params": [],
+          "source": "vimeo",
+          "url": "vimeo.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "virgilio",
+          "url": "virgilio.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "wakoopa",
+          "url": "wakoopa.com"
+        },
+        {
+          "category": "Shopping",
+          "params": [],
+          "source": "walmart",
+          "url": "walmart.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "wattpad",
+          "url": "wattpad.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "webshots",
+          "url": "webshots.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "wechat",
+          "url": "wechat.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "weebly",
+          "url": "weebly.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "weread",
+          "url": "weread.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "whatsapp",
+          "url": "whatsapp.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "wikihow",
+          "url": "wikihow.com"
+        },
+        {
+          "category": "Video",
+          "params": [],
+          "source": "wistia",
+          "url": "wistia.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "woot",
+          "url": "woot.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "wordpress",
+          "url": "wordpress.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "xanga",
+          "url": "xanga.com"
+        },
+        {
+          "category": "Search",
+          "params": [],
+          "source": "yahoo",
+          "url": "yahoo.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "yammer",
+          "url": "yammer.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "yelp",
+          "url": "yelp.com"
+        },
+        {
+          "category": "Video",
+          "params": [],
+          "source": "youku",
+          "url": "youku.com"
+        },
+        {
+          "category": "Video",
+          "params": [],
+          "source": "youtube",
+          "url": "youtube.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "zalo",
+          "url": "zalo.com"
+        },
+        {
+          "category": "Social",
+          "params": [],
+          "source": "zooppa",
+          "url": "zooppa.com"
+        }
     ]
 
     # convert referrer_url_source_category_list to a dictionary for faster lookup

--- a/src/analytics/private/sqls/redshift/fn-parse-utm-from-url.sql
+++ b/src/analytics/private/sqls/redshift/fn-parse-utm-from-url.sql
@@ -174,6120 +174,2311 @@ def parse_utm_from_url(page_url, referrer, latest_referrer):
     get_umt_from_url(page_url, "page_url")
 
     referrer_url_source_category_list = [
-        {
-            "url": "www.gnadenmeer.de",
-            "source": "Gnadenmeer",
-            "category": "Search",
-            "params": ["keyword"],
-        },
-        {
-            "url": "aax-us-east.amazon-adsystem.com",
-            "source": "aax-us-east.amazon-adsystem",
-            "category": "Shopping",
-            "params": [],
-        },
-        {"url": "lang-8.com", "source": "lang-8", "category": "Social", "params": []},
-        {
-            "url": "search.comcast.net",
-            "source": "Comcast",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "wsdsold.infospace.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": [],
-        },
-        {"url": "airg.ca", "source": "airg", "category": "Social", "params": []},
-        {
-            "url": "43things.com",
-            "source": "43things",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "search.naver.com",
-            "source": "Naver",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {"url": "hatena.com", "source": "Hatena", "category": "Social", "params": []},
-        {"url": "360.cn", "source": "360", "category": "Search", "params": []},
-        {
-            "url": "activerain.com",
-            "source": "activerain",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "ameba.jp", "source": "ameba", "category": "Social", "params": []},
-        {
-            "url": "search.avast.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "isearch.babylon.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {"url": "last.fm", "source": "last", "category": "Social", "params": []},
-        {"url": "lastfm.ru", "source": "Last.fm", "category": "Social", "params": []},
-        {"url": "lastfm.de", "source": "Last.fm", "category": "Social", "params": []},
-        {"url": "lastfm.es", "source": "Last.fm", "category": "Social", "params": []},
-        {"url": "lastfm.fr", "source": "Last.fm", "category": "Social", "params": []},
-        {"url": "lastfm.it", "source": "Last.fm", "category": "Social", "params": []},
-        {"url": "lastfm.jp", "source": "Last.fm", "category": "Social", "params": []},
-        {"url": "lastfm.pl", "source": "Last.fm", "category": "Social", "params": []},
-        {
-            "url": "lastfm.com.br",
-            "source": "Last.fm",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "lastfm.se", "source": "Last.fm", "category": "Social", "params": []},
-        {
-            "url": "lastfm.com.tr",
-            "source": "Last.fm",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "linkedin.com",
-            "source": "linkedin",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "lnkd.in", "source": "lnkd", "category": "Social", "params": []},
-        {
-            "url": "linkedin.android",
-            "source": "LinkedIn",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "51.com", "source": "51", "category": "Social", "params": []},
-        {
-            "url": "activeworlds.com",
-            "source": "activeworlds",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "ko.search.need2find.com",
-            "source": "Needtofind",
-            "category": "Search",
-            "params": ["searchfor"],
-        },
-        {
-            "url": "www.neti.ee",
-            "source": "Neti",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {"url": "avg.com", "source": "avg", "category": "Search", "params": []},
-        {
-            "url": "b.hatena.ne.jp",
-            "source": "b.hatena",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "alibaba.com",
-            "source": "alibaba",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "ar.pinterest.com",
-            "source": "ar.pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "start.facemoods.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["s"],
-        },
-        {
-            "url": "start.funmoods.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.magentic.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.searchcompletion.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "au.search.yahoo.com",
-            "source": "au.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "babyblog.ru",
-            "source": "babyblog",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "babylon.com", "source": "babylon", "category": "Search", "params": []},
-        {"url": "bebo.com", "source": "Bebo", "category": "Social", "params": []},
-        {
-            "url": "www.searchmobileonline.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "isearch.glarysoft.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.chatzum.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "home.speedbit.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.b1.org",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "searchya.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.handycafe.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.v9.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "imageshack.com",
-            "source": "imageshack",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "addthis.com", "source": "addthis", "category": "Social", "params": []},
-        {
-            "url": "igshopping.com",
-            "source": "IGShopping",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "websearch.cs.com",
-            "source": "Compuserve.com (Enhanced by Google)",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "search.conduit.com",
-            "source": "Conduit.com",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "livejournal.ru",
-            "source": "LiveJournal",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "livejournal.com",
-            "source": "livejournal",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "mastodon.social",
-            "source": "Mastodon",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "mastodon.cloud",
-            "source": "Mastodon",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "mastodon.technology",
-            "source": "Mastodon",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "mastodon.xyz",
-            "source": "Mastodon",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "mastodon.at",
-            "source": "Mastodon",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "mastodon.art",
-            "source": "Mastodon",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "mamot.fr", "source": "Mastodon", "category": "Social", "params": []},
-        {"url": "pawoo.net", "source": "Mastodon", "category": "Social", "params": []},
-        {"url": "mstdn.io", "source": "Mastodon", "category": "Social", "params": []},
-        {"url": "mstdn.jp", "source": "Mastodon", "category": "Social", "params": []},
-        {
-            "url": "friends.nico",
-            "source": "Mastodon",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "ro-mastodon.puyo.jp",
-            "source": "Mastodon",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "quey.org", "source": "Mastodon", "category": "Social", "params": []},
-        {
-            "url": "botsin.space",
-            "source": "Mastodon",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "social.tchncs.de",
-            "source": "Mastodon",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "knzk.me", "source": "Mastodon", "category": "Social", "params": []},
-        {
-            "url": "mastodont.cat",
-            "source": "Mastodon",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "bitcoinhackers.org",
-            "source": "Mastodon",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "fosstodon.org",
-            "source": "Mastodon",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "chaos.social",
-            "source": "Mastodon",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "cybre.space",
-            "source": "Mastodon",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "vis.social", "source": "Mastodon", "category": "Social", "params": []},
-        {"url": "meinvz.net", "source": "meinvz", "category": "Social", "params": []},
-        {"url": "mixi.jp", "source": "mixi", "category": "Social", "params": []},
-        {"url": "blogg.no", "source": "blogg", "category": "Social", "params": []},
-        {
-            "url": "blogspot.com",
-            "source": "blogspot",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "bookmarks.yahoo.co.jp",
-            "source": "bookmarks.yahoo",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "bookmarks.yahoo.com",
-            "source": "bookmarks.yahoo",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "ca.search.yahoo.com",
-            "source": "ca.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "cellufun.com",
-            "source": "cellufun",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "doostang.com",
-            "source": "doostang",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "edublogs.org",
-            "source": "edublogs",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "alumniclass.com",
-            "source": "alumniclass",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "amp.reddit.com",
-            "source": "amp.reddit",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "artstation.com",
-            "source": "artstation",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "askubuntu.com",
-            "source": "askubuntu",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "americantowns.com",
-            "source": "americantowns",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "anobii.com", "source": "anobii", "category": "Social", "params": []},
-        {
-            "url": "images.search.conduit.com",
-            "source": "Conduit.com",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.crawler.com",
-            "source": "Crawler",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.cuil.com",
-            "source": "Cuil",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "daemon-search.com",
-            "source": "Daemon search",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.gomeo.com",
-            "source": "Gomeo",
-            "category": "Search",
-            "params": ["keywords"],
-        },
-        {
-            "url": "search.goo.ne.jp",
-            "source": "goo",
-            "category": "Search",
-            "params": ["mt"],
-        },
-        {
-            "url": "moikrug.ru",
-            "source": "MoiKrug.ru",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "multiply.com",
-            "source": "Multiply",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "my.mail.ru",
-            "source": "my.mail.ru",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "myheritage.com",
-            "source": "myheritage",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "mylife.ru", "source": "MyLife", "category": "Social", "params": []},
-        {"url": "myspace.com", "source": "myspace", "category": "Social", "params": []},
-        {
-            "url": "myyearbook.com",
-            "source": "myYearbook",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "nk.pl",
-            "source": "Nasza-klasa.pl",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "search.iminent.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "utorrent.inspsearch.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "govome.inspsearch.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.google.interia.pl",
-            "source": "Interia",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.isodelen.se",
-            "source": "Isodelen",
-            "category": "Search",
-            "params": ["keywords"],
-        },
-        {
-            "url": "ixquick.com",
-            "source": "IxQuick",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.eu.ixquick.com",
-            "source": "IxQuick",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "ixquick.de",
-            "source": "IxQuick",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.ixquick.de",
-            "source": "IxQuick",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "us.ixquick.com",
-            "source": "IxQuick",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s1.us.ixquick.com",
-            "source": "IxQuick",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s2.us.ixquick.com",
-            "source": "IxQuick",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s3.us.ixquick.com",
-            "source": "IxQuick",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s4.us.ixquick.com",
-            "source": "IxQuick",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s5.us.ixquick.com",
-            "source": "IxQuick",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "eu.ixquick.com",
-            "source": "IxQuick",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "apps.shopify.com",
-            "source": "apps.shopify",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "ask.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {"url": "awe.sm", "source": "awe", "category": "Social", "params": []},
-        {"url": "biswap.org", "source": "biswap", "category": "Social", "params": []},
-        {"url": "bing.com", "source": "Bing", "category": "Search", "params": ["q"]},
-        {
-            "url": "blackcareernetwork.com",
-            "source": "blackcareernetwork",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "blackplanet.com",
-            "source": "blackplanet",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "blogster.com",
-            "source": "blogster",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "caringbridge.org",
-            "source": "caringbridge",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "couchsurfing.org",
-            "source": "couchsurfing",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "cr.shopping.naver.com",
-            "source": "cr.shopping.naver",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "de.search.yahoo.com",
-            "source": "de.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "ocnsearch.goo.ne.jp",
-            "source": "goo",
-            "category": "Search",
-            "params": ["mt"],
-        },
-        {"url": "google.com", "source": "google", "category": "Search", "params": []},
-        {
-            "url": "encrypted.google.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "es.search.yahoo.com",
-            "source": "es.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {"url": "etsy.com", "source": "etsy", "category": "Shopping", "params": []},
-        {"url": "excite.com", "source": "excite", "category": "Search", "params": []},
-        {
-            "url": "feedspot.com",
-            "source": "feedspot",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "filmaffinity.com",
-            "source": "filmaffinity",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "flipboard.com",
-            "source": "flipboard",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "forums.imore.com",
-            "source": "forums.imore",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "forums.nexopia.com",
-            "source": "forums.nexopia",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "foursquare.com",
-            "source": "Foursquare",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "free.facebook.com",
-            "source": "free.facebook",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "getpocket.com",
-            "source": "getpocket",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "goodreads.com",
-            "source": "goodreads",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "hu.pinterest.com",
-            "source": "hu.pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "in.pinterest.com",
-            "source": "in.pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "incredimail.com",
-            "source": "incredimail",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "intherooms.com",
-            "source": "intherooms",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "my.daemon-search.com",
-            "source": "Daemon search",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.dasoertliche.de",
-            "source": "DasOertliche",
-            "category": "Search",
-            "params": ["kw"],
-        },
-        {
-            "url": "www2.dasoertliche.de",
-            "source": "DasOertliche",
-            "category": "Search",
-            "params": ["kw", "ph"],
-        },
-        {
-            "url": "www1.dastelefonbuch.de",
-            "source": "DasTelefonbuch",
-            "category": "Search",
-            "params": ["kw"],
-        },
-        {
-            "url": "search.daum.net",
-            "source": "Daum",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "otsing.delfi.ee",
-            "source": "Delfi EE",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "smart.delfi.lv",
-            "source": "Delfi lv",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {"url": "digg.com", "source": "digg", "category": "Social", "params": []},
-        {"url": "netlog.com", "source": "Netlog", "category": "Social", "params": []},
-        {
-            "url": "odnoklassniki.ru",
-            "source": "odnoklassniki",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "orkut.com", "source": "Orkut", "category": "Social", "params": []},
-        {
-            "url": "qzone.qq.com",
-            "source": "qzone.qq",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "peepeth.com", "source": "Peepeth", "category": "Social", "params": []},
-        {
-            "url": "pinterest.com",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pinterest.ca",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pinterest.ch",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pinterest.co.uk",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pinterest.de",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pinterest.dk",
-            "source": "Pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pinterest.es",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pinterest.fr",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pinterest.ie",
-            "source": "Pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pinterest.jp",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pinterest.nz",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pinterest.pt",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pinterest.se",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "plaxo.com", "source": "Plaxo", "category": "Social", "params": []},
-        {"url": "reddit.com", "source": "reddit", "category": "Social", "params": []},
-        {
-            "url": "np.reddit.com",
-            "source": "reddit",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pay.reddit.com",
-            "source": "reddit",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "renren.com", "source": "renren", "category": "Social", "params": []},
-        {"url": "skyrock.com", "source": "skyrock", "category": "Social", "params": []},
-        {
-            "url": "snapchat.com",
-            "source": "snapchat",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "sonico.com",
-            "source": "Sonico.com",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "stackoverflow.com",
-            "source": "stackoverflow",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "studivz.net", "source": "studivz", "category": "Social", "params": []},
-        {
-            "url": "login.tagged.com",
-            "source": "Tagged",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "taringa.net", "source": "taringa", "category": "Social", "params": []},
-        {
-            "url": "www2.google.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "ipv6.google.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "go.google.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "wwwgoogle.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "gogole.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "gppgle.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "ancestry.com",
-            "source": "ancestry",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "baby-gaga.com",
-            "source": "baby-gaga",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "badoo.com", "source": "Badoo", "category": "Social", "params": []},
-        {
-            "url": "baidu.com",
-            "source": "Baidu",
-            "category": "Search",
-            "params": ["kw", "wd", "word"],
-        },
-        {"url": "disqus.com", "source": "disqus", "category": "Social", "params": []},
-        {"url": "dogster.com", "source": "dogster", "category": "Social", "params": []},
-        {
-            "url": "draft.blogger.com",
-            "source": "draft.blogger",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "elftown.com", "source": "elftown", "category": "Social", "params": []},
-        {"url": "fark.com", "source": "fark", "category": "Social", "params": []},
-        {
-            "url": "foodservice.com",
-            "source": "foodservice",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "forums.androidcentral.com",
-            "source": "forums.androidcentral",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "fr.search.yahoo.com",
-            "source": "fr.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {"url": "geni.com", "source": "geni", "category": "Social", "params": []},
-        {
-            "url": "glassdoor.com",
-            "source": "glassdoor",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "globo.com", "source": "globo", "category": "Search", "params": []},
-        {"url": "gowalla.com", "source": "gowalla", "category": "Social", "params": []},
-        {"url": "identi.ca", "source": "identi.ca", "category": "Social", "params": []},
-        {
-            "url": "interpals.net",
-            "source": "interpals",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "kakaocorp.com",
-            "source": "kakaocorp",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "listal.com", "source": "listal", "category": "Social", "params": []},
-        {
-            "url": "s8-eu.ixquick.com",
-            "source": "IxQuick",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s1-eu.ixquick.de",
-            "source": "IxQuick",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s2-eu4.ixquick.com",
-            "source": "IxQuick",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s5-eu4.ixquick.com",
-            "source": "IxQuick",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "junglekey.com",
-            "source": "Jungle Key",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "junglekey.fr",
-            "source": "Jungle Key",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.jungle-spider.de",
-            "source": "Jungle Spider",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "jyxo.1188.cz",
-            "source": "Jyxo",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "k9safesearch.com",
-            "source": "K9 Safe Search",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.kataweb.it",
-            "source": "Kataweb",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.kensaq.com",
-            "source": "Kensaq",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "kvasir.no",
-            "source": "Kvasir",
-            "category": "Search",
-            "params": ["q", "search_word"],
-        },
-        {
-            "url": "www.kvasir.no",
-            "source": "Kvasir",
-            "category": "Search",
-            "params": ["q", "search_word"],
-        },
-        {
-            "url": "www.toile.com",
-            "source": "La Toile Du Québec (Google)",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "web.toile.com",
-            "source": "La Toile Du Québec (Google)",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {"url": "laban.vn", "source": "Laban", "category": "Search", "params": ["q"]},
-        {
-            "url": "www.latne.lv",
-            "source": "Latne",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.lilo.org",
-            "source": "Lilo",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "lo.st",
-            "source": "Lo.st",
-            "category": "Search",
-            "params": ["x_query"],
-        },
-        {
-            "url": "www.lookany.com",
-            "source": "LookAny",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "search.lookseek.com",
-            "source": "Lookseek",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.looksmart.com",
-            "source": "Looksmart",
-            "category": "Search",
-            "params": ["key"],
-        },
-        {
-            "url": "search.lycos.com",
-            "source": "Lycos",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {"url": "lycos.com", "source": "lycos", "category": "Search", "params": []},
-        {
-            "url": "www.maailm.com",
-            "source": "maailm.com",
-            "category": "Search",
-            "params": ["tekst"],
-        },
-        {"url": "go.mail.ru", "source": "go.mail", "category": "Search", "params": []},
-        {
-            "url": "www.mamma.com",
-            "source": "Mamma",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "mamma75.mamma.com",
-            "source": "Mamma",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.meinestadt.de",
-            "source": "Meinestadt.de",
-            "category": "Search",
-            "params": ["words"],
-        },
-        {"url": "meta.ua", "source": "Meta.ua", "category": "Search", "params": ["q"]},
-        {
-            "url": "s1.metacrawler.de",
-            "source": "MetaCrawler DE",
-            "category": "Search",
-            "params": ["qry"],
-        },
-        {
-            "url": "s2.metacrawler.de",
-            "source": "MetaCrawler DE",
-            "category": "Search",
-            "params": ["qry"],
-        },
-        {
-            "url": "aax.amazon-adsystem.com",
-            "source": "aax.amazon-adsystem",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "blog.twitch.tv",
-            "source": "blog.twitch",
-            "category": "Video",
-            "params": [],
-        },
-        {
-            "url": "bloggang.com",
-            "source": "bloggang",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "blogher.com", "source": "blogher", "category": "Social", "params": []},
-        {
-            "url": "buzzfeed.com",
-            "source": "buzzfeed",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "camospace.com",
-            "source": "camospace",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "checkout.shopify.com",
-            "source": "checkout.shopify",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "classquest.com",
-            "source": "classquest",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "conduit.com", "source": "conduit", "category": "Search", "params": []},
-        {
-            "url": "search.nifty.com",
-            "source": "Nifty",
-            "category": "Search",
-            "params": ["q", "text"],
-        },
-        {
-            "url": "search.azby.fmworld.net",
-            "source": "Nifty",
-            "category": "Search",
-            "params": ["q", "text"],
-        },
-        {
-            "url": "videosearch.nifty.com",
-            "source": "Nifty Videos",
-            "category": "Search",
-            "params": ["kw"],
-        },
-        {"url": "nigma.ru", "source": "Nigma", "category": "Search", "params": ["s"]},
-        {
-            "url": "academia.edu",
-            "source": "academia",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "allrecipes.com",
-            "source": "allrecipes",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "s3.metacrawler.de",
-            "source": "MetaCrawler DE",
-            "category": "Search",
-            "params": ["qry"],
-        },
-        {
-            "url": "meta.rrzn.uni-hannover.de",
-            "source": "Metager",
-            "category": "Search",
-            "params": ["eingabe"],
-        },
-        {
-            "url": "www.metager.de",
-            "source": "Metager",
-            "category": "Search",
-            "params": ["eingabe"],
-        },
-        {
-            "url": "metager.de",
-            "source": "Metager",
-            "category": "Search",
-            "params": ["eingabe"],
-        },
-        {
-            "url": "metager2.de",
-            "source": "Metager2",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.mister-wong.com",
-            "source": "Mister Wong",
-            "category": "Search",
-            "params": ["keywords"],
-        },
-        {
-            "url": "www.mister-wong.de",
-            "source": "Mister Wong",
-            "category": "Search",
-            "params": ["keywords"],
-        },
-        {
-            "url": "www.mojeek.com",
-            "source": "Mojeek",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.monstercrawler.com",
-            "source": "Monstercrawler",
-            "category": "Search",
-            "params": ["qry"],
-        },
-        {
-            "url": "www.mozbot.fr",
-            "source": "mozbot",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.mozbot.co.uk",
-            "source": "mozbot",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.mozbot.com",
-            "source": "mozbot",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "searchservice.myspace.com",
-            "source": "MySpace",
-            "category": "Search",
-            "params": ["qry"],
-        },
-        {
-            "url": "www.mysearch.com",
-            "source": "MyWebSearch",
-            "category": "Search",
-            "params": ["searchfor"],
-        },
-        {
-            "url": "ms114.mysearch.com",
-            "source": "MyWebSearch",
-            "category": "Search",
-            "params": ["searchfor"],
-        },
-        {
-            "url": "ms146.mysearch.com",
-            "source": "MyWebSearch",
-            "category": "Search",
-            "params": ["searchfor"],
-        },
-        {
-            "url": "kf.mysearch.myway.com",
-            "source": "MyWebSearch",
-            "category": "Search",
-            "params": ["searchfor"],
-        },
-        {
-            "url": "ki.mysearch.myway.com",
-            "source": "MyWebSearch",
-            "category": "Search",
-            "params": ["searchfor"],
-        },
-        {
-            "url": "search.myway.com",
-            "source": "MyWebSearch",
-            "category": "Search",
-            "params": ["searchfor"],
-        },
-        {
-            "url": "search.mywebsearch.com",
-            "source": "MyWebSearch",
-            "category": "Search",
-            "params": ["searchfor"],
-        },
-        {
-            "url": "www.najdi.si",
-            "source": "Najdi.si",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.nate.com",
-            "source": "Nate",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "fr.dir.com",
-            "source": "dir.com",
-            "category": "Search",
-            "params": ["req"],
-        },
-        {
-            "url": "search.disconnect.me",
-            "source": "DisconnectSearch",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "dmoz.org",
-            "source": "dmoz",
-            "category": "Search",
-            "params": ["search"],
-        },
-        {
-            "url": "editors.dmoz.org",
-            "source": "dmoz",
-            "category": "Search",
-            "params": ["search"],
-        },
-        {
-            "url": "duckduckgo.com",
-            "source": "duckduckgo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "r.duckduckgo.com",
-            "source": "DuckDuckGo",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.earthlink.net",
-            "source": "Earthlink",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {"url": "ecosia.org", "source": "ecosia", "category": "Search", "params": []},
-        {
-            "url": "www.ecosia.org",
-            "source": "Ecosia",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "ariadna.elmundo.es",
-            "source": "El Mundo",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.eniro.se",
-            "source": "Eniro",
-            "category": "Search",
-            "params": ["q", "search_word"],
-        },
-        {
-            "url": "www.entireweb.com",
-            "source": "Entireweb",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {"url": "eo.st", "source": "eo", "category": "Search", "params": ["x_query"]},
-        {
-            "url": "epicsearch.in",
-            "source": "EpicSearch.in",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.epicsearch.in",
-            "source": "EpicSearch.in",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.eurip.com",
-            "source": "Eurip",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "szukaj.onet.pl",
-            "source": "Onet.pl",
-            "category": "Search",
-            "params": ["qt"],
-        },
-        {
-            "url": "online.no",
-            "source": "Online.no",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.only-search.com",
-            "source": "OnlySearch",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.1881.no",
-            "source": "Opplysningen 1881",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "busca.orange.es",
-            "source": "Orange",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "lemoteur.ke.voila.fr",
-            "source": "Orange",
-            "category": "Search",
-            "params": ["kw"],
-        },
-        {
-            "url": "lemoteur.orange.fr",
-            "source": "Orange",
-            "category": "Search",
-            "params": ["kw"],
-        },
-        {
-            "url": "www.paperball.de",
-            "source": "Paperball",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "cr2.shopping.naver.com",
-            "source": "cr2.shopping.naver",
-            "category": "Shopping",
-            "params": [],
-        },
-        {"url": "cross.tv", "source": "cross", "category": "Social", "params": []},
-        {
-            "url": "crunchyroll.com",
-            "source": "crunchyroll",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "discover.hubpages.com",
-            "source": "discover.hubpages",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "dk.search.yahoo.com",
-            "source": "dk.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {"url": "exblog.jp", "source": "exblog", "category": "Social", "params": []},
-        {
-            "url": "fast.wistia.net",
-            "source": "fast.wistia",
-            "category": "Video",
-            "params": [],
-        },
-        {
-            "url": "forums.webosnation.com",
-            "source": "forums.webosnation",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "fubar.com", "source": "fubar", "category": "Social", "params": []},
-        {
-            "url": "goldenline.pl",
-            "source": "goldenline",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "google-play.com",
-            "source": "google-play",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "googlegroups.com",
-            "source": "googlegroups",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "hubculture.com",
-            "source": "hubculture",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "id.search.yahoo.com",
-            "source": "id.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "aolanswers.com",
-            "source": "aolanswers",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "at.search.yahoo.com",
-            "source": "at.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "bharatstudent.com",
-            "source": "bharatstudent",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "biip.no", "source": "biip", "category": "Social", "params": []},
-        {
-            "url": "bloglines.com",
-            "source": "bloglines",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "amazon.com", "source": "amazon", "category": "Shopping", "params": []},
-        {
-            "url": "answerbag.com",
-            "source": "answerbag",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "extern.peoplecheck.de",
-            "source": "PeopleCheck",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.peoplepc.com",
-            "source": "PeoplePC",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.picsearch.com",
-            "source": "Picsearch",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.plazoo.com",
-            "source": "Plazoo",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "plusnetwork.com",
-            "source": "PlusNetwork",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "poisk.ru",
-            "source": "Poisk.Ru",
-            "category": "Search",
-            "params": ["text"],
-        },
-        {
-            "url": "search.qip.ru",
-            "source": "qip.ru",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.qualigo.at",
-            "source": "Qualigo",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.qualigo.ch",
-            "source": "Qualigo",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.qualigo.de",
-            "source": "Qualigo",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.qualigo.nl",
-            "source": "Qualigo",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.qwant.com",
-            "source": "Qwant",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "lite.qwant.com",
-            "source": "lite.qwant",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "websearch.rakuten.co.jp",
-            "source": "websearch.rakuten",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "nova.rambler.ru",
-            "source": "Rambler",
-            "category": "Search",
-            "params": ["query", "words"],
-        },
-        {
-            "url": "www.riksdelen.se",
-            "source": "Riksdelen",
-            "category": "Search",
-            "params": ["what"],
-        },
-        {
-            "url": "ar.search.yahoo.com",
-            "source": "ar.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "blogsome.com",
-            "source": "blogsome",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "brightkite.com",
-            "source": "brightkite",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "cbnt.io", "source": "cbnt", "category": "Social", "params": []},
-        {
-            "url": "dailystrength.org",
-            "source": "dailystrength",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "fanpop.com", "source": "fanpop", "category": "Social", "params": []},
-        {"url": "brizzly.com", "source": "brizzly", "category": "Social", "params": []},
-        {
-            "url": "business.facebook.com",
-            "source": "business.facebook",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "canalblog.com",
-            "source": "canalblog",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "ch.search.yahoo.com",
-            "source": "ch.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "chiebukuro.yahoo.co.jp",
-            "source": "chiebukuro.yahoo",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "curiositystream.com",
-            "source": "curiositystream",
-            "category": "Video",
-            "params": [],
-        },
-        {
-            "url": "dailymotion.com",
-            "source": "dailymotion",
-            "category": "Video",
-            "params": [],
-        },
-        {
-            "url": "dianping.com",
-            "source": "dianping",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "douban.com", "source": "Douban", "category": "Social", "params": []},
-        {
-            "url": "feministing.com",
-            "source": "feministing",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "www.euroseek.com",
-            "source": "Euroseek",
-            "category": "Search",
-            "params": ["string"],
-        },
-        {
-            "url": "www.everyclick.com",
-            "source": "Everyclick",
-            "category": "Search",
-            "params": ["keyword"],
-        },
-        {
-            "url": "www.exalead.fr",
-            "source": "Exalead",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.exalead.com",
-            "source": "Exalead",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.excite.it",
-            "source": "Excite",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.excite.fr",
-            "source": "Excite",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.excite.de",
-            "source": "Excite",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.excite.co.uk",
-            "source": "Excite",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.excite.es",
-            "source": "Excite",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.excite.nl",
-            "source": "Excite",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "msxml.excite.com",
-            "source": "Excite",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.excite.co.jp",
-            "source": "Excite",
-            "category": "Search",
-            "params": ["search"],
-        },
-        {
-            "url": "www.facebook.com",
-            "source": "Facebook",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.fastbrowsersearch.com",
-            "source": "Fast Browser Search",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.findhurtig.dk",
-            "source": "Findhurtig",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.fireball.de",
-            "source": "Fireball",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.firstsfind.com",
-            "source": "Firstsfind",
-            "category": "Search",
-            "params": ["qry"],
-        },
-        {
-            "url": "www.fixsuche.de",
-            "source": "Fixsuche",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.flix.de",
-            "source": "Flix.de",
-            "category": "Search",
-            "params": ["keyword"],
-        },
-        {
-            "url": "search.fooooo.com",
-            "source": "Fooooo",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "forestle.org",
-            "source": "Forestle",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "forestle.mobi",
-            "source": "Forestle",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "recherche.francite.com",
-            "source": "Francite",
-            "category": "Search",
-            "params": ["name"],
-        },
-        {
-            "url": "search.free.fr",
-            "source": "Free",
-            "category": "Search",
-            "params": ["q", "qs"],
-        },
-        {
-            "url": "search1-2.free.fr",
-            "source": "Free",
-            "category": "Search",
-            "params": ["q", "qs"],
-        },
-        {
-            "url": "search1-1.free.fr",
-            "source": "Free",
-            "category": "Search",
-            "params": ["q", "qs"],
-        },
-        {
-            "url": "search.freecause.com",
-            "source": "FreeCause",
-            "category": "Search",
-            "params": ["p"],
-        },
-        {
-            "url": "suche.freenet.de",
-            "source": "Freenet",
-            "category": "Search",
-            "params": ["keywords", "query"],
-        },
-        {
-            "url": "friendfeed.com",
-            "source": "friendfeed",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "search.frontier.com",
-            "source": "Frontier",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "gais.cs.ccu.edu.tw",
-            "source": "GAIS",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "id.twitch.tv",
-            "source": "id.twitch",
-            "category": "Video",
-            "params": [],
-        },
-        {
-            "url": "imageshack.us",
-            "source": "imageshack",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "imvu.com", "source": "imvu", "category": "Social", "params": []},
-        {
-            "url": "jobs.netflix.com",
-            "source": "jobs.netflix",
-            "category": "Video",
-            "params": [],
-        },
-        {
-            "url": "m.kin.naver.com",
-            "source": "m.kin.naver",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "messages.google.com",
-            "source": "messages.google",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "messages.yahoo.co.jp",
-            "source": "messages.yahoo",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "mix.com", "source": "mix", "category": "Social", "params": []},
-        {
-            "url": "nicovideo.jp",
-            "source": "nicovideo",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "ning.com", "source": "ning", "category": "Social", "params": []},
-        {
-            "url": "nl.pinterest.com",
-            "source": "nl.pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "no.shopping.net",
-            "source": "no.shopping",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "oshiete.goo.ne.jp",
-            "source": "oshiete.goo",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "rtl.de", "source": "rtl", "category": "Social", "params": []},
-        {
-            "url": "screenrant.com",
-            "source": "screenrant",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "seznam.com", "source": "seznam", "category": "Search", "params": []},
-        {"url": "seznam.cz", "source": "seznam", "category": "Search", "params": []},
-        {
-            "url": "shopify.com",
-            "source": "shopify",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "shopping.yahoo.co.jp",
-            "source": "shopping.yahoo",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "shopping.yahoo.com",
-            "source": "shopping.yahoo",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "shopzilla.com",
-            "source": "shopzilla",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "smartnews.com",
-            "source": "smartnews",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "sociallife.com.br",
-            "source": "sociallife",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "ssense.com", "source": "ssense", "category": "Social", "params": []},
-        {
-            "url": "stackexchange.com",
-            "source": "stackexchange",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "toolbox.com", "source": "toolbox", "category": "Social", "params": []},
-        {"url": "vimeo.com", "source": "vimeo", "category": "Video", "params": []},
-        {"url": "vk.com", "source": "Vkontakte", "category": "Social", "params": []},
-        {
-            "url": "webshots.com",
-            "source": "webshots",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "weibo.com", "source": "Weibo", "category": "Social", "params": []},
-        {
-            "url": "search.genieo.com",
-            "source": "Genieo",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {"url": "geona.net", "source": "Geona", "category": "Search", "params": ["q"]},
-        {
-            "url": "gibiru.com",
-            "source": "Gibiru",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.gibiru.com",
-            "source": "Gibiru",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.gigablast.com",
-            "source": "Gigablast",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "dir.gigablast.com",
-            "source": "Gigablast (Directory)",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {"url": "weread.com", "source": "weread", "category": "Social", "params": []},
-        {
-            "url": "wikitravel.org",
-            "source": "wikitravel",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "wistia.com", "source": "wistia", "category": "Video", "params": []},
-        {
-            "url": "yahoo-mbga.jp",
-            "source": "yahoo-mbga",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "zooppa.com", "source": "zooppa", "category": "Social", "params": []},
-        {
-            "url": "biglobe.co.jp",
-            "source": "biglobe",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "biglobe.ne.jp",
-            "source": "biglobe",
-            "category": "Search",
-            "params": [],
-        },
-        {"url": "blog.com", "source": "blog", "category": "Social", "params": []},
-        {"url": "blogs.com", "source": "blogs", "category": "Social", "params": []},
-        {
-            "url": "blog.goo.ne.jp",
-            "source": "blog.goo",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "buzznet.com", "source": "Buzznet", "category": "Social", "params": []},
-        {"url": "cn.bing.com", "source": "cn.bing", "category": "Search", "params": []},
-        {
-            "url": "co.pinterest.com",
-            "source": "co.pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "disneyplus.com",
-            "source": "disneyplus",
-            "category": "Video",
-            "params": [],
-        },
-        {"url": "dzone.com", "source": "dzone", "category": "Social", "params": []},
-        {
-            "url": "everforo.com",
-            "source": "everforo",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "facebook.com",
-            "source": "Facebook",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "fi.search.yahoo.com",
-            "source": "fi.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "goldstar.com",
-            "source": "goldstar",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "firmy.cz", "source": "firmy", "category": "Search", "params": []},
-        {"url": "godtube.com", "source": "godtube", "category": "Social", "params": []},
-        {"url": "gulli.com", "source": "gulli", "category": "Social", "params": []},
-        {
-            "url": "help.netflix.com",
-            "source": "help.netflix",
-            "category": "Video",
-            "params": [],
-        },
-        {"url": "hi5.com", "source": "hi5", "category": "Social", "params": []},
-        {
-            "url": "hootsuite.com",
-            "source": "hootsuite",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "internations.org",
-            "source": "internations",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "meetin.org", "source": "meetin", "category": "Social", "params": []},
-        {"url": "ntp.msn.com", "source": "ntp.msn", "category": "Search", "params": []},
-        {
-            "url": "nz.search.yahoo.com",
-            "source": "nz.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "plus.url.google.com",
-            "source": "plus.url.google",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "pocket.co", "source": "pocket", "category": "Social", "params": []},
-        {"url": "ryze.com", "source": "ryze", "category": "Social", "params": []},
-        {
-            "url": "simplycodes.com",
-            "source": "simplycodes",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "slashdot.org",
-            "source": "slashdot",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "slideshare.net",
-            "source": "slideshare",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "superuser.com",
-            "source": "superuser",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "tuenti.com", "source": "Tuenti", "category": "Social", "params": []},
-        {"url": "unblog.fr", "source": "unblog", "category": "Social", "params": []},
-        {"url": "woot.com", "source": "woot", "category": "Social", "params": []},
-        {"url": "yammer.com", "source": "yammer", "category": "Social", "params": []},
-        {"url": "fb.me", "source": "Facebook", "category": "Social", "params": []},
-        {
-            "url": "fruehstueckstreff.org",
-            "source": "fruehstueckstreff",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "gamerdna.com",
-            "source": "gamerdna",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "hoverspot.com",
-            "source": "hoverspot",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "id.pinterest.com",
-            "source": "id.pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "irc-galleria.net",
-            "source": "irc-galleria",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "is.gd", "source": "is", "category": "Social", "params": []},
-        {"url": "jappy.de", "source": "jappy", "category": "Social", "params": []},
-        {"url": "justin.tv", "source": "justin", "category": "Video", "params": []},
-        {"url": "gooblog.com", "source": "gooblog", "category": "Social", "params": []},
-        {"url": "govloop.com", "source": "govloop", "category": "Social", "params": []},
-        {
-            "url": "gutefrage.net",
-            "source": "gutefrage",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "ibibo.com", "source": "ibibo", "category": "Social", "params": []},
-        {"url": "ig.com", "source": "ig", "category": "Social", "params": []},
-        {"url": "iq.com", "source": "iq", "category": "Video", "params": []},
-        {
-            "url": "jammerdirect.com",
-            "source": "jammerdirect",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "kaneva.com", "source": "kaneva", "category": "Social", "params": []},
-        {
-            "url": "livedoor.com",
-            "source": "livedoor",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "m.blog.naver.com",
-            "source": "m.blog.naver",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "m.naver.com", "source": "m.naver", "category": "Search", "params": []},
-        {
-            "url": "mail.rambler.ru",
-            "source": "mail.rambler",
-            "category": "Search",
-            "params": [],
-        },
-        {"url": "menuism.com", "source": "menuism", "category": "Social", "params": []},
-        {
-            "url": "in.search.yahoo.com",
-            "source": "in.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "it.search.yahoo.com",
-            "source": "it.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "l.facebook.com",
-            "source": "Facebook",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "lens.google.com",
-            "source": "lens.google",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "librarything.com",
-            "source": "librarything",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "m.facebook.com",
-            "source": "Facebook",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "m.search.naver.com",
-            "source": "m.search.naver",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "message.alibaba.com",
-            "source": "message.alibaba",
-            "category": "Shopping",
-            "params": [],
-        },
-        {"url": "5ch.net", "source": "5ch", "category": "Social", "params": []},
-        {
-            "url": "blog.naver.com",
-            "source": "blog.naver",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "blog.yahoo.co.jp",
-            "source": "blog.yahoo",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "blurtit.com", "source": "blurtit", "category": "Social", "params": []},
-        {"url": "cnn.com", "source": "cnn", "category": "Search", "params": []},
-        {
-            "url": "cocolog-nifty.com",
-            "source": "cocolog-nifty",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "cyworld.com", "source": "cyworld", "category": "Social", "params": []},
-        {"url": "deluxe.com", "source": "deluxe", "category": "Social", "params": []},
-        {
-            "url": "kin.naver.com",
-            "source": "kin.naver",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "mercadolibre.com.ar",
-            "source": "mercadolibre",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "mercadolibre.com.mx",
-            "source": "mercadolibre",
-            "category": "Shopping",
-            "params": [],
-        },
-        {"url": "mubi.com", "source": "mubi", "category": "Social", "params": []},
-        {
-            "url": "my.opera.com",
-            "source": "my.opera",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "netvibes.com",
-            "source": "netvibes",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "partners.shopify.com",
-            "source": "partners.shopify",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "photobucket.com",
-            "source": "photobucket",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pinterest.at",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pinterest.co.kr",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pinterest.com.mx",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "player.twitch.tv",
-            "source": "player.twitch",
-            "category": "Video",
-            "params": [],
-        },
-        {
-            "url": "rakuten.co.jp",
-            "source": "rakuten",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "researchgate.net",
-            "source": "researchgate",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "sharethis.com",
-            "source": "sharethis",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "shvoong.com", "source": "shvoong", "category": "Social", "params": []},
-        {"url": "stickam.com", "source": "stickam", "category": "Social", "params": []},
-        {"url": "stripe.com", "source": "stripe", "category": "Shopping", "params": []},
-        {"url": "ted.com", "source": "ted", "category": "Video", "params": []},
-        {
-            "url": "tr.pinterest.com",
-            "source": "tr.pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "tr.search.yahoo.com",
-            "source": "tr.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {"url": "twitter.com", "source": "twitter", "category": "Social", "params": []},
-        {
-            "url": "ushareit.com",
-            "source": "ushareit",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "veoh.com", "source": "veoh", "category": "Video", "params": []},
-        {
-            "url": "video.ibm.com",
-            "source": "video.ibm",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "walmart.com",
-            "source": "walmart",
-            "category": "Shopping",
-            "params": [],
-        },
-        {"url": "wikihow.com", "source": "wikihow", "category": "Social", "params": []},
-        {
-            "url": "amazon.co.uk",
-            "source": "amazon",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "apps.facebook.com",
-            "source": "apps.facebook",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "athlinks.com",
-            "source": "athlinks",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "xanga.com", "source": "xanga", "category": "Social", "params": []},
-        {"url": "yandex.fr", "source": "yandex", "category": "Search", "params": []},
-        {"url": "youku.com", "source": "youku", "category": "Video", "params": []},
-        {
-            "url": "zen.yandex.ru",
-            "source": "zen.yandex",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "messenger.com",
-            "source": "messenger",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "music.youtube.com",
-            "source": "music.youtube",
-            "category": "Video",
-            "params": [],
-        },
-        {
-            "url": "odnoklassniki.ua",
-            "source": "odnoklassniki",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "paper.li", "source": "paper", "category": "Social", "params": []},
-        {
-            "url": "pe.search.yahoo.com",
-            "source": "pe.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "qapacity.com",
-            "source": "qapacity",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "quechup.com", "source": "quechup", "category": "Social", "params": []},
-        {"url": "quora.com", "source": "quora", "category": "Social", "params": []},
-        {"url": "rambler.ru", "source": "rambler", "category": "Search", "params": []},
-        {
-            "url": "s3.amazonaws.com",
-            "source": "s3.amazonaws",
-            "category": "Shopping",
-            "params": [],
-        },
-        {"url": "scoop.it", "source": "scoop", "category": "Social", "params": []},
-        {"url": "scvngr.com", "source": "scvngr", "category": "Social", "params": []},
-        {
-            "url": "serverfault.com",
-            "source": "serverfault",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "shop.app", "source": "shop", "category": "Shopping", "params": []},
-        {"url": "spoke.com", "source": "spoke", "category": "Social", "params": []},
-        {
-            "url": "stackapps.com",
-            "source": "stackapps",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "store.shopping.yahoo.co.jp",
-            "source": "store.shopping.yahoo",
-            "category": "Shopping",
-            "params": [],
-        },
-        {"url": "suomi24.fi", "source": "suomi24", "category": "Social", "params": []},
-        {"url": "t.co", "source": "Twitter", "category": "Social", "params": []},
-        {"url": "tencent.com", "source": "tencent", "category": "Social", "params": []},
-        {
-            "url": "travellerspoint.com",
-            "source": "travellerspoint",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "trombi.com", "source": "trombi", "category": "Social", "params": []},
-        {
-            "url": "urbanspoon.com",
-            "source": "urbanspoon",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "viadeo.journaldunet.com",
-            "source": "viadeo.journaldunet",
-            "category": "Video",
-            "params": [],
-        },
-        {"url": "wattpad.com", "source": "wattpad", "category": "Social", "params": []},
-        {
-            "url": "webmaster.yandex.ru",
-            "source": "webmaster.yandex",
-            "category": "Search",
-            "params": [],
-        },
-        {"url": "diigo.com", "source": "diigo", "category": "Social", "params": []},
-        {
-            "url": "dogpile.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {"url": "dopplr.com", "source": "dopplr", "category": "Social", "params": []},
-        {"url": "fb.com", "source": "fb", "category": "Social", "params": []},
-        {
-            "url": "groups.google.com",
-            "source": "groups.google",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "houzz.com", "source": "houzz", "category": "Social", "params": []},
-        {"url": "hulu.com", "source": "hulu", "category": "Video", "params": []},
-        {"url": "hyves.net", "source": "hyves", "category": "Social", "params": []},
-        {"url": "hyves.nl", "source": "hyves", "category": "Social", "params": []},
-        {
-            "url": "myanimelist.net",
-            "source": "myanimelist",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "nightlifelink.com",
-            "source": "nightlifelink",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "okwave.jp", "source": "okwave", "category": "Social", "params": []},
-        {
-            "url": "old.reddit.com",
-            "source": "old.reddit",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "oneworldgroup.org",
-            "source": "oneworldgroup",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "order.shopping.yahoo.co.jp",
-            "source": "order.shopping.yahoo",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "overblog.com",
-            "source": "overblog",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "plurk.com", "source": "plurk", "category": "Social", "params": []},
-        {
-            "url": "pro.homeadvisor.com",
-            "source": "pro.homeadvisor",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "reverbnation.com",
-            "source": "reverbnation",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "sp-web.search.auone.jp",
-            "source": "auone",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "startsiden.com",
-            "source": "startsiden",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "startsiden.no",
-            "source": "Startsiden",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {"url": "t.me", "source": "t", "category": "Social", "params": []},
-        {
-            "url": "talkbiznow.com",
-            "source": "talkbiznow",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "tripadvisor.com",
-            "source": "tripadvisor",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "trustpilot.com",
-            "source": "trustpilot",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "tudou.com", "source": "tudou", "category": "Social", "params": []},
-        {
-            "url": "us.search.yahoo.com",
-            "source": "us.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "search.rr.com",
-            "source": "Road Runner",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "rpmfind.net",
-            "source": "rpmfind",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "fr2.rpmfind.net",
-            "source": "rpmfind",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "pesquisa.sapo.pt",
-            "source": "Sapo",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {"url": "scour.com", "source": "Scour.com", "category": "Search", "params": []},
-        {
-            "url": "www.search.ch",
-            "source": "Search.ch",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.search.com",
-            "source": "Search.com",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "searchalot.com",
-            "source": "Searchalot",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.searchcanvas.com",
-            "source": "SearchCanvas",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "searchlock.com",
-            "source": "SearchLock",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "results.searchlock.com",
-            "source": "SearchLock",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.searchy.co.uk",
-            "source": "Searchy",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.seesaa.jp",
-            "source": "SeeSaa",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "bg.setooz.com",
-            "source": "Setooz",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "da.setooz.com",
-            "source": "Setooz",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "el.setooz.com",
-            "source": "Setooz",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "fa.setooz.com",
-            "source": "Setooz",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "ur.setooz.com",
-            "source": "Setooz",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "setooz.com",
-            "source": "Setooz",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "search.seznam.cz",
-            "source": "Seznam",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "videa.seznam.cz",
-            "source": "Seznam Videa",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.sharelook.fr",
-            "source": "Sharelook",
-            "category": "Search",
-            "params": ["keyword"],
-        },
-        {
-            "url": "www.skynet.be",
-            "source": "Skynet",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {"url": "m.sm.cn", "source": "sm.cn", "category": "Search", "params": ["q"]},
-        {"url": "so.m.sm.cn", "source": "sm.cn", "category": "Search", "params": ["q"]},
-        {"url": "m.sp.sm.cn", "source": "sm.cn", "category": "Search", "params": ["q"]},
-        {"url": "yz.m.sm.cn", "source": "sm.cn", "category": "Search", "params": ["q"]},
-        {
-            "url": "quark.sm.cn",
-            "source": "sm.cn",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {"url": "www.sm.de", "source": "sm.de", "category": "Search", "params": ["q"]},
-        {
-            "url": "search.smartaddressbar.com",
-            "source": "SmartAddressbar",
-            "category": "Search",
-            "params": ["s"],
-        },
-        {
-            "url": "search.smartshopping.com",
-            "source": "SmartShopping",
-            "category": "Search",
-            "params": ["keywords", "kwd"],
-        },
-        {
-            "url": "search.snap.do",
-            "source": "Snap.do",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {"url": "blogger.com", "source": "blogger", "category": "Social", "params": []},
-        {
-            "url": "cafe.naver.com",
-            "source": "cafe.naver",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "care2.com", "source": "care2", "category": "Social", "params": []},
-        {
-            "url": "classmates.com",
-            "source": "Classmates.com",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "copainsdavant.linternaute.com",
-            "source": "copainsdavant.linternaute",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "d.hatena.ne.jp",
-            "source": "d.hatena",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "daum.net", "source": "daum", "category": "Search", "params": []},
-        {
-            "url": "wer-weiss-was.de",
-            "source": "wer-weiss-was",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "wordpress.com",
-            "source": "wordpress",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "yahoo.co.jp", "source": "yahoo", "category": "Search", "params": []},
-        {"url": "yandex.ua", "source": "yandex", "category": "Search", "params": []},
-        {
-            "url": "deviantart.com",
-            "source": "deviantart",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "extole.com", "source": "extole", "category": "Social", "params": []},
-        {
-            "url": "faceparty.com",
-            "source": "faceparty",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "flickr.com", "source": "flickr", "category": "Social", "params": []},
-        {
-            "url": "forums.crackberry.com",
-            "source": "forums.crackberry",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "gaiaonline.com",
-            "source": "Gaia Online",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "habbo.com", "source": "Haboo", "category": "Social", "params": []},
-        {
-            "url": "help.hulu.com",
-            "source": "help.hulu",
-            "category": "Video",
-            "params": [],
-        },
-        {
-            "url": "insanejournal.com",
-            "source": "insanejournal",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "l.instagram.com",
-            "source": "Instagram",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "mouthshut.com",
-            "source": "mouthshut",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "msearch.shopping.naver.com",
-            "source": "msearch.shopping.naver",
-            "category": "Shopping",
-            "params": [],
-        },
-        {"url": "netflix.com", "source": "netflix", "category": "Video", "params": []},
-        {
-            "url": "nl.search.yahoo.com",
-            "source": "nl.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "no.search.yahoo.com",
-            "source": "no.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "partyflock.nl",
-            "source": "partyflock",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "ph.search.yahoo.com",
-            "source": "ph.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {"url": "pingsta.com", "source": "pingsta", "category": "Social", "params": []},
-        {
-            "url": "pinterest.it",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "pixiv.net", "source": "pixiv", "category": "Social", "params": []},
-        {
-            "url": "pl.search.yahoo.com",
-            "source": "pl.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "plus.google.com",
-            "source": "plus.google",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "redux.com", "source": "redux", "category": "Social", "params": []},
-        {
-            "url": "se.search.yahoo.com",
-            "source": "se.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "search.google.com",
-            "source": "search.google",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "search.ukr.net",
-            "source": "search.ukr",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "secureurl.ukr.net",
-            "source": "secureurl.ukr",
-            "category": "Search",
-            "params": [],
-        },
-        {"url": "sweeva.com", "source": "sweeva", "category": "Social", "params": []},
-        {
-            "url": "www.so-net.ne.jp",
-            "source": "So-net",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "video.so-net.ne.jp",
-            "source": "So-net Videos",
-            "category": "Search",
-            "params": ["kw"],
-        },
-        {
-            "url": "search.softonic.com",
-            "source": "Softonic",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.sogou.com",
-            "source": "Sogou",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {"url": "sogou.com", "source": "sogou", "category": "Search", "params": []},
-        {"url": "m.sogou.com", "source": "m.sogou", "category": "Search", "params": []},
-        {
-            "url": "wap.sogou.com",
-            "source": "wap.sogou",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "english.sogou.com",
-            "source": "Sogou",
-            "category": "Search",
-            "params": ["keyword"],
-        },
-        {
-            "url": "www.soso.com",
-            "source": "Soso",
-            "category": "Search",
-            "params": ["w"],
-        },
-        {
-            "url": "kaboodle.com",
-            "source": "kaboodle",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "m.alibaba.com",
-            "source": "m.alibaba",
-            "category": "Shopping",
-            "params": [],
-        },
-        {"url": "m.twitch.tv", "source": "m.twitch", "category": "Video", "params": []},
-        {"url": "m.vk.com", "source": "m.vk", "category": "Social", "params": []},
-        {
-            "url": "malaysia.search.yahoo.com",
-            "source": "Yahoo!",
-            "category": "Search",
-            "params": ["p", "q"],
-        },
-        {"url": "mbga.jp", "source": "mbga", "category": "Social", "params": []},
-        {
-            "url": "mercadolibre.com",
-            "source": "mercadolibre",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "news.google.com",
-            "source": "Google News",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "newsshowcase.com",
-            "source": "newsshowcase",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "ngopost.org", "source": "ngopost", "category": "Social", "params": []},
-        {
-            "url": "onstartups.com",
-            "source": "onstartups",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "play.google.com",
-            "source": "play.google",
-            "category": "Search",
-            "params": [],
-        },
-        {"url": "reunion.com", "source": "reunion", "category": "Social", "params": []},
-        {"url": "scribd.com", "source": "scribd", "category": "Social", "params": []},
-        {
-            "url": "search.aol.co.uk",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "search.aol.com",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {"url": "shareit.com", "source": "shareit", "category": "Social", "params": []},
-        {
-            "url": "sites.google.com",
-            "source": "sites.google",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "spruz.com", "source": "spruz", "category": "Social", "params": []},
-        {
-            "url": "techmeme.com",
-            "source": "techmeme",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "terra.com", "source": "terra", "category": "Search", "params": []},
-        {"url": "tinyurl.com", "source": "tinyurl", "category": "Social", "params": []},
-        {"url": "twitch.com", "source": "twitch", "category": "Video", "params": []},
-        {"url": "twitch.tv", "source": "twitch", "category": "Video", "params": []},
-        {"url": "typepad.com", "source": "typepad", "category": "Social", "params": []},
-        {
-            "url": "vampirerave.com",
-            "source": "vampirerave",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "virgilio.com",
-            "source": "virgilio",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "vkontakte.ru",
-            "source": "vkontakte",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "vn.search.yahoo.com",
-            "source": "vn.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "web.facebook.com",
-            "source": "web.facebook",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "zoo.gr", "source": "zoo", "category": "Social", "params": []},
-        {"url": "tiktok.com", "source": "TikTok", "category": "Social", "params": []},
-        {"url": "ushi.cn", "source": "ushi", "category": "Social", "params": []},
-        {
-            "url": "web.skype.com",
-            "source": "web.skype",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "xing.com", "source": "XING", "category": "Social", "params": []},
-        {"url": "yahoo.com", "source": "yahoo", "category": "Search", "params": []},
-        {"url": "yandex.by", "source": "yandex", "category": "Search", "params": []},
-        {"url": "youtube.com", "source": "youtube", "category": "Video", "params": []},
-        {"url": "kakao.com", "source": "kakao", "category": "Social", "params": []},
-        {
-            "url": "livedoorblog.com",
-            "source": "livedoorblog",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "meneame.net", "source": "meneame", "category": "Social", "params": []},
-        {
-            "url": "mobile.facebook.com",
-            "source": "mobile.facebook",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "news.ycombinator.com",
-            "source": "Hacker News",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "nexopia.com", "source": "nexopia", "category": "Social", "params": []},
-        {
-            "url": "niconico.com",
-            "source": "niconico",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "ravelry.com", "source": "ravelry", "category": "Social", "params": []},
-        {"url": "tagged.com", "source": "tagged", "category": "Social", "params": []},
-        {"url": "twoo.com", "source": "twoo", "category": "Social", "params": []},
-        {
-            "url": "uk.search.yahoo.com",
-            "source": "uk.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {"url": "utreon.com", "source": "utreon", "category": "Video", "params": []},
-        {
-            "url": "lm.facebook.com",
-            "source": "lm.facebook",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "mail.yandex.ru",
-            "source": "mail.yandex",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "mymodernmet.com",
-            "source": "mymodernmet",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "one.walmart.com",
-            "source": "one.walmart",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "over-blog.com",
-            "source": "over-blog",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pl.pinterest.com",
-            "source": "pl.pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "playahead.se",
-            "source": "playahead",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "so.com", "source": "so", "category": "Search", "params": []},
-        {
-            "url": "taggedmail.com",
-            "source": "taggedmail",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "touch.facebook.com",
-            "source": "touch.facebook",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "ukr.com", "source": "ukr", "category": "Search", "params": []},
-        {"url": "weebly.com", "source": "weebly", "category": "Social", "params": []},
-        {
-            "url": "web.telegram.org",
-            "source": "Telegram",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "org.telegram.messenger",
-            "source": "Telegram",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "threads.net", "source": "Threads", "category": "Social", "params": []},
-        {
-            "url": "l.threads.net",
-            "source": "Threads",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "tumblr.com", "source": "tumblr", "category": "Social", "params": []},
-        {"url": "t.umblr.com", "source": "tumblr", "category": "Social", "params": []},
-        {
-            "url": "sourceforge.net",
-            "source": "Sourceforge",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "stumbleupon.com",
-            "source": "StumbleUpon",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "youtu.be", "source": "YouTube", "category": "Social", "params": []},
-        {"url": "v2ex.com", "source": "V2EX", "category": "Social", "params": []},
-        {"url": "viadeo.com", "source": "Viadeo", "category": "Social", "params": []},
-        {
-            "url": "vkrugudruzei.ru",
-            "source": "vkrugudruzei.ru",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "wayn.com", "source": "WAYN", "category": "Social", "params": []},
-        {"url": "t.cn", "source": "Weibo", "category": "Social", "params": []},
-        {
-            "url": "weeworld.com",
-            "source": "WeeWorld",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "login.live.com",
-            "source": "Windows Live Spaces",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "workplace.com",
-            "source": "Workplace",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "l.workplace.com",
-            "source": "Workplace",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "lm.workplace.com",
-            "source": "Workplace",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "googel.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.avg.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "isearch.avg.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "com.google.android.googlequicksearchbox",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "android-app//com.google.android.googlequicksearchbox/https/www.google.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.chedot.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["text"],
-        },
-        {
-            "url": "www.cnn.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "darkoogle.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "search.darkoogle.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "search.foxtab.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.gooofullsearch.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["keywords"],
-        },
-        {
-            "url": "search.hiyo.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["keywords"],
-        },
-        {
-            "url": "search.incredimail.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["keywords"],
-        },
-        {
-            "url": "search1.incredimail.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["keywords"],
-        },
-        {
-            "url": "search2.incredimail.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["keywords"],
-        },
-        {
-            "url": "search3.incredimail.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["keywords"],
-        },
-        {
-            "url": "search4.incredimail.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["keywords"],
-        },
-        {
-            "url": "search.sweetim.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["keywords"],
-        },
-        {
-            "url": "www.fastweb.it",
-            "source": "Google",
-            "category": "Search",
-            "params": ["keywords"],
-        },
-        {
-            "url": "search.juno.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "search.zum.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "find.tdc.dk",
-            "source": "Google",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "it.luna.tv",
-            "source": "Google",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "searchresults.verizon.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "search.walla.co.il",
-            "source": "Google",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "search.alot.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "suche.gmx.net",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.gmx.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.incredibar.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.delta-search.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www1.delta-search.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.1und1.de",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "suche.1und1.de",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.zonealarm.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "start.lenovo.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {"url": "wow.com", "source": "Google", "category": "Search", "params": ["q"]},
-        {
-            "url": "search.leonardo.it",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.optuszoo.com.au",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.dolphin-browser.jp",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "netlavis.azione.jp",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.nan.so",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "cgi2.nintendo.co.jp",
-            "source": "Google",
-            "category": "Search",
-            "params": ["gsc.q"],
-        },
-        {
-            "url": "search.smt.docomo.ne.jp",
-            "source": "search.smt.docomo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "image.search.smt.docomo.ne.jp",
-            "source": "Google",
-            "category": "Search",
-            "params": ["mt"],
-        },
-        {
-            "url": "gfsoso.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "searches.safehomepage.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "searches.f-secure.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "search.f-secure.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "webcache.googleusercontent.com",
-            "source": "Google",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "monumentbrowser.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.bt.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["p"],
-        },
-        {
-            "url": "startab.me",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.abv.bg",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.xfinity.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["searchterm"],
-        },
-        {
-            "url": "www.kadaza.com",
-            "source": "Google",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "blogsearch.google.com",
-            "source": "Google Blogsearch",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "google.com/cse",
-            "source": "Google Custom Search",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "cse.google.com",
-            "source": "Google Custom Search",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "google.com/custom",
-            "source": "Google Custom Search",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "images.google.com",
-            "source": "Google Images",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "google.com/imgres",
-            "source": "Google Images",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "maps.google.com",
-            "source": "Google Maps",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "scholar.google.com",
-            "source": "Google Scholar",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "google.com/products",
-            "source": "Google Shopping",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "googlesyndicatedsearch.com",
-            "source": "Google syndicated search",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "translate.google.com",
-            "source": "Google Translations",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "video.google.com",
-            "source": "Google Video",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.goyellow.de",
-            "source": "GoYellow.de",
-            "category": "Search",
-            "params": ["mdn"],
-        },
-        {
-            "url": "www.gulesider.no",
-            "source": "Gule Sider",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.haosou.com",
-            "source": "Haosou",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.highbeam.com",
-            "source": "HighBeam",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "req.hit-parade.com",
-            "source": "Hit-Parade",
-            "category": "Search",
-            "params": ["p7"],
-        },
-        {
-            "url": "class.hit-parade.com",
-            "source": "Hit-Parade",
-            "category": "Search",
-            "params": ["p7"],
-        },
-        {
-            "url": "www.hit-parade.com",
-            "source": "Hit-Parade",
-            "category": "Search",
-            "params": ["p7"],
-        },
-        {"url": "holmes.ge", "source": "Holmes", "category": "Search", "params": ["q"]},
-        {
-            "url": "www.hooseek.com",
-            "source": "Hooseek",
-            "category": "Search",
-            "params": ["recherche"],
-        },
-        {
-            "url": "www.hotbot.com",
-            "source": "Hotbot",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "start.iplay.com",
-            "source": "I-play",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "blogs.icerocket.com",
-            "source": "Icerocket",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {"url": "www.icq.com", "source": "ICQ", "category": "Search", "params": ["q"]},
-        {
-            "url": "search.icq.com",
-            "source": "ICQ",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.ilse.nl",
-            "source": "Ilse NL",
-            "category": "Search",
-            "params": ["search_for"],
-        },
-        {
-            "url": "search.imesh.com",
-            "source": "iMesh",
-            "category": "Search",
-            "params": ["q", "si"],
-        },
-        {
-            "url": "www2.inbox.com",
-            "source": "Inbox",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "infospace.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "tattoodle.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "metacrawler.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "webfetch.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "webcrawler.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.kiwee.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "searches.vi-view.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.webssearches.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.fbdownloader.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "searches3.globososo.com",
-            "source": "InfoSpace",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {"url": "aol.com", "source": "aol", "category": "Search", "params": []},
-        {
-            "url": "asmallworld.com",
-            "source": "asmallworld",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "bit.ly", "source": "bit", "category": "Social", "params": []},
-        {"url": "blip.fm", "source": "blip", "category": "Social", "params": []},
-        {"url": "cafemom.com", "source": "cafemom", "category": "Social", "params": []},
-        {"url": "care.com", "source": "care", "category": "Social", "params": []},
-        {
-            "url": "centerblog.net",
-            "source": "centerblog",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "centrum.cz", "source": "centrum", "category": "Search", "params": []},
-        {"url": "chegg.com", "source": "chegg", "category": "Social", "params": []},
-        {
-            "url": "chicagonow.com",
-            "source": "chicagonow",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "crackle.com", "source": "crackle", "category": "Video", "params": []},
-        {
-            "url": "cz.pinterest.com",
-            "source": "cz.pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "d.tube", "source": "d", "category": "Video", "params": []},
-        {"url": "ebay.co.uk", "source": "ebay", "category": "Shopping", "params": []},
-        {"url": "ebay.com", "source": "ebay", "category": "Shopping", "params": []},
-        {"url": "ebay.com.au", "source": "ebay", "category": "Shopping", "params": []},
-        {"url": "ebay.de", "source": "ebay", "category": "Shopping", "params": []},
-        {"url": "exalead.com", "source": "exalead", "category": "Search", "params": []},
-        {"url": "fandom.com", "source": "fandom", "category": "Social", "params": []},
-        {
-            "url": "folkdirect.com",
-            "source": "folkdirect",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "gather.com", "source": "gather", "category": "Social", "params": []},
-        {
-            "url": "googleplus.com",
-            "source": "googleplus",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "hr.com", "source": "hr", "category": "Social", "params": []},
-        {
-            "url": "instagram.com",
-            "source": "instagram",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "line.com", "source": "line", "category": "Social", "params": []},
-        {"url": "line.me", "source": "line", "category": "Social", "params": []},
-        {
-            "url": "m.cafe.naver.com",
-            "source": "m.cafe.naver",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "m.shopping.naver.com",
-            "source": "m.shopping.naver",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "mocospace.com",
-            "source": "mocospace",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "offer.alibaba.com",
-            "source": "offer.alibaba",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "opendiary.com",
-            "source": "opendiary",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "qwant.com", "source": "qwant", "category": "Search", "params": []},
-        {
-            "url": "se.shopping.net",
-            "source": "se.shopping",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "shopping.naver.com",
-            "source": "shopping.naver",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "socialvibe.com",
-            "source": "socialvibe",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "suche.aol.de",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {"url": "tut.by", "source": "tut", "category": "Search", "params": []},
-        {
-            "url": "tweetdeck.com",
-            "source": "tweetdeck",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "youroom.in", "source": "youroom", "category": "Social", "params": []},
-        {
-            "url": "whatsapp.com",
-            "source": "whatsapp",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "wiki.answers.com",
-            "source": "wiki.answers",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "yandex.com",
-            "source": "Yandex",
-            "category": "Search",
-            "params": ["text"],
-        },
-        {
-            "url": "yandex.com.tr",
-            "source": "yandex",
-            "category": "Search",
-            "params": [],
-        },
-        {"url": "yandex.kz", "source": "yandex", "category": "Search", "params": []},
-        {
-            "url": "yandex.ru",
-            "source": "Yandex",
-            "category": "Search",
-            "params": ["text"],
-        },
-        {"url": "yandex.uz", "source": "yandex", "category": "Search", "params": []},
-        {
-            "url": "allnurses.com",
-            "source": "allnurses",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "br.search.yahoo.com",
-            "source": "br.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "checkout.stripe.com",
-            "source": "checkout.stripe",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "cl.search.yahoo.com",
-            "source": "cl.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {"url": "cozycot.com", "source": "cozycot", "category": "Social", "params": []},
-        {
-            "url": "draugiem.lv",
-            "source": "draugiem",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "epicurious.com",
-            "source": "epicurious",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "glassboard.com",
-            "source": "glassboard",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "goo.gl", "source": "goo", "category": "Social", "params": []},
-        {
-            "url": "hk.search.yahoo.com",
-            "source": "hk.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {"url": "jappy.com", "source": "jappy", "category": "Social", "params": []},
-        {
-            "url": "lifestream.aol.com",
-            "source": "lifestream.aol",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "meetup.com", "source": "meetup", "category": "Social", "params": []},
-        {"url": "onet.pl", "source": "onet", "category": "Search", "params": []},
-        {
-            "url": "pinterest.com.au",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pinterest.ru",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "tw.search.yahoo.com",
-            "source": "tw.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {"url": "yelp.com", "source": "yelp", "category": "Social", "params": []},
-        {"url": "alice.com", "source": "alice", "category": "Search", "params": []},
-        {"url": "ameblo.jp", "source": "ameblo", "category": "Social", "params": []},
-        {
-            "url": "answers.yahoo.com",
-            "source": "answers.yahoo",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "beforeitsnews.com",
-            "source": "beforeitsnews",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "biglobe.com", "source": "biglobe", "category": "Search", "params": []},
-        {
-            "url": "dashboard.twitch.tv",
-            "source": "dashboard.twitch",
-            "category": "Video",
-            "params": [],
-        },
-        {"url": "daum.com", "source": "daum", "category": "Search", "params": []},
-        {
-            "url": "drugs-forum.com",
-            "source": "drugs-forum",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "eniro.com", "source": "eniro", "category": "Search", "params": []},
-        {
-            "url": "espanol.search.yahoo.com",
-            "source": "Yahoo!",
-            "category": "Search",
-            "params": ["p", "q"],
-        },
-        {"url": "fc2.com", "source": "fc2", "category": "Social", "params": []},
-        {
-            "url": "forums.wpcentral.com",
-            "source": "forums.wpcentral",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "fotolog.com", "source": "Fotolog", "category": "Social", "params": []},
-        {"url": "google+.com", "source": "google+", "category": "Social", "params": []},
-        {
-            "url": "instapaper.com",
-            "source": "instapaper",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "iqiyi.com", "source": "iqiyi", "category": "Video", "params": []},
-        {"url": "kvasir.com", "source": "kvasir", "category": "Search", "params": []},
-        {
-            "url": "l.messenger.com",
-            "source": "l.messenger",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "m.yelp.com", "source": "m.yelp", "category": "Social", "params": []},
-        {
-            "url": "m.youtube.com",
-            "source": "m.youtube",
-            "category": "Video",
-            "params": [],
-        },
-        {"url": "najdi.com", "source": "najdi", "category": "Search", "params": []},
-        {"url": "naver.com", "source": "naver", "category": "Search", "params": []},
-        {"url": "onet.com", "source": "onet", "category": "Search", "params": []},
-        {
-            "url": "pinboard.com",
-            "source": "pinboard",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pinterest.cl",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pinterest.ph",
-            "source": "pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "player.vimeo.com",
-            "source": "player.vimeo",
-            "category": "Video",
-            "params": [],
-        },
-        {
-            "url": "posterous.com",
-            "source": "posterous",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "pulse.yahoo.com",
-            "source": "pulse.yahoo",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "rambler.com", "source": "rambler", "category": "Search", "params": []},
-        {"url": "skype.com", "source": "skype", "category": "Social", "params": []},
-        {"url": "social.com", "source": "social", "category": "Social", "params": []},
-        {
-            "url": "stardoll.com",
-            "source": "stardoll",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "th.search.yahoo.com",
-            "source": "th.search.yahoo",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "vampirefreaks.com",
-            "source": "vampirefreaks",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "wordpress.org",
-            "source": "wordpress",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "zalo.com", "source": "zalo", "category": "Social", "params": []},
-        {"url": "1.cz", "source": "1.cz", "category": "Search", "params": ["q"]},
-        {
-            "url": "www.118700.se",
-            "source": "118 700",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "foretag.118700.se",
-            "source": "118 700",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "webben.118700.se",
-            "source": "118 700",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.123people.com",
-            "source": "123people",
-            "category": "Search",
-            "params": ["search_term"],
-        },
-        {
-            "url": "123people.com",
-            "source": "123people",
-            "category": "Search",
-            "params": ["search_term"],
-        },
-        {
-            "url": "so.360.cn",
-            "source": "360search",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.so.com",
-            "source": "360search",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "m.so.com",
-            "source": "360search",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.abacho.de",
-            "source": "Abacho",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.abacho.com",
-            "source": "Abacho",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.abacho.co.uk",
-            "source": "Abacho",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.se.abacho.com",
-            "source": "Abacho",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.tr.abacho.com",
-            "source": "Abacho",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.abacho.at",
-            "source": "Abacho",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.abacho.fr",
-            "source": "Abacho",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.abacho.es",
-            "source": "Abacho",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.abacho.ch",
-            "source": "Abacho",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.abacho.it",
-            "source": "Abacho",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {"url": "abcsok.no", "source": "ABCsøk", "category": "Search", "params": ["q"]},
-        {
-            "url": "verden.abcsok.no",
-            "source": "ABCsøk",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.acoon.de",
-            "source": "Acoon",
-            "category": "Search",
-            "params": ["begriff"],
-        },
-        {
-            "url": "chercherfr.aguea.com",
-            "source": "Aguea",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.allaverksamheter.se",
-            "source": "Allaverksamheter",
-            "category": "Search",
-            "params": ["what"],
-        },
-        {"url": "alexa.com", "source": "Alexa", "category": "Search", "params": ["q"]},
-        {
-            "url": "search.toolbars.alexa.com",
-            "source": "Alexa",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "rechercher.aliceadsl.fr",
-            "source": "Alice Adsl",
-            "category": "Search",
-            "params": ["qs"],
-        },
-        {
-            "url": "all.by",
-            "source": "All.by",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.allesklar.de",
-            "source": "Allesklar",
-            "category": "Search",
-            "params": ["words"],
-        },
-        {
-            "url": "www.allesklar.at",
-            "source": "Allesklar",
-            "category": "Search",
-            "params": ["words"],
-        },
-        {
-            "url": "www.allesklar.ch",
-            "source": "Allesklar",
-            "category": "Search",
-            "params": ["words"],
-        },
-        {
-            "url": "www.alltheinternet.com",
-            "source": "AllTheInternet",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.alltheweb.com",
-            "source": "AllTheWeb",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "alohafind.com",
-            "source": "AlohaFind",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.altavista.com",
-            "source": "AltaVista",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.altavista.com",
-            "source": "AltaVista",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "listings.altavista.com",
-            "source": "AltaVista",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "altavista.de",
-            "source": "AltaVista",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "altavista.fr",
-            "source": "AltaVista",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "altavista.com",
-            "source": "AltaVista",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "be-nl.altavista.com",
-            "source": "AltaVista",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "be-fr.altavista.com",
-            "source": "AltaVista",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.aol.it",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "aolsearch.aol.com",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "www.aolrecherche.aol.fr",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "www.aolrecherches.aol.fr",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "www.aolimages.aol.fr",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "aim.search.aol.com",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "www.recherche.aol.fr",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "recherche.aol.fr",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "find.web.aol.com",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "recherche.aol.ca",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "aolsearch.aol.co.uk",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "aolrecherche.aol.fr",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "sucheaol.aol.de",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "o2suche.aol.de",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "suche.aolsvc.de",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "aolbusqueda.aol.com.mx",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "alicesuche.aol.de",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "alicesuchet.aol.de",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "suchet2.aol.de",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "search.hp.my.aol.com.au",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "search.hp.my.aol.de",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "search.hp.my.aol.it",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "search-intl.netscape.com",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "de.aolsearch.com",
-            "source": "AOL",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "apollo.lv/portal/search/",
-            "source": "Apollo lv",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "apollo7.de",
-            "source": "Apollo7",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "sm.aport.ru",
-            "source": "Aport",
-            "category": "Search",
-            "params": ["r"],
-        },
-        {"url": "arama.com", "source": "Arama", "category": "Search", "params": ["q"]},
-        {
-            "url": "www.arcor.de",
-            "source": "Arcor",
-            "category": "Search",
-            "params": ["keywords"],
-        },
-        {
-            "url": "arianna.libero.it",
-            "source": "Arianna",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.arianna.com",
-            "source": "Arianna",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "web.ask.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "int.ask.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "mws.ask.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "images.ask.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "ask.reference.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "www.askkids.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "iwon.ask.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "www.ask.co.uk",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "www.qbyrd.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "qbyrd.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "www.search-results.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "www1.search-results.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "int.search-results.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "search-results.com",
-            "source": "search-results",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "search.ask.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "avira-int.ask.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "searchqu.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "search.tb.ask.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "nortonsafe.search.ask.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "avira.search.ask.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "int.search.tb.ask.com",
-            "source": "Ask",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "search.avira.com",
-            "source": "Avira SafeSearch",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "search.avira.net",
-            "source": "Avira SafeSearch",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "safesearch.avira.com",
-            "source": "Avira SafeSearch",
-            "category": "Search",
-            "params": ["ask", "q", "searchfor"],
-        },
-        {
-            "url": "searchatlas.centrum.cz",
-            "source": "Atlas",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.auone.jp",
-            "source": "auone",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "sp-search.auone.jp",
-            "source": "auone",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "sp-image.search.auone.jp",
-            "source": "auone Images",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www2.austronaut.at",
-            "source": "Austronaut",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www1.austronaut.at",
-            "source": "Austronaut",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.babylon.com",
-            "source": "Babylon",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "searchassist.babylon.com",
-            "source": "Babylon",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.baidu.com",
-            "source": "Baidu",
-            "category": "Search",
-            "params": ["kw", "wd", "word"],
-        },
-        {
-            "url": "www1.baidu.com",
-            "source": "Baidu",
-            "category": "Search",
-            "params": ["kw", "wd", "word"],
-        },
-        {"url": "m.baidu.com", "source": "m.baidu", "category": "Search", "params": []},
-        {
-            "url": "www.baidu.co.th",
-            "source": "Baidu",
-            "category": "Search",
-            "params": ["kw", "wd", "word"],
-        },
-        {
-            "url": "zhidao.baidu.com",
-            "source": "Baidu",
-            "category": "Search",
-            "params": ["kw", "wd", "word"],
-        },
-        {
-            "url": "tieba.baidu.com",
-            "source": "Baidu",
-            "category": "Search",
-            "params": ["kw", "wd", "word"],
-        },
-        {
-            "url": "news.baidu.com",
-            "source": "Baidu",
-            "category": "Search",
-            "params": ["kw", "wd", "word"],
-        },
-        {
-            "url": "web.gougou.com",
-            "source": "Baidu",
-            "category": "Search",
-            "params": ["search"],
-        },
-        {
-            "url": "cgi.search.biglobe.ne.jp",
-            "source": "Biglobe",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "images.search.biglobe.ne.jp",
-            "source": "Biglobe Images",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "global.bing.com",
-            "source": "Bing",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "msnbc.msn.com",
-            "source": "Bing",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "dizionario.it.msn.com",
-            "source": "Bing",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "enciclopedia.it.msn.com",
-            "source": "Bing",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "cc.bingj.com",
-            "source": "Bing",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "bing.com/images/search",
-            "source": "Bing Images",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "blekko.com",
-            "source": "blekko",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.blogdigger.com",
-            "source": "Blogdigger",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.blogpulse.com",
-            "source": "Blogpulse",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "search.bluewin.ch",
-            "source": "Bluewin",
-            "category": "Search",
-            "params": ["q", "searchterm"],
-        },
-        {
-            "url": "search.brave.com",
-            "source": "Brave",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "web.canoe.ca",
-            "source": "Canoe.ca",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.centrum.cz",
-            "source": "Centrum",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "morfeo.centrum.cz",
-            "source": "Centrum",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.charter.net",
-            "source": "Charter",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "claro-search.com",
-            "source": "Claro Search",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "chat.openai.com",
-            "source": "ChatGPT",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "pesquisa.clix.pt",
-            "source": "Clix",
-            "category": "Search",
-            "params": ["question"],
-        },
-        {
-            "url": "coccoc.com",
-            "source": "Cốc Cốc",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "images.search.yahoo.com",
-            "source": "Yahoo! Images",
-            "category": "Search",
-            "params": ["p", "va"],
-        },
-        {
-            "url": "images.yahoo.com",
-            "source": "Yahoo! Images",
-            "category": "Search",
-            "params": ["p", "va"],
-        },
-        {
-            "url": "cade.images.yahoo.com",
-            "source": "Yahoo! Images",
-            "category": "Search",
-            "params": ["p", "va"],
-        },
-        {
-            "url": "espanol.images.yahoo.com",
-            "source": "Yahoo! Images",
-            "category": "Search",
-            "params": ["p", "va"],
-        },
-        {
-            "url": "qc.images.yahoo.com",
-            "source": "Yahoo! Images",
-            "category": "Search",
-            "params": ["p", "va"],
-        },
-        {
-            "url": "search.yahoo.co.jp",
-            "source": "Yahoo! Japan",
-            "category": "Search",
-            "params": ["p", "vp"],
-        },
-        {
-            "url": "jp.hao123.com",
-            "source": "Yahoo! Japan",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "home.kingsoft.jp",
-            "source": "Yahoo! Japan",
-            "category": "Search",
-            "params": ["keyword"],
-        },
-        {
-            "url": "jwsearch.jword.jp",
-            "source": "Yahoo! Japan",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "image.search.yahoo.co.jp",
-            "source": "Yahoo! Japan Images",
-            "category": "Search",
-            "params": ["p"],
-        },
-        {
-            "url": "video.search.yahoo.co.jp",
-            "source": "Yahoo! Japan Videos",
-            "category": "Search",
-            "params": ["p"],
-        },
-        {
-            "url": "search.yam.com",
-            "source": "Yam",
-            "category": "Search",
-            "params": ["k"],
-        },
-        {
-            "url": "www.yandex.com",
-            "source": "Yandex",
-            "category": "Search",
-            "params": ["text"],
-        },
-        {
-            "url": "clck.yandex.com",
-            "source": "Yandex",
-            "category": "Search",
-            "params": ["text"],
-        },
-        {
-            "url": "m.yandex.com",
-            "source": "Yandex",
-            "category": "Search",
-            "params": ["text"],
-        },
-        {"url": "ya.ru", "source": "Yandex", "category": "Search", "params": ["text"]},
-        {
-            "url": "yabs.yandex.com",
-            "source": "Yandex",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "images.yandex.ru",
-            "source": "Yandex Images",
-            "category": "Search",
-            "params": ["text"],
-        },
-        {
-            "url": "images.yandex.com",
-            "source": "Yandex Images",
-            "category": "Search",
-            "params": ["text"],
-        },
-        {
-            "url": "www.yasni.de",
-            "source": "Yasni",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.yasni.com",
-            "source": "Yasni",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.yasni.co.uk",
-            "source": "Yasni",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.yasni.ch",
-            "source": "Yasni",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.yasni.at",
-            "source": "Yasni",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.yatedo.com",
-            "source": "Yatedo",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.yatedo.fr",
-            "source": "Yatedo",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "yellowmap.de",
-            "source": "Yellowmap",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "search.yippy.com",
-            "source": "Yippy",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.yougoo.fr",
-            "source": "YouGoo",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.zapmeta.com",
-            "source": "Zapmeta",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "zapmeta.com",
-            "source": "Zapmeta",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "uk.zapmeta.com",
-            "source": "Zapmeta",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "ar.zapmeta.com",
-            "source": "Zapmeta",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "au.zapmeta.com",
-            "source": "Zapmeta",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "ca.zapmeta.com",
-            "source": "Zapmeta",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "fi.zapmeta.com",
-            "source": "Zapmeta",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "no.zapmeta.com",
-            "source": "Zapmeta",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "tr.zapmeta.com",
-            "source": "Zapmeta",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "p.zhongsou.com",
-            "source": "Zhongsou",
-            "category": "Search",
-            "params": ["w"],
-        },
-        {
-            "url": "www3.zoek.nl",
-            "source": "Zoek",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.zoeken.nl",
-            "source": "Zoeken",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {"url": "zoohoo.cz", "source": "Zoohoo", "category": "Search", "params": ["q"]},
-        {
-            "url": "www.zoznam.sk",
-            "source": "Zoznam",
-            "category": "Search",
-            "params": ["s"],
-        },
-        {
-            "url": "www.zxuso.com",
-            "source": "Zxuso",
-            "category": "Search",
-            "params": ["wd"],
-        },
-        {
-            "url": "kwzf.net",
-            "source": "묻지마 검색",
-            "category": "Search",
-            "params": ["search"],
-        },
-        {"url": "bsky.app", "source": "Bluesky", "category": "Social", "params": []},
-        {"url": "skyfeed.app", "source": "Bluesky", "category": "Social", "params": []},
-        {
-            "url": "global.cyworld.com",
-            "source": "Cyworld",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "github.com", "source": "GitHub", "category": "Social", "params": []},
-        {
-            "url": "url.google.com",
-            "source": "Google%2B",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "com.google.android.apps.plus",
-            "source": "Google%2B",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "dribbble.com",
-            "source": "Dribbble",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "fetlife.com", "source": "Fetlife", "category": "Social", "params": []},
-        {
-            "url": "flixster.com",
-            "source": "Flixster",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "friendsreunited.com",
-            "source": "Friends Reunited",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "friendster.com",
-            "source": "Friendster",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "gree.jp", "source": "gree", "category": "Social", "params": []},
-        {"url": "away.vk.com", "source": "away.vk", "category": "Social", "params": []},
-        {
-            "url": "blog.feedspot.com",
-            "source": "blog.feedspot",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "chat.zalo.me",
-            "source": "chat.zalo",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "italki.com", "source": "italki", "category": "Social", "params": []},
-        {"url": "msn.com", "source": "msn", "category": "Search", "params": []},
-        {"url": "mylife.com", "source": "mylife", "category": "Social", "params": []},
-        {
-            "url": "secondlife.com",
-            "source": "secondlife",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "br.pinterest.com",
-            "source": "br.pinterest",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "catster.com", "source": "catster", "category": "Social", "params": []},
-        {
-            "url": "email.seznam.cz",
-            "source": "email.seznam",
-            "category": "Search",
-            "params": [],
-        },
-        {"url": "fotki.com", "source": "fotki", "category": "Social", "params": []},
-        {
-            "url": "movabletype.com",
-            "source": "movabletype",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "out.reddit.com",
-            "source": "out.reddit",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "salespider.com",
-            "source": "salespider",
-            "category": "Social",
-            "params": [],
-        },
-        {
-            "url": "uk.shopping.net",
-            "source": "uk.shopping",
-            "category": "Shopping",
-            "params": [],
-        },
-        {
-            "url": "www.sputnik.ru",
-            "source": "Sputnik",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "classic.startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "eu.startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s6-eu5.ixquick.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s2-eu4.startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s6-eu4.startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s7-eu4.startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s1-eu5.startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s2-eu5.startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s4-eu5.startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s5-eu5.startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s6-eu5.startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s7-eu5.startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s8-eu5.startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s10-eu5.startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s11-eu5.startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s12-eu5.startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s13-eu5.startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "s14-eu5.startpage.com",
-            "source": "StartPage",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "startgoogle.startpagina.nl",
-            "source": "Startpagina (Google)",
-            "category": "Search",
-            "params": ["q", "query"],
-        },
-        {
-            "url": "www.startsiden.no",
-            "source": "Startsiden",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "suche.info",
-            "source": "Suche.info",
-            "category": "Search",
-            "params": ["keywords"],
-        },
-        {
-            "url": "www.suchmaschine.com",
-            "source": "Suchmaschine.com",
-            "category": "Search",
-            "params": ["suchstr"],
-        },
-        {
-            "url": "www.suchnase.de",
-            "source": "Suchnase",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "surfcanyon.com",
-            "source": "Surf Canyon",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "suche.t-online.de",
-            "source": "T-Online",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "brisbane.t-online.de",
-            "source": "T-Online",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "navigationshilfe.t-online.de",
-            "source": "T-Online",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.talimba.com",
-            "source": "talimba",
-            "category": "Search",
-            "params": ["search"],
-        },
-        {
-            "url": "www.talktalk.co.uk",
-            "source": "TalkTalk",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "tarmot.com",
-            "source": "Tarmot",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "technorati.com",
-            "source": "Technorati",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.teoma.com",
-            "source": "Teoma",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "buscador.terra.es",
-            "source": "Terra",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "buscador.terra.cl",
-            "source": "Terra",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "buscador.terra.com.br",
-            "source": "Terra",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "search.tiscali.it",
-            "source": "Tiscali",
-            "category": "Search",
-            "params": ["key", "q"],
-        },
-        {
-            "url": "search-dyn.tiscali.it",
-            "source": "Tiscali",
-            "category": "Search",
-            "params": ["key", "q"],
-        },
-        {
-            "url": "hledani.tiscali.cz",
-            "source": "Tiscali",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.tixuma.de",
-            "source": "Tixuma",
-            "category": "Search",
-            "params": ["sc"],
-        },
-        {
-            "url": "www.toolbarhome.com",
-            "source": "Toolbarhome",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "vshare.toolbarhome.com",
-            "source": "Toolbarhome",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.toppreise.ch",
-            "source": "Toppreise.ch",
-            "category": "Search",
-            "params": ["search"],
-        },
-        {
-            "url": "toppreise.ch",
-            "source": "Toppreise.ch",
-            "category": "Search",
-            "params": ["search"],
-        },
-        {
-            "url": "fr.toppreise.ch",
-            "source": "Toppreise.ch",
-            "category": "Search",
-            "params": ["search"],
-        },
-        {
-            "url": "de.toppreise.ch",
-            "source": "Toppreise.ch",
-            "category": "Search",
-            "params": ["search"],
-        },
-        {
-            "url": "en.toppreise.ch",
-            "source": "Toppreise.ch",
-            "category": "Search",
-            "params": ["search"],
-        },
-        {
-            "url": "www.trouvez.com",
-            "source": "Trouvez.com",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.trovarapido.com",
-            "source": "TrovaRapido",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.trusted-search.com",
-            "source": "Trusted Search",
-            "category": "Search",
-            "params": ["w"],
-        },
-        {
-            "url": "www.twingly.com",
-            "source": "Twingly",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "busca.uol.com.br",
-            "source": "uol.com.br",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.url.org",
-            "source": "URL.ORGanzier",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.vinden.nl",
-            "source": "Vinden",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.vindex.nl",
-            "source": "Vindex",
-            "category": "Search",
-            "params": ["search_for"],
-        },
-        {
-            "url": "search.vindex.nl",
-            "source": "Vindex",
-            "category": "Search",
-            "params": ["search_for"],
-        },
-        {
-            "url": "ricerca.virgilio.it",
-            "source": "Virgilio",
-            "category": "Search",
-            "params": ["qs"],
-        },
-        {
-            "url": "ricercaimmagini.virgilio.it",
-            "source": "Virgilio",
-            "category": "Search",
-            "params": ["qs"],
-        },
-        {
-            "url": "ricercavideo.virgilio.it",
-            "source": "Virgilio",
-            "category": "Search",
-            "params": ["qs"],
-        },
-        {
-            "url": "ricercanews.virgilio.it",
-            "source": "Virgilio",
-            "category": "Search",
-            "params": ["qs"],
-        },
-        {
-            "url": "mobile.virgilio.it",
-            "source": "Virgilio",
-            "category": "Search",
-            "params": ["qrs"],
-        },
-        {
-            "url": "search.ke.voila.fr",
-            "source": "Voila",
-            "category": "Search",
-            "params": ["rdata"],
-        },
-        {
-            "url": "www.lemoteur.fr",
-            "source": "Voila",
-            "category": "Search",
-            "params": ["rdata"],
-        },
-        {
-            "url": "web.volny.cz",
-            "source": "Volny",
-            "category": "Search",
-            "params": ["search"],
-        },
-        {
-            "url": "www.walhello.info",
-            "source": "Walhello",
-            "category": "Search",
-            "params": ["key"],
-        },
-        {
-            "url": "www.walhello.com",
-            "source": "Walhello",
-            "category": "Search",
-            "params": ["key"],
-        },
-        {
-            "url": "www.walhello.de",
-            "source": "Walhello",
-            "category": "Search",
-            "params": ["key"],
-        },
-        {
-            "url": "www.walhello.nl",
-            "source": "Walhello",
-            "category": "Search",
-            "params": ["key"],
-        },
-        {
-            "url": "suche.web.de",
-            "source": "Web.de",
-            "category": "Search",
-            "params": ["q", "su"],
-        },
-        {
-            "url": "m.suche.web.de",
-            "source": "Web.de",
-            "category": "Search",
-            "params": ["q", "su"],
-        },
-        {
-            "url": "www.web.nl",
-            "source": "Web.nl",
-            "category": "Search",
-            "params": ["zoekwoord"],
-        },
-        {
-            "url": "www.weborama.fr",
-            "source": "weborama",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.websearch.com",
-            "source": "WebSearch",
-            "category": "Search",
-            "params": ["q", "qkw"],
-        },
-        {
-            "url": "fr.wedoo.com",
-            "source": "Wedoo",
-            "category": "Search",
-            "params": ["keyword"],
-        },
-        {
-            "url": "en.wedoo.com",
-            "source": "Wedoo",
-            "category": "Search",
-            "params": ["keyword"],
-        },
-        {
-            "url": "es.wedoo.com",
-            "source": "Wedoo",
-            "category": "Search",
-            "params": ["keyword"],
-        },
-        {
-            "url": "search.winamp.com",
-            "source": "Winamp",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "szukaj.wp.pl",
-            "source": "Wirtualna Polska",
-            "category": "Search",
-            "params": ["szukaj"],
-        },
-        {
-            "url": "www.witch.de",
-            "source": "Witch",
-            "category": "Search",
-            "params": ["search"],
-        },
-        {
-            "url": "www.woopie.jp",
-            "source": "Woopie",
-            "category": "Search",
-            "params": ["kw"],
-        },
-        {
-            "url": "search.www.ee",
-            "source": "www värav",
-            "category": "Search",
-            "params": ["query"],
-        },
-        {
-            "url": "www.x-recherche.com",
-            "source": "X-Recherche",
-            "category": "Search",
-            "params": ["mots"],
-        },
-        {
-            "url": "search.yahoo.com",
-            "source": "Yahoo!",
-            "category": "Search",
-            "params": ["p", "q"],
-        },
-        {
-            "url": "cade.yahoo.com",
-            "source": "Yahoo!",
-            "category": "Search",
-            "params": ["p", "q"],
-        },
-        {
-            "url": "qc.search.yahoo.com",
-            "source": "Yahoo!",
-            "category": "Search",
-            "params": ["p", "q"],
-        },
-        {
-            "url": "one.cn.yahoo.com",
-            "source": "Yahoo!",
-            "category": "Search",
-            "params": ["p", "q"],
-        },
-        {
-            "url": "r.search.yahoo.com",
-            "source": "Yahoo!",
-            "category": "Search",
-            "params": [],
-        },
-        {
-            "url": "www.cercato.it",
-            "source": "Yahoo!",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.offerbox.com",
-            "source": "Yahoo!",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "www.benefind.de",
-            "source": "Yahoo!",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "ys.mirostart.com",
-            "source": "Yahoo!",
-            "category": "Search",
-            "params": ["q"],
-        },
-        {
-            "url": "search.yahoo.com/search/dir",
-            "source": "Yahoo! Directory",
-            "category": "Search",
-            "params": ["p"],
-        },
-        {"url": "comcast.com", "source": "comcast", "category": "Search", "params": []},
-        {"url": "dol2day.com", "source": "dol2day", "category": "Social", "params": []},
-        {
-            "url": "listography.com",
-            "source": "listography",
-            "category": "Social",
-            "params": [],
-        },
-        {"url": "rakuten.com", "source": "rakuten", "category": "Search", "params": []},
-        {"url": "wakoopa.com", "source": "wakoopa", "category": "Social", "params": []},
-        {"url": "wechat.com", "source": "wechat", "category": "Social", "params": []},
-        {
-            "url": "za.pinterest.com",
-            "source": "za.pinterest",
-            "category": "Social",
-            "params": [],
-        },
+    {
+        "url": "lang-8.com",
+        "source": "lang-8",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "43things.com",
+        "source": "43things",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "hatena.com",
+        "source": "Hatena",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "activerain.com",
+        "source": "activerain",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "linkedin.com",
+        "source": "linkedin",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "51.com",
+        "source": "51",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "activeworlds.com",
+        "source": "activeworlds",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "avg.com",
+        "source": "avg",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "alibaba.com",
+        "source": "alibaba",
+        "category": "Shopping",
+        "params": []
+    },
+    {
+        "url": "babylon.com",
+        "source": "babylon",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "bebo.com",
+        "source": "Bebo",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "searchya.com",
+        "source": "InfoSpace",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "imageshack.com",
+        "source": "imageshack",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "addthis.com",
+        "source": "addthis",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "igshopping.com",
+        "source": "IGShopping",
+        "category": "Shopping",
+        "params": []
+    },
+    {
+        "url": "livejournal.com",
+        "source": "livejournal",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "blogspot.com",
+        "source": "blogspot",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "cellufun.com",
+        "source": "cellufun",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "doostang.com",
+        "source": "doostang",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "alumniclass.com",
+        "source": "alumniclass",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "artstation.com",
+        "source": "artstation",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "askubuntu.com",
+        "source": "askubuntu",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "americantowns.com",
+        "source": "americantowns",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "anobii.com",
+        "source": "anobii",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "daemon-search.com",
+        "source": "Daemon search",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "multiply.com",
+        "source": "Multiply",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "myheritage.com",
+        "source": "myheritage",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "myspace.com",
+        "source": "myspace",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "myyearbook.com",
+        "source": "myYearbook",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "ixquick.com",
+        "source": "IxQuick",
+        "category": "Search",
+        "params": [
+            "query"
+        ]
+    },
+    {
+        "url": "ask.com",
+        "source": "Ask",
+        "category": "Search",
+        "params": [
+            "ask",
+            "q",
+            "searchfor"
+        ]
+    },
+    {
+        "url": "bing.com",
+        "source": "Bing",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "blackcareernetwork.com",
+        "source": "blackcareernetwork",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "blackplanet.com",
+        "source": "blackplanet",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "blogster.com",
+        "source": "blogster",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "google.com",
+        "source": "google",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "etsy.com",
+        "source": "etsy",
+        "category": "Shopping",
+        "params": []
+    },
+    {
+        "url": "excite.com",
+        "source": "excite",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "feedspot.com",
+        "source": "feedspot",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "filmaffinity.com",
+        "source": "filmaffinity",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "flipboard.com",
+        "source": "flipboard",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "foursquare.com",
+        "source": "Foursquare",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "getpocket.com",
+        "source": "getpocket",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "goodreads.com",
+        "source": "goodreads",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "incredimail.com",
+        "source": "incredimail",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "intherooms.com",
+        "source": "intherooms",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "digg.com",
+        "source": "digg",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "netlog.com",
+        "source": "Netlog",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "orkut.com",
+        "source": "Orkut",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "peepeth.com",
+        "source": "Peepeth",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "pinterest.com",
+        "source": "pinterest",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "plaxo.com",
+        "source": "Plaxo",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "reddit.com",
+        "source": "reddit",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "renren.com",
+        "source": "renren",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "skyrock.com",
+        "source": "skyrock",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "snapchat.com",
+        "source": "snapchat",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "sonico.com",
+        "source": "Sonico.com",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "stackoverflow.com",
+        "source": "stackoverflow",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "wwwgoogle.com",
+        "source": "Google",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "gogole.com",
+        "source": "Google",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "gppgle.com",
+        "source": "Google",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "ancestry.com",
+        "source": "ancestry",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "baby-gaga.com",
+        "source": "baby-gaga",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "badoo.com",
+        "source": "Badoo",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "baidu.com",
+        "source": "Baidu",
+        "category": "Search",
+        "params": [
+            "kw",
+            "wd",
+            "word"
+        ]
+    },
+    {
+        "url": "disqus.com",
+        "source": "disqus",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "dogster.com",
+        "source": "dogster",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "elftown.com",
+        "source": "elftown",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "fark.com",
+        "source": "fark",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "foodservice.com",
+        "source": "foodservice",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "geni.com",
+        "source": "geni",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "glassdoor.com",
+        "source": "glassdoor",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "globo.com",
+        "source": "globo",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "gowalla.com",
+        "source": "gowalla",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "kakaocorp.com",
+        "source": "kakaocorp",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "listal.com",
+        "source": "listal",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "junglekey.com",
+        "source": "Jungle Key",
+        "category": "Search",
+        "params": [
+            "query"
+        ]
+    },
+    {
+        "url": "k9safesearch.com",
+        "source": "K9 Safe Search",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "lycos.com",
+        "source": "lycos",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "bloggang.com",
+        "source": "bloggang",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "blogher.com",
+        "source": "blogher",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "buzzfeed.com",
+        "source": "buzzfeed",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "camospace.com",
+        "source": "camospace",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "classquest.com",
+        "source": "classquest",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "conduit.com",
+        "source": "conduit",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "allrecipes.com",
+        "source": "allrecipes",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "duckduckgo.com",
+        "source": "duckduckgo",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "crunchyroll.com",
+        "source": "crunchyroll",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "fubar.com",
+        "source": "fubar",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "google-play.com",
+        "source": "google-play",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "googlegroups.com",
+        "source": "googlegroups",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "hubculture.com",
+        "source": "hubculture",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "aolanswers.com",
+        "source": "aolanswers",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "bharatstudent.com",
+        "source": "bharatstudent",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "bloglines.com",
+        "source": "bloglines",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "amazon.com",
+        "source": "amazon",
+        "category": "Shopping",
+        "params": []
+    },
+    {
+        "url": "answerbag.com",
+        "source": "answerbag",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "plusnetwork.com",
+        "source": "PlusNetwork",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "blogsome.com",
+        "source": "blogsome",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "brightkite.com",
+        "source": "brightkite",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "fanpop.com",
+        "source": "fanpop",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "brizzly.com",
+        "source": "brizzly",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "canalblog.com",
+        "source": "canalblog",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "curiositystream.com",
+        "source": "curiositystream",
+        "category": "Video",
+        "params": []
+    },
+    {
+        "url": "dailymotion.com",
+        "source": "dailymotion",
+        "category": "Video",
+        "params": []
+    },
+    {
+        "url": "dianping.com",
+        "source": "dianping",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "douban.com",
+        "source": "Douban",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "feministing.com",
+        "source": "feministing",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "friendfeed.com",
+        "source": "friendfeed",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "imvu.com",
+        "source": "imvu",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "mix.com",
+        "source": "mix",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "ning.com",
+        "source": "ning",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "screenrant.com",
+        "source": "screenrant",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "seznam.com",
+        "source": "seznam",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "shopify.com",
+        "source": "shopify",
+        "category": "Shopping",
+        "params": []
+    },
+    {
+        "url": "shopzilla.com",
+        "source": "shopzilla",
+        "category": "Shopping",
+        "params": []
+    },
+    {
+        "url": "smartnews.com",
+        "source": "smartnews",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "ssense.com",
+        "source": "ssense",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "stackexchange.com",
+        "source": "stackexchange",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "toolbox.com",
+        "source": "toolbox",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "vimeo.com",
+        "source": "vimeo",
+        "category": "Video",
+        "params": []
+    },
+    {
+        "url": "vk.com",
+        "source": "Vkontakte",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "webshots.com",
+        "source": "webshots",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "weibo.com",
+        "source": "Weibo",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "gibiru.com",
+        "source": "Gibiru",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "weread.com",
+        "source": "weread",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "wistia.com",
+        "source": "wistia",
+        "category": "Video",
+        "params": []
+    },
+    {
+        "url": "zooppa.com",
+        "source": "zooppa",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "blog.com",
+        "source": "blog",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "blogs.com",
+        "source": "blogs",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "buzznet.com",
+        "source": "Buzznet",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "disneyplus.com",
+        "source": "disneyplus",
+        "category": "Video",
+        "params": []
+    },
+    {
+        "url": "dzone.com",
+        "source": "dzone",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "everforo.com",
+        "source": "everforo",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "facebook.com",
+        "source": "Facebook",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "goldstar.com",
+        "source": "goldstar",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "godtube.com",
+        "source": "godtube",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "gulli.com",
+        "source": "gulli",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "hi5.com",
+        "source": "hi5",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "hootsuite.com",
+        "source": "hootsuite",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "ryze.com",
+        "source": "ryze",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "simplycodes.com",
+        "source": "simplycodes",
+        "category": "Shopping",
+        "params": []
+    },
+    {
+        "url": "superuser.com",
+        "source": "superuser",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "tuenti.com",
+        "source": "Tuenti",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "woot.com",
+        "source": "woot",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "yammer.com",
+        "source": "yammer",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "gamerdna.com",
+        "source": "gamerdna",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "hoverspot.com",
+        "source": "hoverspot",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "gooblog.com",
+        "source": "gooblog",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "govloop.com",
+        "source": "govloop",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "ibibo.com",
+        "source": "ibibo",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "ig.com",
+        "source": "ig",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "iq.com",
+        "source": "iq",
+        "category": "Video",
+        "params": []
+    },
+    {
+        "url": "jammerdirect.com",
+        "source": "jammerdirect",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "kaneva.com",
+        "source": "kaneva",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "livedoor.com",
+        "source": "livedoor",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "menuism.com",
+        "source": "menuism",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "librarything.com",
+        "source": "librarything",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "blurtit.com",
+        "source": "blurtit",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "cnn.com",
+        "source": "cnn",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "cocolog-nifty.com",
+        "source": "cocolog-nifty",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "cyworld.com",
+        "source": "cyworld",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "deluxe.com",
+        "source": "deluxe",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "mubi.com",
+        "source": "mubi",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "netvibes.com",
+        "source": "netvibes",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "photobucket.com",
+        "source": "photobucket",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "sharethis.com",
+        "source": "sharethis",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "shvoong.com",
+        "source": "shvoong",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "stickam.com",
+        "source": "stickam",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "stripe.com",
+        "source": "stripe",
+        "category": "Shopping",
+        "params": []
+    },
+    {
+        "url": "ted.com",
+        "source": "ted",
+        "category": "Video",
+        "params": []
+    },
+    {
+        "url": "twitter.com",
+        "source": "twitter",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "ushareit.com",
+        "source": "ushareit",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "veoh.com",
+        "source": "veoh",
+        "category": "Video",
+        "params": []
+    },
+    {
+        "url": "walmart.com",
+        "source": "walmart",
+        "category": "Shopping",
+        "params": []
+    },
+    {
+        "url": "wikihow.com",
+        "source": "wikihow",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "athlinks.com",
+        "source": "athlinks",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "xanga.com",
+        "source": "xanga",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "youku.com",
+        "source": "youku",
+        "category": "Video",
+        "params": []
+    },
+    {
+        "url": "messenger.com",
+        "source": "messenger",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "qapacity.com",
+        "source": "qapacity",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "quechup.com",
+        "source": "quechup",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "quora.com",
+        "source": "quora",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "scvngr.com",
+        "source": "scvngr",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "serverfault.com",
+        "source": "serverfault",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "spoke.com",
+        "source": "spoke",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "stackapps.com",
+        "source": "stackapps",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "tencent.com",
+        "source": "tencent",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "travellerspoint.com",
+        "source": "travellerspoint",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "trombi.com",
+        "source": "trombi",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "urbanspoon.com",
+        "source": "urbanspoon",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "wattpad.com",
+        "source": "wattpad",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "diigo.com",
+        "source": "diigo",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "dogpile.com",
+        "source": "InfoSpace",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "dopplr.com",
+        "source": "dopplr",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "fb.com",
+        "source": "fb",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "houzz.com",
+        "source": "houzz",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "hulu.com",
+        "source": "hulu",
+        "category": "Video",
+        "params": []
+    },
+    {
+        "url": "nightlifelink.com",
+        "source": "nightlifelink",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "overblog.com",
+        "source": "overblog",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "plurk.com",
+        "source": "plurk",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "reverbnation.com",
+        "source": "reverbnation",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "startsiden.com",
+        "source": "startsiden",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "talkbiznow.com",
+        "source": "talkbiznow",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "tripadvisor.com",
+        "source": "tripadvisor",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "trustpilot.com",
+        "source": "trustpilot",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "tudou.com",
+        "source": "tudou",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "scour.com",
+        "source": "Scour.com",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "searchalot.com",
+        "source": "Searchalot",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "searchlock.com",
+        "source": "SearchLock",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "setooz.com",
+        "source": "Setooz",
+        "category": "Search",
+        "params": [
+            "query"
+        ]
+    },
+    {
+        "url": "blogger.com",
+        "source": "blogger",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "care2.com",
+        "source": "care2",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "classmates.com",
+        "source": "Classmates.com",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "wordpress.com",
+        "source": "wordpress",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "deviantart.com",
+        "source": "deviantart",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "extole.com",
+        "source": "extole",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "faceparty.com",
+        "source": "faceparty",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "flickr.com",
+        "source": "flickr",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "gaiaonline.com",
+        "source": "Gaia Online",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "habbo.com",
+        "source": "Haboo",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "insanejournal.com",
+        "source": "insanejournal",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "mouthshut.com",
+        "source": "mouthshut",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "netflix.com",
+        "source": "netflix",
+        "category": "Video",
+        "params": []
+    },
+    {
+        "url": "pingsta.com",
+        "source": "pingsta",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "redux.com",
+        "source": "redux",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "sweeva.com",
+        "source": "sweeva",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "sogou.com",
+        "source": "sogou",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "kaboodle.com",
+        "source": "kaboodle",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "mercadolibre.com",
+        "source": "mercadolibre",
+        "category": "Shopping",
+        "params": []
+    },
+    {
+        "url": "newsshowcase.com",
+        "source": "newsshowcase",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "onstartups.com",
+        "source": "onstartups",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "reunion.com",
+        "source": "reunion",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "scribd.com",
+        "source": "scribd",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "shareit.com",
+        "source": "shareit",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "spruz.com",
+        "source": "spruz",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "techmeme.com",
+        "source": "techmeme",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "terra.com",
+        "source": "terra",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "tinyurl.com",
+        "source": "tinyurl",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "twitch.com",
+        "source": "twitch",
+        "category": "Video",
+        "params": []
+    },
+    {
+        "url": "typepad.com",
+        "source": "typepad",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "vampirerave.com",
+        "source": "vampirerave",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "virgilio.com",
+        "source": "virgilio",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "tiktok.com",
+        "source": "TikTok",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "xing.com",
+        "source": "XING",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "yahoo.com",
+        "source": "yahoo",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "youtube.com",
+        "source": "youtube",
+        "category": "Video",
+        "params": []
+    },
+    {
+        "url": "kakao.com",
+        "source": "kakao",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "livedoorblog.com",
+        "source": "livedoorblog",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "nexopia.com",
+        "source": "nexopia",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "niconico.com",
+        "source": "niconico",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "ravelry.com",
+        "source": "ravelry",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "tagged.com",
+        "source": "tagged",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "twoo.com",
+        "source": "twoo",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "utreon.com",
+        "source": "utreon",
+        "category": "Video",
+        "params": []
+    },
+    {
+        "url": "mymodernmet.com",
+        "source": "mymodernmet",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "over-blog.com",
+        "source": "over-blog",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "so.com",
+        "source": "so",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "taggedmail.com",
+        "source": "taggedmail",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "ukr.com",
+        "source": "ukr",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "weebly.com",
+        "source": "weebly",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "tumblr.com",
+        "source": "tumblr",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "stumbleupon.com",
+        "source": "StumbleUpon",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "v2ex.com",
+        "source": "V2EX",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "viadeo.com",
+        "source": "Viadeo",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "wayn.com",
+        "source": "WAYN",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "weeworld.com",
+        "source": "WeeWorld",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "workplace.com",
+        "source": "Workplace",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "googel.com",
+        "source": "Google",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "darkoogle.com",
+        "source": "Google",
+        "category": "Search",
+        "params": [
+            "query"
+        ]
+    },
+    {
+        "url": "wow.com",
+        "source": "Google",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "gfsoso.com",
+        "source": "Google",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "monumentbrowser.com",
+        "source": "Google",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "googlesyndicatedsearch.com",
+        "source": "Google syndicated search",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "infospace.com",
+        "source": "InfoSpace",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "tattoodle.com",
+        "source": "InfoSpace",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "metacrawler.com",
+        "source": "InfoSpace",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "webfetch.com",
+        "source": "InfoSpace",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "webcrawler.com",
+        "source": "InfoSpace",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "aol.com",
+        "source": "aol",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "asmallworld.com",
+        "source": "asmallworld",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "cafemom.com",
+        "source": "cafemom",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "care.com",
+        "source": "care",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "chegg.com",
+        "source": "chegg",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "chicagonow.com",
+        "source": "chicagonow",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "crackle.com",
+        "source": "crackle",
+        "category": "Video",
+        "params": []
+    },
+    {
+        "url": "ebay.com",
+        "source": "ebay",
+        "category": "Shopping",
+        "params": []
+    },
+    {
+        "url": "exalead.com",
+        "source": "exalead",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "fandom.com",
+        "source": "fandom",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "folkdirect.com",
+        "source": "folkdirect",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "gather.com",
+        "source": "gather",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "googleplus.com",
+        "source": "googleplus",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "hr.com",
+        "source": "hr",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "instagram.com",
+        "source": "instagram",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "line.com",
+        "source": "line",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "mocospace.com",
+        "source": "mocospace",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "opendiary.com",
+        "source": "opendiary",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "qwant.com",
+        "source": "qwant",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "socialvibe.com",
+        "source": "socialvibe",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "tweetdeck.com",
+        "source": "tweetdeck",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "whatsapp.com",
+        "source": "whatsapp",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "yandex.com",
+        "source": "Yandex",
+        "category": "Search",
+        "params": [
+            "text"
+        ]
+    },
+    {
+        "url": "allnurses.com",
+        "source": "allnurses",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "cozycot.com",
+        "source": "cozycot",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "epicurious.com",
+        "source": "epicurious",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "glassboard.com",
+        "source": "glassboard",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "jappy.com",
+        "source": "jappy",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "meetup.com",
+        "source": "meetup",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "yelp.com",
+        "source": "yelp",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "alice.com",
+        "source": "alice",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "beforeitsnews.com",
+        "source": "beforeitsnews",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "biglobe.com",
+        "source": "biglobe",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "daum.com",
+        "source": "daum",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "drugs-forum.com",
+        "source": "drugs-forum",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "eniro.com",
+        "source": "eniro",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "fc2.com",
+        "source": "fc2",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "fotolog.com",
+        "source": "Fotolog",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "google+.com",
+        "source": "google+",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "instapaper.com",
+        "source": "instapaper",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "iqiyi.com",
+        "source": "iqiyi",
+        "category": "Video",
+        "params": []
+    },
+    {
+        "url": "kvasir.com",
+        "source": "kvasir",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "najdi.com",
+        "source": "najdi",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "naver.com",
+        "source": "naver",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "onet.com",
+        "source": "onet",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "pinboard.com",
+        "source": "pinboard",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "posterous.com",
+        "source": "posterous",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "rambler.com",
+        "source": "rambler",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "skype.com",
+        "source": "skype",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "social.com",
+        "source": "social",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "stardoll.com",
+        "source": "stardoll",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "vampirefreaks.com",
+        "source": "vampirefreaks",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "zalo.com",
+        "source": "zalo",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "123people.com",
+        "source": "123people",
+        "category": "Search",
+        "params": [
+            "search_term"
+        ]
+    },
+    {
+        "url": "alexa.com",
+        "source": "Alexa",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "alohafind.com",
+        "source": "AlohaFind",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "altavista.com",
+        "source": "AltaVista",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "arama.com",
+        "source": "Arama",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "qbyrd.com",
+        "source": "Ask",
+        "category": "Search",
+        "params": [
+            "ask",
+            "q",
+            "searchfor"
+        ]
+    },
+    {
+        "url": "search-results.com",
+        "source": "search-results",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "searchqu.com",
+        "source": "Ask",
+        "category": "Search",
+        "params": [
+            "ask",
+            "q",
+            "searchfor"
+        ]
+    },
+    {
+        "url": "blekko.com",
+        "source": "blekko",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "claro-search.com",
+        "source": "Claro Search",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "coccoc.com",
+        "source": "C\u1ed1c C\u1ed1c",
+        "category": "Search",
+        "params": [
+            "query"
+        ]
+    },
+    {
+        "url": "zapmeta.com",
+        "source": "Zapmeta",
+        "category": "Search",
+        "params": [
+            "q",
+            "query"
+        ]
+    },
+    {
+        "url": "github.com",
+        "source": "GitHub",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "dribbble.com",
+        "source": "Dribbble",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "fetlife.com",
+        "source": "Fetlife",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "flixster.com",
+        "source": "Flixster",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "friendsreunited.com",
+        "source": "Friends Reunited",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "friendster.com",
+        "source": "Friendster",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "italki.com",
+        "source": "italki",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "msn.com",
+        "source": "msn",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "mylife.com",
+        "source": "mylife",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "secondlife.com",
+        "source": "secondlife",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "catster.com",
+        "source": "catster",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "fotki.com",
+        "source": "fotki",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "movabletype.com",
+        "source": "movabletype",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "salespider.com",
+        "source": "salespider",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "startpage.com",
+        "source": "StartPage",
+        "category": "Search",
+        "params": [
+            "query"
+        ]
+    },
+    {
+        "url": "surfcanyon.com",
+        "source": "Surf Canyon",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "tarmot.com",
+        "source": "Tarmot",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "technorati.com",
+        "source": "Technorati",
+        "category": "Search",
+        "params": [
+            "q"
+        ]
+    },
+    {
+        "url": "comcast.com",
+        "source": "comcast",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "dol2day.com",
+        "source": "dol2day",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "listography.com",
+        "source": "listography",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "rakuten.com",
+        "source": "rakuten",
+        "category": "Search",
+        "params": []
+    },
+    {
+        "url": "wakoopa.com",
+        "source": "wakoopa",
+        "category": "Social",
+        "params": []
+    },
+    {
+        "url": "wechat.com",
+        "source": "wechat",
+        "category": "Social",
+        "params": []
+    }
     ]
 
     # convert referrer_url_source_category_list to a dictionary for faster lookup


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

- Data API limit a single sql less than 100K.
- remove all domains that do not end with `.com`
- only keep first level domains, remove domains like 'xxx.xxxx.com'
- the sql file is 63K now

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend