### PR TITLE
fix: lambda put s3 role permissions

### DIFF
--- a/src/data-pipeline/utils/utils-lambda.ts
+++ b/src/data-pipeline/utils/utils-lambda.ts
@@ -140,7 +140,7 @@ export class LambdaUtil {
 
     const ruleConfigDir = getRuleConfigDir(this.props.pipelineS3Prefix, this.props.projectId);
     this.props.pipelineS3Bucket.grantReadWrite(lambdaRole, `${ruleConfigDir}*`);
-    this.props.pipelineS3Bucket.grantReadWrite(lambdaRole, `clickstream/${this.props.projectId}/rules`);
+    this.props.pipelineS3Bucket.grantReadWrite(lambdaRole, `clickstream/${this.props.projectId}/rules/*`);
 
     const fn = new SolutionNodejsFunction(this.scope, 'EmrSparkJobSubmitterFunction', {
       role: lambdaRole,

--- a/test/data-pipeline/data-pipeline-stack.test.ts
+++ b/test/data-pipeline/data-pipeline-stack.test.ts
@@ -1278,7 +1278,7 @@ describe('Data Processing job submitter', () => {
                     Match.anyValue(),
                     '/clickstream/',
                     Match.anyValue(),
-                    '/rules',
+                    '/rules/*',
                   ],
                 ],
               },


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend