### PR TITLE
chore: append is_first_day_event in metadata

### DIFF
--- a/frontend/src/pages/analytics/analytics-utils.ts
+++ b/frontend/src/pages/analytics/analytics-utils.ts
@@ -680,6 +680,7 @@ const categoryMapping = (category: ConditionCategoryFrontend | undefined) => {
     case ConditionCategoryFrontend.GEO:
     case ConditionCategoryFrontend.SDK:
     case ConditionCategoryFrontend.OTHER:
+    case ConditionCategoryFrontend.EVENT_OUTER:
       return ConditionCategory.EVENT_OUTER;
     default:
       return ConditionCategory.EVENT;

--- a/frontend/src/pages/analytics/comps/AttributeGroup.tsx
+++ b/frontend/src/pages/analytics/comps/AttributeGroup.tsx
@@ -42,7 +42,7 @@ const AttributeGroup: React.FC<AttributeGroupProps> = (
         return (
           <div key={identity(index)}>
             <div className="cs-analytics-parameter">
-              <div className="flex w-75p">
+              <div className="flex w-85p">
                 <div className="cs-para-name">{index + 1}</div>
                 <div className="flex-1">
                   <EventItem

--- a/frontend/src/ts/utils.ts
+++ b/frontend/src/ts/utils.ts
@@ -415,8 +415,8 @@ export const getEventParameters = (
     return [];
   }
   if (metadataEventParameters?.[0]?.eventNames?.length > 0) {
-    const associatedParameters = metadataEventParameters.filter((p) =>
-      p.eventNames.includes(eventName)
+    const associatedParameters = metadataEventParameters.filter(
+      (p) => p.eventNames.includes(eventName) || p.eventNames.includes('*')
     );
     patchBuiltInMetadata(eventName, associatedParameters, builtInMetadata);
     return associatedParameters;

--- a/src/control-plane/backend/lambda/api/service/display.ts
+++ b/src/control-plane/backend/lambda/api/service/display.ts
@@ -92,8 +92,9 @@ export class CMetadataDisplay {
     const prefix = parameter.prefix.split('#')[0];
     const key = `${prefix}#${parameter.projectId}#${parameter.appId}#${parameter.category}#${parameter.name}#${parameter.valueType}`;
     const metadataDisplay = this.displays.find((d: IMetadataDisplay) => d.id === key);
-    parameter.displayName = this.patchCategoryToDisplayName(parameter.category, parameter.name, metadataDisplay?.displayName);
-    parameter.description = metadataDisplay?.description ?? { 'en-US': '', 'zh-CN': '' };
+    parameter.displayName = parameter.displayName ??
+      this.patchCategoryToDisplayName(parameter.category, parameter.name, metadataDisplay?.displayName);
+    parameter.description = parameter.description ?? metadataDisplay?.description ?? { 'en-US': '', 'zh-CN': '' };
     this._patchEventParameterInfoFromPresetConfiguration(parameter, eventName);
   }
 
@@ -138,8 +139,8 @@ export class CMetadataDisplay {
       }
     }
     if (!matchParameter) {
-      parameter.metadataSource = MetadataSource.CUSTOM;
-      parameter.parameterType = MetadataParameterType.PRIVATE;
+      parameter.metadataSource = parameter.metadataSource ?? MetadataSource.CUSTOM;
+      parameter.parameterType = parameter.parameterType ?? MetadataParameterType.PRIVATE;
     }
   }
 

--- a/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-metadata-store.ts
+++ b/src/control-plane/backend/lambda/api/store/dynamodb/dynamodb-metadata-store.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-import { ConditionCategory, MetadataValueType } from '@aws/clickstream-base-lib';
+import { ConditionCategory, MetadataParameterType, MetadataPlatform, MetadataSource, MetadataValueType } from '@aws/clickstream-base-lib';
 import {
   UpdateCommand,
   QueryCommandInput,
@@ -214,6 +214,39 @@ export class DynamoDbMetadataStore implements MetadataStore {
       records = await this.queryMetadataRawsFromBuiltInList(projectId, appId, 'EVENT_PARAMETER', version);
     }
     const parameters = rawToParameter(records, false);
+    // Add view parameters
+    parameters.push({
+      id: `${projectId}#${appId}#${ConditionCategory.EVENT_OUTER}#is_first_day_event#${MetadataValueType.STRING}`,
+      month: 'latest',
+      prefix: `EVENT_PARAMETER#${projectId}#${appId}`,
+      projectId: projectId,
+      appId: appId,
+      name: 'is_first_day_event',
+      platform: [MetadataPlatform.ANDROID, MetadataPlatform.IOS, MetadataPlatform.WEB, MetadataPlatform.WECHAT_MINIPROGRAM],
+      category: ConditionCategory.EVENT_OUTER,
+      valueType: MetadataValueType.STRING,
+      metadataSource: MetadataSource.PRESET,
+      parameterType: MetadataParameterType.PUBLIC,
+      displayName: {
+        'en-US': 'Is first day event',
+        'zh-CN': '是否首日事件',
+      },
+      description: {
+        'en-US': 'Is first day event',
+        'zh-CN': '是否首日事件',
+      },
+      valueEnum: [
+        {
+          value: 'true',
+          count: 0,
+        },
+        {
+          value: 'false',
+          count: 0,
+        },
+      ],
+      eventNames: ['*'],
+    });
     return parameters;
   };
 

--- a/src/control-plane/backend/lambda/api/test/api/metadata-v3.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/metadata-v3.test.ts
@@ -182,7 +182,7 @@ describe('Metadata Event Attribute test V3', () => {
       .get(`/api/metadata/event_parameters?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(200);
-    expect(res.body.data.totalCount).toEqual(79);
+    expect(res.body.data.totalCount).toEqual(80);
   });
   it('Get metadata event attribute for path nodes v3', async () => {
     ddbMock.on(QueryCommand, {

--- a/src/control-plane/backend/lambda/api/test/api/metadata.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/metadata.test.ts
@@ -1672,8 +1672,35 @@ describe('Metadata Event Attribute test V2', () => {
               { value: 'value-02', displayValue: 'value-02' },
             ],
           },
+          {
+            associatedEvents: [],
+            id: `${MOCK_PROJECT_ID}#${MOCK_APP_ID}#${ConditionCategory.EVENT_OUTER}#is_first_day_event#${MetadataValueType.STRING}`,
+            month: 'latest',
+            prefix: `EVENT_PARAMETER#${MOCK_PROJECT_ID}#${MOCK_APP_ID}`,
+            projectId: MOCK_PROJECT_ID,
+            appId: MOCK_APP_ID,
+            name: 'is_first_day_event',
+            displayName: {
+              'en-US': 'Is first day event',
+              'zh-CN': '是否首日事件',
+            },
+            description: {
+              'en-US': 'Is first day event',
+              'zh-CN': '是否首日事件',
+            },
+            eventNames: ['*'],
+            category: ConditionCategory.EVENT_OUTER,
+            metadataSource: MetadataSource.PRESET,
+            parameterType: MetadataParameterType.PUBLIC,
+            platform: [MetadataPlatform.ANDROID, MetadataPlatform.IOS, MetadataPlatform.WEB, MetadataPlatform.WECHAT_MINIPROGRAM],
+            valueType: MetadataValueType.STRING,
+            values: [
+              { value: 'true', displayValue: 'true' },
+              { value: 'false', displayValue: 'false' },
+            ],
+          },
         ],
-        totalCount: 2,
+        totalCount: 3,
       },
     });
   });
@@ -1701,7 +1728,7 @@ describe('Metadata Event Attribute test V2', () => {
       .get(`/api/metadata/event_parameters?projectId=${MOCK_PROJECT_ID}&appId=${MOCK_APP_ID}`);
     expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     expect(res.statusCode).toBe(200);
-    expect(res.body.data.totalCount).toEqual(80);
+    expect(res.body.data.totalCount).toEqual(81);
   });
   it('Get metadata event attribute for path nodes', async () => {
     ddbMock.on(QueryCommand, {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend