### PR TITLE
fix: retry all stacks when delete failed

### DIFF
--- a/src/control-plane/backend/lambda/api/service/stack.ts
+++ b/src/control-plane/backend/lambda/api/service/stack.ts
@@ -318,7 +318,8 @@ export class StackManager {
   private _getRetryState(
     state: WorkflowState, stackDetails: PipelineStatusDetail[], retryStackNames: string[],
     lastAction: string): WorkflowState {
-    if (state.Data?.Input.StackName && retryStackNames.includes(state.Data.Input.StackName)) {
+    if (state.Data?.Input.StackName &&
+      (retryStackNames.includes(state.Data.Input.StackName) || lastAction === 'Delete')) {
       const status = this.getStackStatusByName(state.Data?.Input.StackName, stackDetails);
       state.Data.Input.Action = this._getRetryAction(lastAction, status);
     } else {

--- a/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
@@ -11,6 +11,7 @@
  *  and limitations under the License.
  */
 
+import { StackStatus } from '@aws-sdk/client-cloudformation';
 import { CloudWatchEventsClient } from '@aws-sdk/client-cloudwatch-events';
 import { EC2Client } from '@aws-sdk/client-ec2';
 import {
@@ -48,6 +49,7 @@ import {
   dictionaryMock,
 } from './ddb-mock';
 import {
+  BASE_STATUS,
   KAFKA_INGESTION_PIPELINE,
   KAFKA_WITH_CONNECTOR_INGESTION_PIPELINE,
   KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE,
@@ -3282,6 +3284,161 @@ describe('Workflow test', () => {
                 },
                 End: true,
                 Type: 'Pass',
+              },
+            },
+          },
+        ],
+        End: true,
+        Type: 'Parallel',
+      },
+    };
+    expect(stackManager.getExecWorkflow()).toEqual(expected);
+  });
+  it('Generate Retry Workflow when delete failed', async () => {
+    dictionaryMock(ddbMock);
+    // KafkaConnector, DataModelingRedshift Failed
+    // Reporting Miss
+    const stackManager: StackManager = new StackManager({
+      ...RETRY_PIPELINE_WITH_WORKFLOW,
+      stackDetails: [
+        {
+          ...BASE_STATUS.stackDetails[0],
+          stackStatus: StackStatus.DELETE_FAILED,
+        },
+        BASE_STATUS.stackDetails[1],
+        BASE_STATUS.stackDetails[2],
+        {
+          ...BASE_STATUS.stackDetails[3],
+          stackStatus: StackStatus.DELETE_FAILED,
+        },
+        BASE_STATUS.stackDetails[4],
+        BASE_STATUS.stackDetails[5],
+      ],
+    });
+    stackManager.retryWorkflow();
+    const expected = {
+      Version: '2022-03-15',
+      Workflow: {
+        Branches: [
+          {
+            StartAt: 'Ingestion',
+            States: {
+              Ingestion: {
+                Data: {
+                  Callback: {
+                    BucketName: 'TEST_EXAMPLE_BUCKET',
+                    BucketPrefix: 'clickstream/workflow/main-3333-3333',
+                  },
+                  Input: {
+                    Action: 'Delete',
+                    Region: 'ap-southeast-1',
+                    Parameters: [],
+                    StackName: `${getStackPrefix()}-Ingestion-kafka-6666-6666`,
+                    TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/ingestion-server-kafka-stack.template.json',
+                  },
+                },
+                Next: 'KafkaConnector',
+                Type: 'Stack',
+              },
+              KafkaConnector: {
+                Data: {
+                  Callback: {
+                    BucketName: 'TEST_EXAMPLE_BUCKET',
+                    BucketPrefix: 'clickstream/workflow/main-3333-3333',
+                  },
+                  Input: {
+                    Action: 'Delete',
+                    Region: 'ap-southeast-1',
+                    Parameters: [],
+                    StackName: `${getStackPrefix()}-KafkaConnector-6666-6666`,
+                    TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/kafka-s3-sink-stack.template.json',
+                  },
+                },
+                End: true,
+                Type: 'Stack',
+              },
+            },
+          },
+          {
+            StartAt: 'DataProcessing',
+            States: {
+              DataProcessing: {
+                Data: {
+                  Callback: {
+                    BucketName: 'TEST_EXAMPLE_BUCKET',
+                    BucketPrefix: 'clickstream/workflow/main-3333-3333',
+                  },
+                  Input: {
+                    Action: 'Delete',
+                    Region: 'ap-southeast-1',
+                    Parameters: [],
+                    StackName: `${getStackPrefix()}-DataProcessing-6666-6666`,
+                    TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-pipeline-stack.template.json',
+                  },
+                },
+                Next: 'DataModeling',
+                Type: 'Stack',
+              },
+              Reporting: {
+                Type: 'Stack',
+                Data: {
+                  Input: {
+                    Region: 'ap-southeast-1',
+                    TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-reporting-quicksight-stack.template.json',
+                    Action: 'Delete',
+                    Parameters: [],
+                    StackName: `${getStackPrefix()}-Reporting-6666-6666`,
+                  },
+                  Callback: {
+                    BucketPrefix: 'clickstream/workflow/main-3333-3333',
+                    BucketName: 'TEST_EXAMPLE_BUCKET',
+                  },
+                },
+                End: true,
+              },
+              DataModeling: {
+                Data: {
+                  Callback: {
+                    BucketName: 'TEST_EXAMPLE_BUCKET',
+                    BucketPrefix: 'clickstream/workflow/main-3333-3333',
+                  },
+                  Input: {
+                    Action: 'Delete',
+                    Region: 'ap-southeast-1',
+                    Parameters: [
+                      {
+                        ParameterKey: 'DataProcessingCronOrRateExpression',
+                        ParameterValue: 'rate(16 minutes)',
+                      },
+                    ],
+                    StackName: `${getStackPrefix()}-DataModelingRedshift-6666-6666`,
+                    TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-analytics-redshift-stack.template.json',
+                  },
+                },
+                Next: 'Reporting',
+                Type: 'Stack',
+              },
+            },
+          },
+          {
+            StartAt: 'Metrics',
+            States: {
+              Metrics: {
+                Data: {
+                  Callback: {
+                    BucketName: 'TEST_EXAMPLE_BUCKET',
+                    BucketPrefix: 'clickstream/workflow/main-3333-3333',
+                  },
+                  Input: {
+                    Action: 'Delete',
+                    Region: 'ap-southeast-1',
+                    Parameters: BASE_METRICS_PARAMETERS,
+                    StackName: `${getStackPrefix()}-Metrics-6666-6666`,
+                    TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/v1.0.0/default/metrics-stack.template.json',
+                  },
+                },
+                End: true,
+                Type: 'Stack',
               },
             },
           },


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary


## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend