### PR TITLE
chore: add Redshift api role ARN as reporting stack parameter

### DIFF
--- a/src/base-lib/src/constant/constant.ts
+++ b/src/base-lib/src/constant/constant.ts
@@ -268,6 +268,7 @@ export const SERVICE_CATALOG_APPREGISTRY_ARN_PATTERN = 'arn:aws(-cn|-us-gov)?:se
 export const S3_BUCKET_ARN_PATTERN = 'arn:aws(-cn|-us-gov)?:s3:::[a-z0-9\\.\\-]{3,63}';
 export const KINESIS_DATA_STREAM_ARN_PATTERN = '^arn:aws(-cn|-us-gov)?:kinesis:[a-z0-9-]+:[0-9]{12}:stream/[a-zA-Z0-9_.-]{1,128}$';
 export const KMS_KEY_ARN_PATTERN = '^arn:aws(-cn|-us-gov)?:kms:[a-z0-9-]+:[0-9]{12}:key/([a-zA-Z0-9-_]+)$';
+export const IAM_ROLE_ARN_PATTERN = '^arn:aws(-cn|-us-gov)?:iam::[0-9]{12}:role/([a-zA-Z0-9-_]+)$';
 export const SCHEDULE_EXPRESSION_PATTERN =
   '^(rate\\(\\s*\\d+\\s+(hour|minute|day)s?\\s*\\))|(cron\\(.*\\))$';
 
@@ -359,6 +360,12 @@ export const OUTPUT_REPORTING_QUICKSIGHT_DATA_SOURCE_ARN =
   'DataSourceArn';
 export const OUTPUT_REPORTING_QUICKSIGHT_DASHBOARDS =
   'Dashboards';
+
+export const OUTPUT_REPORTING_QUICKSIGHT_REDSHIFT_DATA_API_ROLE_ARN =
+  'RedshiftDataApiRoleArn';
+
+export const OUTPUT_REPORTING_QUICKSIGHT_REDSHIFT_ENDPOINT_ADDRESS =
+  'RedshiftEndpointAddress';
 
 export const OUTPUT_METRICS_OBSERVABILITY_DASHBOARD_NAME =
   'ObservabilityDashboardName';

--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -372,7 +372,6 @@ export class CPipeline {
       length: 255,
       omission: '',
     });
-    console.log(`Creating topic ${topicName}`);
     const topicArn = await createTopicAndSubscribeSQSQueue(
       this.pipeline.region,
       this.pipeline.projectId,

--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -19,6 +19,7 @@ import {
   MULTI_EMAIL_PATTERN,
   MULTI_SECURITY_GROUP_PATTERN,
   OUTPUT_DATA_MODELING_REDSHIFT_BI_USER_CREDENTIAL_PARAMETER_SUFFIX,
+  OUTPUT_DATA_MODELING_REDSHIFT_DATA_API_ROLE_ARN_SUFFIX,
   OUTPUT_DATA_MODELING_REDSHIFT_SERVERLESS_WORKGROUP_ENDPOINT_ADDRESS,
   OUTPUT_DATA_MODELING_REDSHIFT_SERVERLESS_WORKGROUP_ENDPOINT_PORT,
   OUTPUT_DATA_PROCESSING_EMR_SERVERLESS_APPLICATION_ID_SUFFIX,
@@ -1316,6 +1317,7 @@ export class CReportingStack extends JSONObject {
       'RedShiftDBSchemaParam',
       'QuickSightVpcConnectionSubnetParam',
       'RedshiftParameterKeyParam',
+      'RedshiftIAMRoleParam',
       'QuickSightPrincipalParam',
       'QuickSightOwnerPrincipalParam',
       'QuickSightTimezoneParam',
@@ -1435,6 +1437,20 @@ export class CReportingStack extends JSONObject {
     );;
   })
     RedshiftParameterKeyParam?: string;
+
+  @JSONObject.optional('')
+  @JSONObject.custom( (stack:CReportingStack, _key:string, _value:any) => {
+    if (!stack._pipeline) {
+      return '';
+    }
+    return getValueFromStackOutputSuffix(
+      stack._pipeline,
+      PipelineStackType.DATA_MODELING_REDSHIFT,
+      OUTPUT_DATA_MODELING_REDSHIFT_DATA_API_ROLE_ARN_SUFFIX,
+    );;
+  })
+  @supportVersions([SolutionVersion.V_1_1_6, SolutionVersion.ANY])
+    RedshiftIAMRoleParam?: string;
 
   @JSONObject.optional('')
   @JSONObject.custom( (stack :CReportingStack, _key:string, _value:any) => {

--- a/src/control-plane/backend/lambda/api/service/quicksight/reporting-utils.ts
+++ b/src/control-plane/backend/lambda/api/service/quicksight/reporting-utils.ts
@@ -671,7 +671,6 @@ export function getFunnelTableVisualDef(visualId: string, viewName: string, even
     Width: '120px',
   });
 
-  console.log(groupingColNames);
   for (const colName of groupingColNames) {
     const groupColFieldId = uuidv4();
     groupBy.push({

--- a/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
@@ -11,6 +11,7 @@
  *  and limitations under the License.
  */
 
+import { OUTPUT_REPORTING_QUICKSIGHT_REDSHIFT_DATA_API_ROLE_ARN, OUTPUT_REPORTING_QUICKSIGHT_REDSHIFT_ENDPOINT_ADDRESS } from '@aws/clickstream-base-lib';
 import { StackStatus } from '@aws-sdk/client-cloudformation';
 import { ExecutionStatus } from '@aws-sdk/client-sfn';
 import { MOCK_APP_ID, MOCK_EXECUTION_ID, MOCK_EXECUTION_ID_OLD, MOCK_PIPELINE_ID, MOCK_PLUGIN_ID, MOCK_PROJECT_ID, MOCK_SOLUTION_VERSION } from './ddb-mock';
@@ -610,7 +611,7 @@ export const MSK_DATA_PROCESSING_NEW_SERVERLESS_PIPELINE_WITH_WORKFLOW: IPipelin
                   BucketName: 'EXAMPLE_BUCKET',
                 },
               },
-              Next: 'DataModeling',
+              Next: 'DataModelingRedshift',
             },
             Reporting: {
               Type: WorkflowStateType.STACK,
@@ -629,7 +630,7 @@ export const MSK_DATA_PROCESSING_NEW_SERVERLESS_PIPELINE_WITH_WORKFLOW: IPipelin
               },
               End: true,
             },
-            DataModeling: {
+            DataModelingRedshift: {
               Type: WorkflowStateType.STACK,
               Data: {
                 Input: {
@@ -1003,6 +1004,14 @@ export const BASE_STATUS = {
           OutputKey: 'Dashboards',
           OutputValue: '[{"appId":"app1","dashboardId":"clickstream_dashboard_v1_notepad_mtzfsocy_app1"},{"appId":"app2","dashboardId":"clickstream_dashboard_v1_notepad_mtzfsocy_app2"}]',
         },
+        {
+          OutputKey: OUTPUT_REPORTING_QUICKSIGHT_REDSHIFT_DATA_API_ROLE_ARN,
+          OutputValue: 'arn:aws:iam::111122223333:role/RedshiftDataApiRole',
+        },
+        {
+          OutputKey: OUTPUT_REPORTING_QUICKSIGHT_REDSHIFT_ENDPOINT_ADDRESS,
+          OutputValue: 'redshift-cluster-1.cjvqjvqjvqjv.ap-southeast-1.redshift.amazonaws.com',
+        },
       ],
     },
     {
@@ -1129,7 +1138,7 @@ export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW: IPipel
                   BucketName: 'EXAMPLE_BUCKET',
                 },
               },
-              Next: 'DataModeling',
+              Next: 'DataModelingRedshift',
             },
             Reporting: {
               Type: WorkflowStateType.STACK,
@@ -1148,7 +1157,7 @@ export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW: IPipel
               },
               End: true,
             },
-            DataModeling: {
+            DataModelingRedshift: {
               Type: WorkflowStateType.STACK,
               Data: {
                 Input: {
@@ -1267,7 +1276,7 @@ export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW_AND_EXP
                   BucketName: 'EXAMPLE_BUCKET',
                 },
               },
-              Next: 'DataModeling',
+              Next: 'DataModelingRedshift',
             },
             Reporting: {
               Type: WorkflowStateType.STACK,
@@ -1286,7 +1295,7 @@ export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW_AND_EXP
               },
               End: true,
             },
-            DataModeling: {
+            DataModelingRedshift: {
               Type: WorkflowStateType.STACK,
               Data: {
                 Input: {
@@ -1314,7 +1323,7 @@ export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW_AND_EXP
         {
           States: {
           },
-          StartAt: 'DataModeling',
+          StartAt: 'DataModelingRedshift',
         },
         {
           StartAt: 'Metrics',
@@ -1410,7 +1419,7 @@ export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW_FOR_UPG
                   BucketName: 'EXAMPLE_BUCKET',
                 },
               },
-              Next: 'DataModeling',
+              Next: 'DataModelingRedshift',
             },
             Reporting: {
               Type: WorkflowStateType.STACK,
@@ -1429,7 +1438,7 @@ export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW_FOR_UPG
               },
               End: true,
             },
-            DataModeling: {
+            DataModelingRedshift: {
               Type: WorkflowStateType.STACK,
               Data: {
                 Input: {
@@ -1546,7 +1555,7 @@ export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_UPDATE_PIPELINE_WITH_WORKFLOW:
                   BucketName: 'EXAMPLE_BUCKET',
                 },
               },
-              Next: 'DataModeling',
+              Next: 'DataModelingRedshift',
             },
             Reporting: {
               Type: WorkflowStateType.STACK,
@@ -1574,7 +1583,7 @@ export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_UPDATE_PIPELINE_WITH_WORKFLOW:
               },
               End: true,
             },
-            DataModeling: {
+            DataModelingRedshift: {
               Type: WorkflowStateType.STACK,
               Data: {
                 Input: {
@@ -1759,7 +1768,7 @@ const BASE_RETRY_PIPELINE: IPipeline = {
                   BucketName: 'EXAMPLE_BUCKET',
                 },
               },
-              Next: 'DataModeling',
+              Next: 'DataModelingRedshift',
             },
             Reporting: {
               Type: WorkflowStateType.STACK,
@@ -1778,7 +1787,7 @@ const BASE_RETRY_PIPELINE: IPipeline = {
               },
               End: true,
             },
-            DataModeling: {
+            DataModelingRedshift: {
               Type: WorkflowStateType.STACK,
               Data: {
                 Input: {

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -236,7 +236,6 @@ describe('Pipeline test', () => {
       const workflow = input.TransactItems[1].Put.Item.workflow.M.Workflow.M;
       const serviceCatalogAppRegistry = workflow.Branches.L[0].M.States.M.ServiceCatalogAppRegistry.M;
       const callback = serviceCatalogAppRegistry.Data.M.Callback.M;
-      console.log(callback);
       expect(
         callback.BucketName.S === 'TEST_EXAMPLE_BUCKET' &&
         callback.BucketPrefix.S.startsWith('clickstream/workflow/main-') &&
@@ -3427,7 +3426,8 @@ describe('Pipeline test', () => {
         expressionAttributeValues[':templateVersion'].S === SolutionVersion.V_1_1_4.fullVersion &&
         expressionAttributeValues[':tags'].L[0].M.value.S === SolutionVersion.V_1_1_4.fullVersion &&
         reportInput.M.Parameters.L[0].M.ParameterValue.S === 'GCRUser' &&
-        reportInput.M.Parameters.L[1].M.ParameterValue.S === 'arn:aws:quicksight:us-east-1:555555555555:user/default/QuickSightEmbeddingRole/GCRUser',
+        reportInput.M.Parameters.L[1].M.ParameterValue.S === 'default' &&
+        reportInput.M.Parameters.L[2].M.ParameterValue.S === 'arn:aws:quicksight:us-east-1:555555555555:user/default/QuickSightEmbeddingRole/GCRUser',
       ).toBeTruthy();
     });
     process.env.AWS_REGION = 'cn-north-1';

--- a/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
@@ -1002,6 +1002,10 @@ const BASE_REPORTING_PARAMETERS = [
     ParameterValue: `#.${getStackPrefix()}-DataModelingRedshift-6666-6666.BIUserCredentialParameterName`,
   },
   {
+    ParameterKey: 'RedshiftIAMRoleParam.#',
+    ParameterValue: `#.${getStackPrefix()}-DataModelingRedshift-6666-6666.RedshiftDataApiRoleArn`,
+  },
+  {
     ParameterKey: 'QuickSightTimezoneParam',
     ParameterValue: '[{\"timezone\":\"Asia/Singapore\",\"appId\":\"app_7777_7777\"}]',
   },
@@ -1068,6 +1072,10 @@ export const REPORTING_WITH_NEW_REDSHIFT_PARAMETERS = [
   {
     ParameterKey: 'RedshiftParameterKeyParam.#',
     ParameterValue: `#.${getStackPrefix()}-DataModelingRedshift-6666-6666.BIUserCredentialParameterName`,
+  },
+  {
+    ParameterKey: 'RedshiftIAMRoleParam.#',
+    ParameterValue: `#.${getStackPrefix()}-DataModelingRedshift-6666-6666.RedshiftDataApiRoleArn`,
   },
   {
     ParameterKey: 'QuickSightTimezoneParam',

--- a/src/control-plane/backend/lambda/api/test/api/workflow-version.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-version.test.ts
@@ -586,6 +586,9 @@ describe('Workflow test with pipeline version', () => {
                         {
                           ParameterKey: 'QuickSightTimezoneParam',
                         },
+                        {
+                          ParameterKey: 'RedshiftIAMRoleParam.#',
+                        },
                       ],
                       ),
                     },
@@ -677,6 +680,9 @@ describe('Workflow test with pipeline version', () => {
                           {
                             ParameterKey: 'QuickSightTimezoneParam',
                           },
+                          {
+                            ParameterKey: 'RedshiftIAMRoleParam.#',
+                          },
                         ]),
                     },
                   },
@@ -757,6 +763,9 @@ describe('Workflow test with pipeline version', () => {
                         [
                           {
                             ParameterKey: 'QuickSightTimezoneParam',
+                          },
+                          {
+                            ParameterKey: 'RedshiftIAMRoleParam.#',
                           },
                         ],
                       ),
@@ -1219,6 +1228,9 @@ describe('Workflow test with pipeline version in China region', () => {
                         [
                           {
                             ParameterKey: 'QuickSightTimezoneParam',
+                          },
+                          {
+                            ParameterKey: 'RedshiftIAMRoleParam.#',
                           },
                         ],
                       ),

--- a/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
@@ -2946,7 +2946,7 @@ describe('Workflow test', () => {
                     TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-pipeline-stack.template.json',
                   },
                 },
-                Next: 'DataModeling',
+                Next: 'DataModelingRedshift',
                 Type: 'Pass',
               },
               Reporting: {
@@ -2966,7 +2966,7 @@ describe('Workflow test', () => {
                 },
                 End: true,
               },
-              DataModeling: {
+              DataModelingRedshift: {
                 Data: {
                   Callback: {
                     BucketName: 'TEST_EXAMPLE_BUCKET',
@@ -3083,7 +3083,7 @@ describe('Workflow test', () => {
                     TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-pipeline-stack.template.json',
                   },
                 },
-                Next: 'DataModeling',
+                Next: 'DataModelingRedshift',
                 Type: 'Pass',
               },
               Reporting: {
@@ -3103,7 +3103,7 @@ describe('Workflow test', () => {
                 },
                 End: true,
               },
-              DataModeling: {
+              DataModelingRedshift: {
                 Data: {
                   Callback: {
                     BucketName: 'TEST_EXAMPLE_BUCKET',
@@ -3221,7 +3221,7 @@ describe('Workflow test', () => {
                     TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-pipeline-stack.template.json',
                   },
                 },
-                Next: 'DataModeling',
+                Next: 'DataModelingRedshift',
                 Type: 'Pass',
               },
               Reporting: {
@@ -3241,7 +3241,7 @@ describe('Workflow test', () => {
                 },
                 End: true,
               },
-              DataModeling: {
+              DataModelingRedshift: {
                 Data: {
                   Callback: {
                     BucketName: 'TEST_EXAMPLE_BUCKET',
@@ -3376,7 +3376,7 @@ describe('Workflow test', () => {
                     TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-pipeline-stack.template.json',
                   },
                 },
-                Next: 'DataModeling',
+                Next: 'DataModelingRedshift',
                 Type: 'Stack',
               },
               Reporting: {
@@ -3396,7 +3396,7 @@ describe('Workflow test', () => {
                 },
                 End: true,
               },
-              DataModeling: {
+              DataModelingRedshift: {
                 Data: {
                   Callback: {
                     BucketName: 'TEST_EXAMPLE_BUCKET',
@@ -3521,7 +3521,7 @@ describe('Workflow test', () => {
                     TemplateURL: `https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/${MOCK_SOLUTION_VERSION}/default/data-pipeline-stack.template.json`,
                   },
                 },
-                Next: 'DataModeling',
+                Next: 'DataModelingRedshift',
                 Type: 'Stack',
               },
               Reporting: {
@@ -3541,7 +3541,7 @@ describe('Workflow test', () => {
                 },
                 End: true,
               },
-              DataModeling: {
+              DataModelingRedshift: {
                 Data: {
                   Callback: {
                     BucketName: 'TEST_EXAMPLE_BUCKET',
@@ -3660,7 +3660,7 @@ describe('Workflow test', () => {
                     TemplateURL: `https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/${MOCK_SOLUTION_VERSION}/default/data-pipeline-stack.template.json`,
                   },
                 },
-                Next: 'DataModeling',
+                Next: 'DataModelingRedshift',
                 Type: 'Stack',
               },
               Reporting: {
@@ -3680,7 +3680,7 @@ describe('Workflow test', () => {
                 },
                 End: true,
               },
-              DataModeling: {
+              DataModelingRedshift: {
                 Data: {
                   Callback: {
                     BucketName: 'TEST_EXAMPLE_BUCKET',
@@ -3810,9 +3810,9 @@ describe('Workflow test', () => {
                     BucketName: 'TEST_EXAMPLE_BUCKET',
                   },
                 },
-                Next: 'DataModeling',
+                Next: 'DataModelingRedshift',
               },
-              DataModeling: {
+              DataModelingRedshift: {
                 Data: {
                   Callback: {
                     BucketName: 'TEST_EXAMPLE_BUCKET',
@@ -4723,7 +4723,7 @@ describe('Workflow test', () => {
           {
             StartAt: 'DataModeling',
             States: {
-              DataModeling: {
+              DataModelingRedshift: {
                 Type: WorkflowStateType.STACK,
                 Data: {
                   Input: {

--- a/src/data-reporting-quicksight-stack.ts
+++ b/src/data-reporting-quicksight-stack.ts
@@ -13,7 +13,7 @@
 
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { OUTPUT_REPORTING_QUICKSIGHT_DASHBOARDS, OUTPUT_REPORTING_QUICKSIGHT_DATA_SOURCE_ARN, SolutionInfo } from '@aws/clickstream-base-lib';
+import { OUTPUT_REPORTING_QUICKSIGHT_DASHBOARDS, OUTPUT_REPORTING_QUICKSIGHT_DATA_SOURCE_ARN, OUTPUT_REPORTING_QUICKSIGHT_REDSHIFT_DATA_API_ROLE_ARN, OUTPUT_REPORTING_QUICKSIGHT_REDSHIFT_ENDPOINT_ADDRESS, SolutionInfo } from '@aws/clickstream-base-lib';
 import {
   Aspects,
   Aws,
@@ -190,6 +190,17 @@ export class DataReportingQuickSightStack extends Stack {
       description: 'The QuickSight data source arn',
       value: dataSource.attrArn,
     }).overrideLogicalId(OUTPUT_REPORTING_QUICKSIGHT_DATA_SOURCE_ARN);
+
+    new CfnOutput(this, OUTPUT_REPORTING_QUICKSIGHT_REDSHIFT_DATA_API_ROLE_ARN, {
+      description: 'Redshift data api role arn.',
+      value: stackParams.redshiftIAMRoleParam.valueAsString,
+    }).overrideLogicalId(OUTPUT_REPORTING_QUICKSIGHT_REDSHIFT_DATA_API_ROLE_ARN);
+
+    new CfnOutput(this, OUTPUT_REPORTING_QUICKSIGHT_REDSHIFT_ENDPOINT_ADDRESS, {
+      description: 'Redshift workgroup name.',
+      value: stackParams.redshiftEndpointParam.valueAsString,
+    }).overrideLogicalId(OUTPUT_REPORTING_QUICKSIGHT_REDSHIFT_ENDPOINT_ADDRESS);
+
 
     addCfnNag(this);
 

--- a/src/reporting/parameter.ts
+++ b/src/reporting/parameter.ts
@@ -20,6 +20,7 @@ import {
   SECURITY_GROUP_PATTERN,
   SUBNETS_PATTERN,
   QUICKSIGHT_USER_ARN_PATTERN,
+  IAM_ROLE_ARN_PATTERN,
 } from '@aws/clickstream-base-lib';
 import { CfnParameter } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
@@ -142,6 +143,15 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
     default: 'Parameter Key Name',
   };
 
+  const redshiftIAMRoleParam = new CfnParameter(scope, 'RedshiftIAMRoleParam', {
+    description: 'The ARN of IAM role used by Redshift Data API.',
+    type: 'String',
+    allowedPattern: IAM_ROLE_ARN_PATTERN,
+  });
+  labels[redshiftIAMRoleParam.logicalId] = {
+    default: 'Redshift Data API Role ARN',
+  };
+
   groups.push({
     Label: { default: 'QuickSight Information' },
     Parameters: [
@@ -163,6 +173,7 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
       redShiftDBSchemaParam.logicalId,
       redshiftPortParam.logicalId,
       redshiftParameterKeyParam.logicalId,
+      redshiftIAMRoleParam.logicalId,
     ],
   });
 
@@ -179,6 +190,7 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
     redShiftDBSchemaParam,
     redshiftPortParam,
     redshiftParameterKeyParam,
+    redshiftIAMRoleParam,
     paramLabels: labels,
     paramGroups: groups,
   };

--- a/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
+++ b/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-import { OUTPUT_REPORTING_QUICKSIGHT_DASHBOARDS, OUTPUT_REPORTING_QUICKSIGHT_DATA_SOURCE_ARN } from '@aws/clickstream-base-lib';
+import { OUTPUT_REPORTING_QUICKSIGHT_DASHBOARDS, OUTPUT_REPORTING_QUICKSIGHT_DATA_SOURCE_ARN, OUTPUT_REPORTING_QUICKSIGHT_REDSHIFT_DATA_API_ROLE_ARN, OUTPUT_REPORTING_QUICKSIGHT_REDSHIFT_ENDPOINT_ADDRESS } from '@aws/clickstream-base-lib';
 import { App } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { DataReportingQuickSightStack } from '../../../src/data-reporting-quicksight-stack';
@@ -31,6 +31,14 @@ describe('DataReportingQuickSightStack parameter test', () => {
 
   test('Has Dashboards output', () => {
     template.hasOutput(OUTPUT_REPORTING_QUICKSIGHT_DATA_SOURCE_ARN, {});
+  });
+
+  test('Has Redshift serverless data api role output', () => {
+    template.hasOutput(OUTPUT_REPORTING_QUICKSIGHT_REDSHIFT_DATA_API_ROLE_ARN, {});
+  });
+
+  test('Has Redshift serverless workgroup name', () => {
+    template.hasOutput(OUTPUT_REPORTING_QUICKSIGHT_REDSHIFT_ENDPOINT_ADDRESS, {});
   });
 
   test('Should has Parameter quickSightUserParam', () => {
@@ -88,6 +96,12 @@ describe('DataReportingQuickSightStack parameter test', () => {
   test('Should has Parameter redshiftPortParam', () => {
     template.hasParameter('RedshiftPortParam', {
       Type: 'Number',
+    });
+  });
+
+  test('Should has Parameter redshiftIAMRoleParam', () => {
+    template.hasParameter('RedshiftIAMRoleParam', {
+      Type: 'String',
     });
   });
 
@@ -316,6 +330,34 @@ describe('DataReportingQuickSightStack parameter test', () => {
       Type: 'String',
     });
   });
+
+  test('RedshiftIAMRole allowedPattern', () => {
+    const param = template.toJSON().Parameters.RedshiftIAMRoleParam;
+    const pattern = param.AllowedPattern;
+    const regex = new RegExp(`${pattern}`);
+    const validValues = [
+      'arn:aws:iam::000000000000:role/redshift-serverless-role',
+      'arn:aws-cn:iam::000000000000:role/redshift-serverless-role',
+    ];
+
+    for (const v of validValues) {
+      expect(v).toMatch(regex);
+    }
+
+    const invalidValues = [
+      'arn:aws:iam::xxxxxxxxxxxx:role/redshift-serverless-role',
+      'arn:aws:iam::1234:role/redshift-serverless-role',
+      'b1.test.com:abc',
+      'b-1.test.com:9092,b-2.test.com:9092',
+      'b1.test.com:9092',
+      'b_1.test.com',
+      '',
+    ];
+    for (const v of invalidValues) {
+      expect(v).not.toMatch(regex);
+    }
+  });
+
 });
 
 describe('DataReportingQuickSightStack resource test', () => {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend