### PR TITLE
chore: check app timezone when upgrade

### DIFF
--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -1497,6 +1497,23 @@ function getTemplateUrl(templateName: string, solutionMetadata?: IDictionary, us
   return `${s3Host}/${solutionName}/${version}/${prefix}${templateName}`;
 }
 
+export function checkAppTimezone(pipeline: IPipeline, appIds: string[]): string[] {
+  if (appIds.length === 0) {
+    return [];
+  }
+  const hadTimezoneAppIds: string[] = [];
+  for (const tz of pipeline?.timezone ?? []) {
+    if (tz.timezone.trim()) {
+      hadTimezoneAppIds.push(tz.appId);
+    }
+  }
+  // find ip in appIds but not in hadTimezoneAppIds
+  const needUpgradeAppIds = appIds?.filter(
+    (id) => !hadTimezoneAppIds.includes(id),
+  );
+  return needUpgradeAppIds;
+}
+
 export {
   isEmpty,
   isEmail,


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend