### PR TITLE
fix: long field value causes scanning workflow failure

### DIFF
--- a/src/analytics/private/sqls/redshift/sp-scan-metadata.sql
+++ b/src/analytics/private/sqls/redshift/sp-scan-metadata.sql
@@ -84,7 +84,7 @@ BEGIN
 		event_timestamp TIMESTAMP,
     property_category VARCHAR(20),
     property_name VARCHAR(255),
-    property_value VARCHAR(512),
+    property_value VARCHAR(MAX),
     value_type VARCHAR(255),
     platform VARCHAR(255)	
   );


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

fix long value issue

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend