### PR TITLE
fix: retry all stacks when delete failed

### DIFF
--- a/src/control-plane/backend/lambda/api/service/stack.ts
+++ b/src/control-plane/backend/lambda/api/service/stack.ts
@@ -318,7 +318,8 @@ export class StackManager {
   private _getRetryState(
     state: WorkflowState, stackDetails: PipelineStatusDetail[], retryStackNames: string[],
     lastAction: string): WorkflowState {
-    if (state.Data?.Input.StackName && retryStackNames.includes(state.Data.Input.StackName)) {
+    if (state.Data?.Input.StackName &&
+      (retryStackNames.includes(state.Data.Input.StackName) || lastAction === 'Delete')) {
       const status = this.getStackStatusByName(state.Data?.Input.StackName, stackDetails);
       state.Data.Input.Action = this._getRetryAction(lastAction, status);
     } else {

--- a/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
@@ -11,6 +11,7 @@
  *  and limitations under the License.
  */
 
+import { StackStatus } from '@aws-sdk/client-cloudformation';
 import { CloudWatchEventsClient } from '@aws-sdk/client-cloudwatch-events';
 import { EC2Client } from '@aws-sdk/client-ec2';
 import {
@@ -109,7 +110,6 @@ import { getStackPrefix } from '../../common/utils';
 import { server } from '../../index';
 import { CPipeline } from '../../model/pipeline';
 import { StackManager } from '../../service/stack';
-import { StackStatus } from '@aws-sdk/client-cloudformation';
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 const kafkaMock = mockClient(KafkaClient);


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend