### PR TITLE
chore: use existing physicalId of batch insert lambda to recognize as an updateable resource

### DIFF
--- a/src/control-plane/backend/lambda/batch-insert-ddb/index.ts
+++ b/src/control-plane/backend/lambda/batch-insert-ddb/index.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-import { aws_sdk_client_common_config, logger, marshallOptions, unmarshallOptions } from '@aws/clickstream-base-lib';
+import { aws_sdk_client_common_config, generateRandomStr, logger, marshallOptions, unmarshallOptions } from '@aws/clickstream-base-lib';
 import {
   DynamoDBClient,
   BatchWriteItemCommand,
@@ -48,15 +48,17 @@ interface DicItem {
 
 export const handler = async (
   event: CdkCustomResourceEvent,
-  context: Context,
+  _context: Context,
 ): Promise<CdkCustomResourceResponse> => {
   logger.debug('dictionary:', { dictionary });
 
+  const physicalId = ('PhysicalResourceId' in event) ? event.PhysicalResourceId :
+    `batchInsertDDB${generateRandomStr(8, 'abcdefghijklmnopqrstuvwxyz0123456789')}`;
   const response: CdkCustomResourceResponse = {
     StackId: event.StackId,
     RequestId: event.RequestId,
     LogicalResourceId: event.LogicalResourceId,
-    PhysicalResourceId: context.logGroupName,
+    PhysicalResourceId: physicalId,
     Data: {
       TableName: event.ResourceProperties.tableName,
     },

--- a/test/control-plane/lambda/batch-insert-ddb.test.ts
+++ b/test/control-plane/lambda/batch-insert-ddb.test.ts
@@ -87,6 +87,7 @@ describe('Dictionary Data', () => {
     ddbMock.on(BatchWriteItemCommand).resolvesOnce({});
     const resp = await handler(updateDictionaryEvent, context) as CdkCustomResourceResponse;
     expect(resp.Status).toEqual('SUCCESS');
+    expect(resp.PhysicalResourceId).toEqual('physical-resource-id');
     expect(docMock).toHaveReceivedCommandTimes(ScanCommand, 1);
     expect(docMock).toHaveReceivedCommandTimes(DeleteCommand, 1);
     expect(ddbMock).toHaveReceivedCommandTimes(BatchWriteItemCommand, 1);
@@ -109,6 +110,7 @@ describe('Dictionary Data', () => {
     };
     const resp = await handler(event, context) as CdkCustomResourceResponse;
     expect(resp.Status).toEqual('SUCCESS');
+    expect(resp.PhysicalResourceId).toEqual('physical-resource-id');
     expect(docMock).toHaveReceivedCommandTimes(ScanCommand, 1);
     expect(docMock).toHaveReceivedCommandTimes(DeleteCommand, 1);
     expect(ddbMock).toHaveReceivedCommandTimes(BatchWriteItemCommand, 1);


### PR DESCRIPTION
… as an updatable resource (#1119)


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend