### PR TITLE
fix: add default db param to Reporting stack

### DIFF
--- a/src/data-reporting-quicksight-stack.ts
+++ b/src/data-reporting-quicksight-stack.ts
@@ -136,7 +136,7 @@ export class DataReportingQuickSightStack extends Stack {
       },
       dataSourceParameters: {
         redshiftParameters: {
-          database: stackParams.redshiftDBParam.valueAsString,
+          database: stackParams.redshiftDefaultDBParam.valueAsString,
           host: stackParams.redshiftEndpointParam.valueAsString,
           port: stackParams.redshiftPortParam.valueAsNumber,
         },

--- a/src/reporting/parameter.ts
+++ b/src/reporting/parameter.ts
@@ -110,6 +110,15 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
     default: 'Enable QuickSight SPICE Import Mode',
   };
 
+  const redshiftDefaultDBParam = new CfnParameter(scope, 'RedshiftDefaultDBParam', {
+    description: 'Redshift Default database name.',
+    type: 'String',
+    default: 'dev',
+  });
+  labels[redshiftDefaultDBParam.logicalId] = {
+    default: 'Redshift Default Database Name',
+  };
+
   const redshiftDBParam = new CfnParameter(scope, 'RedshiftDBParam', {
     description: 'Redshift database name.',
     type: 'String',
@@ -181,6 +190,7 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
     Label: { default: 'Redshift Information' },
     Parameters: [
       redshiftEndpointParam.logicalId,
+      redshiftDefaultDBParam.logicalId,
       redshiftDBParam.logicalId,
       redShiftDBSchemaParam.logicalId,
       redshiftPortParam.logicalId,
@@ -199,6 +209,7 @@ export function createStackParametersQuickSight(scope: Construct, paramGroups?: 
     quickSightTimezoneParam,
     quickSightUseSpiceParam,
     redshiftEndpointParam,
+    redshiftDefaultDBParam,
     redshiftDBParam,
     redShiftDBSchemaParam,
     redshiftPortParam,

--- a/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
+++ b/test/reporting/quicksight/data-reporting-quicksight-stack.test.ts
@@ -99,6 +99,13 @@ describe('DataReportingQuickSightStack parameter test', () => {
     });
   });
 
+  test('Should has Parameter redshiftDefaultDBParam', () => {
+    template.hasParameter('RedshiftDefaultDBParam', {
+      Type: 'String',
+      Default: 'dev',
+    });
+  });
+
   test('Should has Parameter redShiftDBSchemaParam', () => {
     template.hasParameter('RedShiftDBSchemaParam', {
       Description: 'Comma delimited Redshift database schema name list',
@@ -844,7 +851,7 @@ describe('DataReportingQuickSightStack resource test', () => {
     DataSourceParameters: {
       RedshiftParameters: {
         Database: {
-          Ref: 'RedshiftDBParam',
+          Ref: 'RedshiftDefaultDBParam',
         },
         Host: {
           Ref: 'RedshiftEndpointParam',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend