### PR TITLE
chore: delete DataFreshnessInHour for data modeling stack

### DIFF
--- a/src/analytics/parameter.ts
+++ b/src/analytics/parameter.ts
@@ -634,7 +634,7 @@ export function createStackParameters(scope: Construct): {
     default: 365,
   });
 
-  const dataFreshnessInHourParam = Parameters.createDataFreshnessInHourParameter(scope);
+  const dataFreshnessInHourParam = Parameters.createDataFreshnessInHourParameter(scope, 24);
 
   const timezoneWithAppIdParam = new CfnParameter(scope, 'TimeZoneWithAppId', {
     description: 'The time zone with app id as json string',

--- a/src/common/parameters.ts
+++ b/src/common/parameters.ts
@@ -699,10 +699,10 @@ export class Parameters {
     });
   }
 
-  public static createDataFreshnessInHourParameter(scope: Construct) {
+  public static createDataFreshnessInHourParameter(scope: Construct, hour: number = 72) {
     return new CfnParameter(scope, 'DataFreshnessInHour', {
-      description: 'Data Freshness in hour, default is 72 hours (3 days)',
-      default: 72,
+      description: `Data Freshness in hour, default is ${hour.toString()} hours`,
+      default: hour,
       type: 'Number',
     });
   }

--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -1267,14 +1267,6 @@ export class CDataModelingStack extends JSONObject {
   @supportVersions([SolutionVersion.V_1_1_6, SolutionVersion.ANY])
     TimeZoneWithAppId?: string;
 
-  @JSONObject.optional(72)
-  @JSONObject.gt(0)
-  @JSONObject.custom( (stack :CDataProcessingStack, _key:string, _value:any) => {
-    return stack._pipeline?.dataProcessing?.dataFreshnessInHour ?? 72;
-  })
-  @supportVersions([SolutionVersion.V_1_1_6, SolutionVersion.ANY])
-    DataFreshnessInHour?: number;
-
   @JSONObject.optional('')
   @JSONObject.custom( (stack:CDataModelingStack, _key:string, _value:string) => {
     return getAppRegistryApplicationArn(stack._pipeline);

--- a/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
@@ -839,10 +839,6 @@ const BASE_DATAANALYTICS_PARAMETERS = [
     ParameterKey: 'TimeZoneWithAppId',
     ParameterValue: '[{\"timezone\":\"Asia/Singapore\",\"appId\":\"app_7777_7777\"}]',
   },
-  {
-    ParameterKey: 'DataFreshnessInHour',
-    ParameterValue: '7',
-  },
 ];
 
 export const DATA_PROCESSING_NEW_SERVERLESS_WITH_SPECIFY_PREFIX_PARAMETERS = mergeParameters(


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend