### PR TITLE
fix: add Refresh materialized views metric

### DIFF
--- a/src/analytics/private/metrics-common-workflow.ts
+++ b/src/analytics/private/metrics-common-workflow.ts
@@ -130,6 +130,7 @@ export function buildMetricsWidgetForWorkflows(scope: Construct, id: string, pro
           loadDataWorkflowAlarm.alarmArn,
           newFilesCountAlarm.alarmArn,
           scanMetadataWorkflowAlarm.alarmArn,
+          refreshMaterializedViewsWorkflowAlarm.alarmArn,
         ],
         title: 'Data Modeling Alarms',
       },

--- a/src/analytics/private/metrics-common-workflow.ts
+++ b/src/analytics/private/metrics-common-workflow.ts
@@ -44,6 +44,9 @@ export function buildMetricsWidgetForWorkflows(scope: Construct, id: string, pro
     'StateMachineArn', props.loadDataWorkflow.stateMachineArn,
   ];
 
+  const refreshMaterializedViewsWorkflowDimension = [
+    'StateMachineArn', props.refreshMaterializedViewsWorkflow.stateMachineArn,
+  ];
 
   const scanMetadataWorkflowDimension = [
     'StateMachineArn', props.scanMetadataWorkflow.stateMachineArn,
@@ -136,6 +139,7 @@ export function buildMetricsWidgetForWorkflows(scope: Construct, id: string, pro
 
   const workflowExecMetrics: MetricWidgetElement[] = [
     [loadDataWorkflowDimension, 'Load data to redshift tables'],
+    [refreshMaterializedViewsWorkflowDimension, 'Refresh materialized views'],
     [clearExpiredEventsWorkflowDimension, 'Clear expired events'],
     [scanMetadataWorkflowDimension, 'Scan metadata'],
     [sqlExecutionWorkflowDimension, 'SQL execution'],

--- a/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
+++ b/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
@@ -2915,6 +2915,26 @@ describe('Should set metrics widgets', () => {
         'Fn::Join': [
           '',
           [
+            'Refresh materialized views workflow failed, projectId: ',
+            Match.anyValue(),
+          ],
+        ],
+      },
+
+      TreatMissingData: TreatMissingData.NOT_BREACHING,
+      Period: {
+        'Fn::GetAtt': [
+          Match.anyValue(),
+          'mvRefreshIntervalSeconds',
+        ],
+      },
+    });
+
+    newServerlessTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmDescription: {
+        'Fn::Join': [
+          '',
+          [
             'Max file age more than ',
             {
               'Fn::GetAtt': [
@@ -2996,6 +3016,26 @@ describe('Should set metrics widgets', () => {
       },
     });
 
+    newServerlessTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmDescription: {
+        'Fn::Join': [
+          '',
+          [
+            'Refresh materialized views workflow failed, projectId: ',
+            Match.anyValue(),
+          ],
+        ],
+      },
+
+      TreatMissingData: TreatMissingData.NOT_BREACHING,
+      Period: {
+        'Fn::GetAtt': [
+          Match.anyValue(),
+          'mvRefreshIntervalSeconds',
+        ],
+      },
+    });
+
     existingServerlessTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
       AlarmDescription: {
         'Fn::Join': [
@@ -3043,8 +3083,39 @@ describe('Should set metrics widgets', () => {
                 Match.objectLike({ 'Fn::GetAtt': Match.anyValue() }),
                 Match.objectLike({ 'Fn::GetAtt': Match.anyValue() }),
                 Match.objectLike({ 'Fn::GetAtt': Match.anyValue() }),
+                Match.objectLike({ 'Fn::GetAtt': Match.anyValue() }),
               ]),
               title: Match.anyValue(),
+            },
+          }),
+          Match.objectLike({
+            type: 'metric',
+            properties: {
+              title: "'Load data to redshift tables' workflow",
+            },
+          }),
+          Match.objectLike({
+            type: 'metric',
+            properties: {
+              title: "'Refresh materialized views' workflow",
+            },
+          }),
+          Match.objectLike({
+            type: 'metric',
+            properties: {
+              title: "'Clear expired events' workflow",
+            },
+          }),
+          Match.objectLike({
+            type: 'metric',
+            properties: {
+              title: "'Scan metadata' workflow",
+            },
+          }),
+          Match.objectLike({
+            type: 'metric',
+            properties: {
+              title: "'SQL execution' workflow",
             },
           }),
         ]),
@@ -3072,7 +3143,7 @@ describe('Should set metrics widgets', () => {
     });
 
 
-    newServerlessTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
+    provisionTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
       AlarmDescription: {
         'Fn::Join': [
           '',
@@ -3088,6 +3159,26 @@ describe('Should set metrics widgets', () => {
         'Fn::GetAtt': [
           Match.anyValue(),
           'scanWorkflowMinIntervalSeconds',
+        ],
+      },
+    });
+
+    provisionTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmDescription: {
+        'Fn::Join': [
+          '',
+          [
+            'Refresh materialized views workflow failed, projectId: ',
+            Match.anyValue(),
+          ],
+        ],
+      },
+
+      TreatMissingData: TreatMissingData.NOT_BREACHING,
+      Period: {
+        'Fn::GetAtt': [
+          Match.anyValue(),
+          'mvRefreshIntervalSeconds',
         ],
       },
     });


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend