### PR TITLE
fix: wrong traffic source configuration rule s3 path

### DIFF
--- a/src/data-pipeline/utils/utils-lambda.ts
+++ b/src/data-pipeline/utils/utils-lambda.ts
@@ -174,7 +174,6 @@ export class LambdaUtil {
         OUTPUT_FORMAT: this.props.outputFormat,
         USER_KEEP_DAYS: this.props.userKeepDays + '',
         ITEM_KEEP_DAYS: this.props.itemKeepDays + '',
-        RULE_CONFIG_DIR: `s3://${this.props.pipelineS3Bucket.bucketName}/${ruleConfigDir}`,
       },
       ...functionSettings,
       memorySize: 1024,


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

the function `getRuleConfigDir()` should be invoked in lambda, not in CDK code. 

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend