### PR TITLE
fix: escaped HTML in dashboard title

### DIFF
--- a/src/control-plane/backend/lambda/api/service/quicksight/templates/attribution-table-chart.json
+++ b/src/control-plane/backend/lambda/api/service/quicksight/templates/attribution-table-chart.json
@@ -3,13 +3,13 @@
     "VisualId":"{{visualId}}",
     "Title":{
         "FormatText": {
-            "PlainText": "{{title}}"
+            "PlainText": "{{{title}}}"
         },
         "Visibility":"VISIBLE"
     },
     "Subtitle":{
         "FormatText": {
-            "PlainText": "{{subTitle}}"
+            "PlainText": "{{{subTitle}}}"
         },
         "Visibility":"VISIBLE"
     },

--- a/src/control-plane/backend/lambda/api/service/quicksight/templates/event-bar-chart-multiple.json
+++ b/src/control-plane/backend/lambda/api/service/quicksight/templates/event-bar-chart-multiple.json
@@ -4,13 +4,13 @@
     "VisualId":"{{visualId}}",
     "Title":{
         "FormatText": {
-            "PlainText": "{{title}}"
+            "PlainText": "{{{title}}}"
         },
         "Visibility":"VISIBLE"
     },
     "Subtitle":{
         "FormatText": {
-            "PlainText": "{{subTitle}}"
+            "PlainText": "{{{subTitle}}}"
         },
         "Visibility":"VISIBLE"
     },

--- a/src/control-plane/backend/lambda/api/service/quicksight/templates/event-bar-chart.json
+++ b/src/control-plane/backend/lambda/api/service/quicksight/templates/event-bar-chart.json
@@ -4,13 +4,13 @@
     "VisualId":"{{visualId}}",
     "Title":{
         "FormatText": {
-            "PlainText": "{{title}}"
+            "PlainText": "{{{title}}}"
         },
         "Visibility":"VISIBLE"
     },
     "Subtitle":{
         "FormatText": {
-            "PlainText": "{{subTitle}}"
+            "PlainText": "{{{subTitle}}}"
         },
         "Visibility":"VISIBLE"
     },

--- a/src/control-plane/backend/lambda/api/service/quicksight/templates/event-line-chart-multiple.json
+++ b/src/control-plane/backend/lambda/api/service/quicksight/templates/event-line-chart-multiple.json
@@ -3,13 +3,13 @@
         "VisualId":"{{visualId}}",
         "Title":{
             "FormatText": {
-                "PlainText": "{{title}}"
+                "PlainText": "{{{title}}}"
             },
             "Visibility":"VISIBLE"
         },
         "Subtitle":{
             "FormatText": {
-                "PlainText": "{{subTitle}}"
+                "PlainText": "{{{subTitle}}}"
             },
             "Visibility":"VISIBLE"
         },

--- a/src/control-plane/backend/lambda/api/service/quicksight/templates/event-line-chart.json
+++ b/src/control-plane/backend/lambda/api/service/quicksight/templates/event-line-chart.json
@@ -3,13 +3,13 @@
         "VisualId":"{{visualId}}",
         "Title":{
             "FormatText": {
-                "PlainText": "{{title}}"
+                "PlainText": "{{{title}}}"
             },
             "Visibility":"VISIBLE"
         },
         "Subtitle":{
             "FormatText": {
-                "PlainText": "{{subTitle}}"
+                "PlainText": "{{{subTitle}}}"
             },
             "Visibility":"VISIBLE"
         },

--- a/src/control-plane/backend/lambda/api/service/quicksight/templates/event-pivot-table-chart-multiple.json
+++ b/src/control-plane/backend/lambda/api/service/quicksight/templates/event-pivot-table-chart-multiple.json
@@ -3,7 +3,7 @@
       "VisualId": "{{visualId}}",
       "Title": {
           "FormatText": {
-            "PlainText": "{{title}}"
+            "PlainText": "{{{title}}}"
           },
           "Visibility": "VISIBLE"
       },

--- a/src/control-plane/backend/lambda/api/service/quicksight/templates/event-pivot-table-chart.json
+++ b/src/control-plane/backend/lambda/api/service/quicksight/templates/event-pivot-table-chart.json
@@ -3,7 +3,7 @@
       "VisualId": "{{visualId}}",
       "Title": {
           "FormatText": {
-            "PlainText": "{{title}}"
+            "PlainText": "{{{title}}}"
           },
           "Visibility": "VISIBLE"
       },

--- a/src/control-plane/backend/lambda/api/service/quicksight/templates/event-table-chart.json
+++ b/src/control-plane/backend/lambda/api/service/quicksight/templates/event-table-chart.json
@@ -3,13 +3,13 @@
       "VisualId":"{{visualId}}",
         "Title":{
             "FormatText": {
-                "PlainText": "{{title}}"
+                "PlainText": "{{{title}}}"
             },
             "Visibility":"VISIBLE"
         },
         "Subtitle":{
             "FormatText": {
-                "PlainText": "{{subTitle}}"
+                "PlainText": "{{{subTitle}}}"
             },
             "Visibility":"VISIBLE"
         },

--- a/src/control-plane/backend/lambda/api/service/quicksight/templates/funnel-bar-chart-multiple.json
+++ b/src/control-plane/backend/lambda/api/service/quicksight/templates/funnel-bar-chart-multiple.json
@@ -4,13 +4,13 @@
     "VisualId": "{{visualId}}",
     "Title":{
         "FormatText": {
-            "PlainText": "{{title}}"
+            "PlainText": "{{{title}}}"
         },
         "Visibility":"VISIBLE"
     },
     "Subtitle":{
         "FormatText": {
-            "PlainText": "{{subTitle}}"
+            "PlainText": "{{{subTitle}}}"
         },
         "Visibility":"VISIBLE"
     },

--- a/src/control-plane/backend/lambda/api/service/quicksight/templates/funnel-bar-chart.json
+++ b/src/control-plane/backend/lambda/api/service/quicksight/templates/funnel-bar-chart.json
@@ -4,13 +4,13 @@
     "VisualId": "{{visualId}}",
     "Title":{
         "FormatText": {
-            "PlainText": "{{title}}"
+            "PlainText": "{{{title}}}"
         },
         "Visibility":"VISIBLE"
     },
     "Subtitle":{
         "FormatText": {
-            "PlainText": "{{subTitle}}"
+            "PlainText": "{{{subTitle}}}"
         },
         "Visibility":"VISIBLE"
     },

--- a/src/control-plane/backend/lambda/api/service/quicksight/templates/funnel-funnel-chart.json
+++ b/src/control-plane/backend/lambda/api/service/quicksight/templates/funnel-funnel-chart.json
@@ -3,13 +3,13 @@
       "VisualId":"{{visualId}}",
       "Title":{
           "FormatText": {
-            "PlainText": "{{title}}"
+            "PlainText": "{{{title}}}"
           },
           "Visibility":"VISIBLE"
       },
       "Subtitle":{
           "FormatText": {
-            "PlainText": "{{subTitle}}"
+            "PlainText": "{{{subTitle}}}"
           },
           "Visibility":"VISIBLE"
       },

--- a/src/control-plane/backend/lambda/api/service/quicksight/templates/path-sankey-chart.json
+++ b/src/control-plane/backend/lambda/api/service/quicksight/templates/path-sankey-chart.json
@@ -3,13 +3,13 @@
       "VisualId": "{{visualId}}",
       "Title": {
           "FormatText": {
-            "PlainText": "{{title}}"
+            "PlainText": "{{{title}}}"
           },
           "Visibility": "VISIBLE"
       },
       "Subtitle": {
           "FormatText": {
-            "PlainText": "{{subTitle}}"
+            "PlainText": "{{{subTitle}}}"
           },
           "Visibility": "VISIBLE"
       },

--- a/src/control-plane/backend/lambda/api/service/quicksight/templates/retention-bar-chart-multiple.json
+++ b/src/control-plane/backend/lambda/api/service/quicksight/templates/retention-bar-chart-multiple.json
@@ -4,13 +4,13 @@
     "VisualId":"{{visualId}}",
     "Title":{
         "FormatText": {
-            "PlainText": "{{title}}"
+            "PlainText": "{{{title}}}"
         },
         "Visibility":"VISIBLE"
     },
     "Subtitle":{
         "FormatText": {
-            "PlainText": "{{subTitle}}"
+            "PlainText": "{{{subTitle}}}"
         },
         "Visibility":"VISIBLE"
     },

--- a/src/control-plane/backend/lambda/api/service/quicksight/templates/retention-bar-chart.json
+++ b/src/control-plane/backend/lambda/api/service/quicksight/templates/retention-bar-chart.json
@@ -4,13 +4,13 @@
     "VisualId":"{{visualId}}",
     "Title":{
         "FormatText": {
-            "PlainText": "{{title}}"
+            "PlainText": "{{{title}}}"
         },
         "Visibility":"VISIBLE"
     },
     "Subtitle":{
         "FormatText": {
-            "PlainText": "{{subTitle}}"
+            "PlainText": "{{{subTitle}}}"
         },
         "Visibility":"VISIBLE"
     },

--- a/src/control-plane/backend/lambda/api/service/quicksight/templates/retention-line-chart-multiple.json
+++ b/src/control-plane/backend/lambda/api/service/quicksight/templates/retention-line-chart-multiple.json
@@ -3,13 +3,13 @@
       "VisualId": "{{visualId}}",
       "Title": {
           "FormatText": {
-            "PlainText": "{{title}}"
+            "PlainText": "{{{title}}}"
           },
           "Visibility": "VISIBLE"
       },
       "Subtitle": {
         "FormatText": {
-            "PlainText": "{{subTitle}}"
+            "PlainText": "{{{subTitle}}}"
           },
           "Visibility": "VISIBLE"
       },

--- a/src/control-plane/backend/lambda/api/service/quicksight/templates/retention-line-chart.json
+++ b/src/control-plane/backend/lambda/api/service/quicksight/templates/retention-line-chart.json
@@ -3,13 +3,13 @@
       "VisualId": "{{visualId}}",
       "Title": {
           "FormatText": {
-            "PlainText": "{{title}}"
+            "PlainText": "{{{title}}}"
           },
           "Visibility": "VISIBLE"
       },
       "Subtitle": {
         "FormatText": {
-            "PlainText": "{{subTitle}}"
+            "PlainText": "{{{subTitle}}}"
           },
           "Visibility": "VISIBLE"
       },

--- a/src/control-plane/backend/lambda/api/service/quicksight/templates/retention-pivot-table-chart-multiple.json
+++ b/src/control-plane/backend/lambda/api/service/quicksight/templates/retention-pivot-table-chart-multiple.json
@@ -3,7 +3,7 @@
       "VisualId": "{{visualId}}",
       "Title": {
           "FormatText": {
-            "PlainText": "{{title}}"
+            "PlainText": "{{{title}}}"
           },
           "Visibility": "VISIBLE"
       },

--- a/src/control-plane/backend/lambda/api/service/quicksight/templates/retention-pivot-table-chart.json
+++ b/src/control-plane/backend/lambda/api/service/quicksight/templates/retention-pivot-table-chart.json
@@ -3,7 +3,7 @@
       "VisualId": "{{visualId}}",
       "Title": {
           "FormatText": {
-            "PlainText": "{{title}}"
+            "PlainText": "{{{title}}}"
           },
           "Visibility": "VISIBLE"
       },


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

[mustache HTML-escaped by default](https://www.npmjs.com/package/mustache#variables)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend