### PR TITLE
chore: compensation all stacks status when execution is final state

### DIFF
--- a/src/control-plane/backend/event-bus-construct.ts
+++ b/src/control-plane/backend/event-bus-construct.ts
@@ -159,6 +159,7 @@ export class BackendEventBus extends Construct {
       handler: 'handler',
       tracing: Tracing.ACTIVE,
       role: createLambdaRole(this, 'ListenStateFuncRole', true, [
+        ...this.getDescribeStackPolicyStatements(props),
         ...this.getDeleteRulePolicyStatements(),
         ...this.getDeleteTopicPolicyStatements(),
       ]),

--- a/src/control-plane/backend/lambda/api/service/stack.ts
+++ b/src/control-plane/backend/lambda/api/service/stack.ts
@@ -303,6 +303,7 @@ export class StackManager {
     retryActionMap.set('Delete+FAILED', 'Delete');
     retryActionMap.set('Delete+COMPLETE', 'Delete');
     retryActionMap.set('Delete+ROLLBACK_COMPLETE', 'Delete');
+    retryActionMap.set('Delete+EMPTY', 'Delete');
 
     let shortStatus = 'EMPTY';
     if (status?.endsWith('FAILED')) {

--- a/src/control-plane/backend/lambda/api/store/aws/cloudformation.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/cloudformation.ts
@@ -32,6 +32,7 @@ export const describeStack = async (region: string, stackName: string) => {
     }
     return undefined;
   } catch (error) {
+    logger.warn('Describe AWS CloudFormation Stack Error', { error });
     return undefined;
   }
 };
@@ -55,6 +56,7 @@ export const getStacksDetailsByNames = async (region: string, stackNames: string
     }
     return stackDetails;
   } catch (error) {
+    logger.warn('Get AWS CloudFormation Stacks Details Error', { error });
     return [];
   }
 };
@@ -71,7 +73,7 @@ export const describeType = async (region: string, typeName: string) => {
     });
     return await cloudFormationClient.send(params);
   } catch (error) {
-    logger.error('Describe AWS Resource Types Error', { error });
+    logger.warn('Describe AWS Resource Types Error', { error });
     return undefined;
   }
 };

--- a/src/control-plane/backend/lambda/listen-stack-status/index.ts
+++ b/src/control-plane/backend/lambda/listen-stack-status/index.ts
@@ -16,6 +16,7 @@ import { EventBridgeEvent, SQSEvent } from 'aws-lambda';
 import { CloudFormationStackStatusChangeNotificationEventDetail, describeStack, getNewStackDetails, getPipeline, getPipelineIdFromStackName, getWorkflowStacks, stackPrefix, updatePipelineStackStatus } from './listen-tools';
 
 export const handler = async (event: SQSEvent): Promise<void> => {
+  logger.debug('Event: ', { event });
   const eventBody = event.Records[0].body;
   const eventBridgeEvent = JSON.parse(eventBody) as EventBridgeEvent<'CloudFormation Stack Status Change', CloudFormationStackStatusChangeNotificationEventDetail>;
   const eventDetail = eventBridgeEvent.detail;

--- a/src/control-plane/backend/lambda/listen-stack-status/listen-tools.ts
+++ b/src/control-plane/backend/lambda/listen-stack-status/listen-tools.ts
@@ -22,6 +22,8 @@ import { BuiltInTagKeys, ExecutionDetail, PipelineStackType, PipelineStatusDetai
 import { CFN_TOPIC_PREFIX } from '../api/common/constants';
 import { WorkflowParallelBranch, WorkflowState, WorkflowStateType } from '../api/common/types';
 import { getStackPrefix } from '../api/common/utils';
+import { IPipeline } from '../api/model/pipeline';
+import { getStacksDetailsByNames } from '../api/store/aws/cloudformation';
 
 const MAX_RETRY_COUNT = 3;
 
@@ -69,8 +71,8 @@ export async function describeStack(stackId: string, region: string): Promise<St
     }
     return;
   } catch (error) {
-    logger.error('Failed to describe stack: ', { stackId, region, error });
-    throw error;
+    logger.warn('Failed to describe stack: ', { stackId, region, error });
+    return;
   }
 }
 
@@ -106,7 +108,7 @@ export async function getPipeline(pipelineId: string): Promise<any> {
   }
 }
 
-async function updateStackStatusWithOptimisticLocking(
+export async function updateStackStatusWithOptimisticLocking(
   projectId: string, pipelineId:string, stackDetails: PipelineStatusDetail[], updateAt: number): Promise<boolean> {
   try {
     const input: UpdateCommandInput = {
@@ -138,11 +140,36 @@ async function updateStackStatusWithOptimisticLocking(
   }
 }
 
+export async function updatePipelineAllStackStatus(
+  projectId: string, pipelineId:string, stackDetails: PipelineStatusDetail[], updateAt: number): Promise<void> {
+  try {
+    let retryCount = 0;
+    let success = await updateStackStatusWithOptimisticLocking(projectId, pipelineId, stackDetails, updateAt);
+    logger.debug('updateStackStatusWithOptimisticLocking details: ', { projectId, pipelineId, retryCount, success, stackDetails, updateAt });
+    while (!success && retryCount < MAX_RETRY_COUNT) {
+      logger.warn('Failed to update pipeline all stack status with optimistic locking: ', { projectId, pipelineId, retryCount });
+      const pipeline = await getPipeline(pipelineId);
+      if (!pipeline) {
+        logger.error('Failed to get pipeline: ', { projectId, pipelineId });
+        throw new Error('Failed to get pipeline');
+      }
+      const newStackDetails = await fetchAllStackDetails(pipeline);
+      success = await updateStackStatusWithOptimisticLocking(projectId, pipelineId, newStackDetails, pipeline.updateAt);
+      retryCount += 1;
+      logger.debug('updateStackStatusWithOptimisticLocking details: ', { projectId, pipelineId, retryCount, success, newStackDetails, updateAt });
+    }
+  } catch (err) {
+    logger.error('Failed to update pipeline all stack status: ', { projectId, pipelineId, err });
+    throw err;
+  }
+}
+
 export async function updatePipelineStackStatus(
   projectId: string, pipelineId:string, curStackDetail: Stack, stackDetails: PipelineStatusDetail[], updateAt: number): Promise<void> {
   try {
     let retryCount = 0;
     let success = await updateStackStatusWithOptimisticLocking(projectId, pipelineId, stackDetails, updateAt);
+    logger.debug('updateStackStatusWithOptimisticLocking details: ', { projectId, pipelineId, retryCount, success, stackDetails, updateAt });
     while (!success && retryCount < MAX_RETRY_COUNT) {
       logger.warn('Failed to update pipeline stack status with optimistic locking: ', { projectId, pipelineId, retryCount });
       const pipeline = await getPipeline(pipelineId);
@@ -154,6 +181,7 @@ export async function updatePipelineStackStatus(
       const newStackDetails = getNewStackDetails(curStackDetail, pipeline.stackDetails ?? [], stackNames);
       success = await updateStackStatusWithOptimisticLocking(projectId, pipelineId, newStackDetails, pipeline.updateAt);
       retryCount += 1;
+      logger.debug('updateStackStatusWithOptimisticLocking details: ', { projectId, pipelineId, retryCount, success, newStackDetails, updateAt });
     }
   } catch (err) {
     logger.error('Failed to update pipeline stack status: ', { projectId, pipelineId, err });
@@ -206,8 +234,11 @@ export function getVersionFromTags(tags: Tag[] | undefined) {
   return version;
 }
 
-export function getWorkflowStacks(state: WorkflowState): string[] {
+export function getWorkflowStacks(state: WorkflowState | undefined): string[] {
   let res: string[] = [];
+  if (!state) {
+    return res;
+  }
   if (state.Type === WorkflowStateType.PARALLEL) {
     for (let branch of state.Branches as WorkflowParallelBranch[]) {
       for (let key of Object.keys(branch.States)) {
@@ -449,4 +480,12 @@ const unsubscribeTopic = async (region: string, topicArn: string) => {
     logger.error('Error in unsubscribe topic', { error });
     throw error;
   }
+};
+
+export const fetchAllStackDetails = async (
+  pipeline: IPipeline,
+) => {
+  const stackNames = getWorkflowStacks(pipeline.workflow?.Workflow);
+  const stackStatusDetails: PipelineStatusDetail[] = await getStacksDetailsByNames(pipeline.region, stackNames);
+  return stackStatusDetails;
 };

--- a/src/control-plane/backend/lambda/listen-state-status/index.ts
+++ b/src/control-plane/backend/lambda/listen-state-status/index.ts
@@ -15,11 +15,12 @@ import { logger } from '@aws/clickstream-base-lib';
 import { ExecutionStatus } from '@aws-sdk/client-sfn';
 import { EventBridgeEvent } from 'aws-lambda';
 import { CFN_RULE_PREFIX } from '../api/common/constants';
-import { StepFunctionsExecutionStatusChangeNotificationEventDetail, deleteProject, deleteRuleAndTopic, getPipeline, getTopicArn, updatePipelineStateStatus } from '../listen-stack-status/listen-tools';
+import { StepFunctionsExecutionStatusChangeNotificationEventDetail, deleteProject, deleteRuleAndTopic, fetchAllStackDetails, getPipeline, getTopicArn, updatePipelineAllStackStatus, updatePipelineStateStatus } from '../listen-stack-status/listen-tools';
 
 export const handler = async (
   event: EventBridgeEvent<'Step Functions Execution Status Change', StepFunctionsExecutionStatusChangeNotificationEventDetail>): Promise<void> => {
 
+  logger.debug('Event: ', { event });
   const eventDetail = event.detail;
   const executionName = eventDetail.name;
   if (!executionName?.startsWith('main-')) {
@@ -38,11 +39,19 @@ export const handler = async (
 
   await updatePipelineStateStatus(projectId, pipelineId, eventDetail, pipeline.updateAt);
 
+  if (eventDetail.status !== ExecutionStatus.RUNNING) {
+    const stackDetails = await fetchAllStackDetails(pipeline);
+    logger.debug('Update all stack status', { eventDetail, stackDetails } );
+    await updatePipelineAllStackStatus(projectId, pipelineId, stackDetails, pipeline.updateAt);
+  }
+
   if (eventDetail.status === ExecutionStatus.SUCCEEDED && pipeline.lastAction === 'Delete') {
     const ruleName = `${CFN_RULE_PREFIX}-${projectId}`;
     const topicArn = getTopicArn(pipeline.region, pipeline.pipelineId);
+    logger.debug('Delete project, rule and topic', { projectId, ruleName, topicArn });
     await deleteProject(projectId);
     await deleteRuleAndTopic(pipeline.region, ruleName, topicArn);
   }
 };
+
 

--- a/src/control-plane/backend/stack-action-state-machine-construct.ts
+++ b/src/control-plane/backend/stack-action-state-machine-construct.ts
@@ -189,19 +189,19 @@ export class StackActionStateMachine extends Construct {
 
     const endState = new Pass(this, 'EndState');
 
-    const wait15 = new Wait(this, 'Wait 15 Seconds', {
-      time: WaitTime.duration(Duration.seconds(15)),
+    const wait30 = new Wait(this, 'Wait 30 Seconds', {
+      time: WaitTime.duration(Duration.seconds(30)),
     });
 
     const endChoice = new Choice(this, 'End?')
       .when(Condition.stringEquals('$.Action', 'End'), endState)
-      .otherwise(wait15);
+      .otherwise(wait30);
 
     executeTask.next(endChoice);
-    wait15.next(describeStack);
+    wait30.next(describeStack);
 
     const progressChoice = new Choice(this, 'Stack in progress?')
-      .when(Condition.stringMatches('$.Result.StackStatus', '*_IN_PROGRESS'), wait15)
+      .when(Condition.stringMatches('$.Result.StackStatus', '*_IN_PROGRESS'), wait30)
       .otherwise(callbackTask);
 
     describeStack.next(progressChoice);

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -1462,7 +1462,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
                 'Arn',
               ],
             },
-            '","Payload.$":"$"}},"End?":{"Type":"Choice","Choices":[{"Variable":"$.Action","StringEquals":"End","Next":"EndState"}],"Default":"Wait 15 Seconds"},"Wait 15 Seconds":{"Type":"Wait","Seconds":15,"Next":"Describe Stack"},"Stack in progress?":{"Type":"Choice","Choices":[{"Variable":"$.Result.StackStatus","StringMatches":"*_IN_PROGRESS","Next":"Wait 15 Seconds"}],"Default":"Callback Task"},"Describe Stack":{"Next":"Stack in progress?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:',
+            '","Payload.$":"$"}},"End?":{"Type":"Choice","Choices":[{"Variable":"$.Action","StringEquals":"End","Next":"EndState"}],"Default":"Wait 30 Seconds"},"Wait 30 Seconds":{"Type":"Wait","Seconds":30,"Next":"Describe Stack"},"Stack in progress?":{"Type":"Choice","Choices":[{"Variable":"$.Result.StackStatus","StringMatches":"*_IN_PROGRESS","Next":"Wait 30 Seconds"}],"Default":"Callback Task"},"Describe Stack":{"Next":"Stack in progress?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:',
             {
               Ref: 'AWS::Partition',
             },
@@ -2040,7 +2040,7 @@ describe('Click Stream Api Cloudfront deploy Construct Test', () => {
                 'Arn',
               ],
             },
-            '","Payload.$":"$"}},"End?":{"Type":"Choice","Choices":[{"Variable":"$.Action","StringEquals":"End","Next":"EndState"}],"Default":"Wait 15 Seconds"},"Wait 15 Seconds":{"Type":"Wait","Seconds":15,"Next":"Describe Stack"},"Stack in progress?":{"Type":"Choice","Choices":[{"Variable":"$.Result.StackStatus","StringMatches":"*_IN_PROGRESS","Next":"Wait 15 Seconds"}],"Default":"Callback Task"},"Describe Stack":{"Next":"Stack in progress?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:',
+            '","Payload.$":"$"}},"End?":{"Type":"Choice","Choices":[{"Variable":"$.Action","StringEquals":"End","Next":"EndState"}],"Default":"Wait 30 Seconds"},"Wait 30 Seconds":{"Type":"Wait","Seconds":30,"Next":"Describe Stack"},"Stack in progress?":{"Type":"Choice","Choices":[{"Variable":"$.Result.StackStatus","StringMatches":"*_IN_PROGRESS","Next":"Wait 30 Seconds"}],"Default":"Callback Task"},"Describe Stack":{"Next":"Stack in progress?","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","OutputPath":"$.Payload","Resource":"arn:',
             {
               Ref: 'AWS::Partition',
             },

--- a/test/control-plane/lambda/listen-state-status.test.ts
+++ b/test/control-plane/lambda/listen-state-status.test.ts
@@ -11,6 +11,7 @@
  *  and limitations under the License.
  */
 
+import { CloudFormationClient, DescribeStacksCommand, StackStatus } from '@aws-sdk/client-cloudformation';
 import { CloudWatchEventsClient, DeleteRuleCommand, ListTargetsByRuleCommand, RemoveTargetsCommand } from '@aws-sdk/client-cloudwatch-events';
 import { ConditionalCheckFailedException, TransactWriteItemsCommand } from '@aws-sdk/client-dynamodb';
 import { ExecutionStatus } from '@aws-sdk/client-sfn';
@@ -18,6 +19,8 @@ import { DeleteTopicCommand, ListSubscriptionsByTopicCommand, SNSClient, Unsubsc
 import { DynamoDBDocumentClient, QueryCommand, ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import { EventBridgeEvent } from 'aws-lambda';
 import { mockClient } from 'aws-sdk-client-mock';
+import { WorkflowStateType } from '../../../src/control-plane/backend/lambda/api/common/types';
+import { getStackPrefix } from '../../../src/control-plane/backend/lambda/api/common/utils';
 import { StepFunctionsExecutionStatusChangeNotificationEventDetail } from '../../../src/control-plane/backend/lambda/listen-stack-status/listen-tools';
 import { handler } from '../../../src/control-plane/backend/lambda/listen-state-status';
 import 'aws-sdk-client-mock-jest';
@@ -25,6 +28,7 @@ import 'aws-sdk-client-mock-jest';
 const docMock = mockClient(DynamoDBDocumentClient);
 const cloudWatchEventsMock = mockClient(CloudWatchEventsClient);
 const snsMock = mockClient(SNSClient);
+const cloudFormationMock = mockClient(CloudFormationClient);
 
 describe('Listen SFN Status Lambda Function', () => {
 
@@ -137,6 +141,134 @@ describe('Listen SFN Status Lambda Function', () => {
     expect(cloudWatchEventsMock).toHaveReceivedCommandTimes(ListTargetsByRuleCommand, 0);
     expect(cloudWatchEventsMock).toHaveReceivedCommandTimes(RemoveTargetsCommand, 0);
     expect(cloudWatchEventsMock).toHaveReceivedCommandTimes(DeleteRuleCommand, 0);
+  });
+
+  test('Fetch all stack status when state machine is not running', async () => {
+    docMock.on(QueryCommand).resolves({
+      Items: [{
+        ...mockPipeline,
+        lastAction: 'Delete',
+        workflow: {
+          Version: '2022-03-15',
+          Workflow: {
+            Type: WorkflowStateType.PARALLEL,
+            End: true,
+            Branches: [
+              {
+                States: {
+                  DataProcessing: {
+                    Type: WorkflowStateType.STACK,
+                    Data: {
+                      Input: {
+                        Region: 'ap-southeast-1',
+                        TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-pipeline-stack.template.json',
+                        Action: 'Create',
+                        Parameters: [],
+                        StackName: `${getStackPrefix()}-DataProcessing-${MOCK_PIPELINE_ID}`,
+                      },
+                    },
+                    Next: 'DataModeling',
+                  },
+                  Reporting: {
+                    Type: WorkflowStateType.STACK,
+                    Data: {
+                      Input: {
+                        Region: 'ap-southeast-1',
+                        TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-reporting-quicksight-stack.template.json',
+                        Action: 'Create',
+                        Parameters: [],
+                        StackName: `${getStackPrefix()}-Reporting-${MOCK_PIPELINE_ID}`,
+                      },
+                    },
+                    End: true,
+                  },
+                  DataModeling: {
+                    Type: WorkflowStateType.STACK,
+                    Data: {
+                      Input: {
+                        Region: 'ap-southeast-1',
+                        TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-analytics-redshift-stack.template.json',
+                        Action: 'Create',
+                        Parameters: [
+                          {
+                            ParameterKey: 'DataProcessingCronOrRateExpression',
+                            ParameterValue: 'rate(16 minutes)',
+                          },
+                        ],
+                        StackName: `${getStackPrefix()}-DataModelingRedshift-${MOCK_PIPELINE_ID}`,
+                      },
+                    },
+                    Next: 'Reporting',
+                  },
+                },
+                StartAt: 'DataProcessing',
+              },
+            ],
+          },
+        },
+      }],
+    });
+    docMock.on(UpdateCommand).resolves({});
+    cloudFormationMock.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackId: 'arn:aws:cloudformation:ap-southeast-1:123456789012:stack/Clickstream-DataModelingRedshift-6972c135cb864885b25c5b7ebe584fdf/123',
+          StackName: `${getStackPrefix()}-DataModelingRedshift-${MOCK_PIPELINE_ID}`,
+          StackStatus: StackStatus.CREATE_COMPLETE,
+          StackStatusReason: 'Stack create completed',
+          Tags: [
+            {
+              Key: 'Version',
+              Value: '1.0.0',
+            },
+          ],
+          Outputs: [
+            {
+              OutputKey: 'Output',
+              OutputValue: 'OutputValue',
+            },
+          ],
+          CreationTime: new Date('2023-01-01'),
+        },
+      ],
+    });
+    jest
+      .useFakeTimers()
+      .setSystemTime(new Date('2023-01-01'));
+
+    const failedEvent: EventBridgeEvent<'Step Functions Execution Status Change', StepFunctionsExecutionStatusChangeNotificationEventDetail> = {
+      ...baseEvent,
+      detail: {
+        ...mockExecutionDetail,
+        status: ExecutionStatus.FAILED,
+      },
+    };
+
+    await handler(failedEvent);
+    expect(docMock).toHaveReceivedCommandTimes(QueryCommand, 1);
+    expect(docMock).toHaveReceivedNthSpecificCommandWith(1, UpdateCommand, {
+      TableName: process.env.CLICKSTREAM_TABLE_NAME ?? '',
+      Key: {
+        id: MOCK_PROJECT_ID,
+        type: `PIPELINE#${MOCK_PIPELINE_ID}#latest`,
+      },
+      ConditionExpression: '#ConditionVersion = :ConditionVersionValue',
+      UpdateExpression: 'SET #executionDetail = :executionDetail, #ConditionVersion = :updateAt',
+      ExpressionAttributeNames: {
+        '#ConditionVersion': 'updateAt',
+        '#executionDetail': 'executionDetail',
+      },
+      ExpressionAttributeValues: {
+        ':executionDetail': {
+          ...mockExecutionDetail,
+          status: ExecutionStatus.FAILED,
+        },
+        ':ConditionVersionValue': new Date('2022-01-01').getTime(),
+        ':updateAt': new Date('2023-01-01').getTime(),
+      },
+    });
+    expect(docMock).toHaveReceivedCommandTimes(UpdateCommand, 2);
+    expect(cloudFormationMock).toHaveReceivedCommandTimes(DescribeStacksCommand, 3);
   });
 
   test('Delete project', async () => {

--- a/test/jestEnv.js
+++ b/test/jestEnv.js
@@ -34,6 +34,8 @@ process.env.IAM_ROLE_PREFIX = 'test-prefix'
 process.env.IAM_ROLE_BOUNDARY_ARN = ''
 process.env.TEMPLATE_FILE = 'cloudfront-s3-control-plane-stack-global.template.json'
 process.env.SOLUTION_VERSION = 'v1.1.5-202403071513'
+process.env.LOG_LEVEL = 'ERROR'
+
 
 // web console bundling
 process.env.IS_SKIP_ASSET_BUNDLE = 'true'


### PR DESCRIPTION
(#1171)


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend