### PR TITLE
chore: add alarm for sql execution

### DIFF
--- a/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
+++ b/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
@@ -2896,6 +2896,22 @@ describe('Should set metrics widgets', () => {
     });
 
     newServerlessTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
+
+      AlarmDescription: {
+        'Fn::Join': [
+          '',
+          [
+            'Sql execution to create schema failed, projectId: ',
+            Match.anyValue(),
+          ],
+        ],
+      },
+
+      TreatMissingData: TreatMissingData.NOT_BREACHING,
+      Period: 86400,
+    });
+
+    newServerlessTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
       AlarmDescription: {
         'Fn::Join': [
           '',
@@ -3000,6 +3016,21 @@ describe('Should set metrics widgets', () => {
       },
     });
 
+    existingServerlessTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
+
+      AlarmDescription: {
+        'Fn::Join': [
+          '',
+          [
+            'Sql execution to create schema failed, projectId: ',
+            Match.anyValue(),
+          ],
+        ],
+      },
+
+      TreatMissingData: TreatMissingData.NOT_BREACHING,
+      Period: 86400,
+    });
 
     newServerlessTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
       AlarmDescription: {
@@ -3089,6 +3120,7 @@ describe('Should set metrics widgets', () => {
                 Match.objectLike({ 'Fn::GetAtt': Match.anyValue() }),
                 Match.objectLike({ 'Fn::GetAtt': Match.anyValue() }),
                 Match.objectLike({ 'Fn::GetAtt': Match.anyValue() }),
+                Match.objectLike({ 'Fn::GetAtt': Match.anyValue() }),
               ]),
               title: Match.anyValue(),
             },
@@ -3147,6 +3179,21 @@ describe('Should set metrics widgets', () => {
       },
     });
 
+    provisionTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
+
+      AlarmDescription: {
+        'Fn::Join': [
+          '',
+          [
+            'Sql execution to create schema failed, projectId: ',
+            Match.anyValue(),
+          ],
+        ],
+      },
+
+      TreatMissingData: TreatMissingData.NOT_BREACHING,
+      Period: 86400,
+    });
 
     provisionTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
       AlarmDescription: {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

cherry-pick "add alarm for sql execution"

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend