### PR TITLE
fix: ETL cache error when processing huge data

### DIFF
--- a/src/data-pipeline/etl-common/src/main/java/software/aws/solution/clickstream/common/Cache.java
+++ b/src/data-pipeline/etl-common/src/main/java/software/aws/solution/clickstream/common/Cache.java
@@ -12,23 +12,19 @@
  */
 
 package software.aws.solution.clickstream.common;
+import java.util.HashMap;
 import java.util.Map;
-
-import java.util.LinkedHashMap;
 
 public class Cache<T> {
     private final Map<String, T> dataCached;
+    private final int size;
 
     public Cache() {
-        this(Integer.MAX_VALUE);
+        this(Integer.MAX_VALUE/2);
     }
     public Cache(final int size) {
-        this.dataCached = new LinkedHashMap<>(10_000, 0.75f, true) {
-            @Override
-            protected boolean removeEldestEntry(final Map.Entry<String, T> eldest) {
-                return size() >  size;
-            }
-        };
+        this.dataCached = new HashMap<>(1024 * 1024);
+        this.size = size;
     }
     public boolean containsKey(final String key) {
         return dataCached.containsKey(key);
@@ -38,6 +34,9 @@ public class Cache<T> {
     }
 
     public void put(final String key, final T data) {
+        if (dataCached.size() >= size) {
+            dataCached.remove(dataCached.keySet().iterator().next());
+        }
         dataCached.put(key, data);
     }
 }

--- a/src/data-pipeline/etl-common/src/test/java/software/aws/solution/clickstream/common/CacheTest.java
+++ b/src/data-pipeline/etl-common/src/test/java/software/aws/solution/clickstream/common/CacheTest.java
@@ -1,0 +1,56 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+package software.aws.solution.clickstream.common;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CacheTest {
+    private Cache<String> cache;
+
+    @BeforeEach
+    void setUp() {
+        cache = new Cache<>(2);
+    }
+
+    @Test
+    void shouldStoreDataWhenCacheIsNotFull() {
+        cache.put("key1", "data1");
+        assertTrue(cache.containsKey("key1"));
+        assertEquals("data1", cache.get("key1"));
+    }
+
+    @Test
+    void shouldOverwriteDataWhenKeyExists() {
+        cache.put("key1", "data1");
+        cache.put("key1", "data2");
+        assertEquals("data2", cache.get("key1"));
+    }
+
+    @Test
+    void shouldRemoveOldestDataWhenCacheIsFull() {
+        cache.put("key1", "data1");
+        cache.put("key2", "data2");
+        cache.put("key3", "data3");
+        assertFalse(cache.containsKey("key1"));
+        assertTrue(cache.containsKey("key2"));
+        assertTrue(cache.containsKey("key3"));
+    }
+
+    @Test
+    void shouldReturnNullWhenKeyDoesNotExist() {
+        assertNull(cache.get("nonexistentKey"));
+    }
+}


### PR DESCRIPTION
Fix below java error in EMR when processing huge data, tried small data, it is ok. do not know why. Copilot suggested change the link hash map to hash map. also reduced the cache max size. 

```
Caused by: java.lang.ClassCastException: class java.util.LinkedHashMap$Entry cannot be cast to class java.util.HashMap$TreeNode (java.util.LinkedHashMap$Entry and java.util.HashMap$TreeNode are in module java.base of loader 'bootstrap')
	at java.base/java.util.HashMap$TreeNode.moveRootToFront(HashMap.java:1986)
	at java.base/java.util.HashMap$TreeNode.treeify(HashMap.java:2102)
	at java.base/java.util.HashMap.treeifyBin(HashMap.java:770)
	at java.base/java.util.HashMap.putVal(HashMap.java:642)
	at java.base/java.util.HashMap.put(HashMap.java:610)
	at software.aws.solution.clickstream.common.Cache.put(Cache.java:41)
	at software.aws.solution.clickstream.IPEnrichment.lambda$enrich$20f73cd0$1(IPEnrichment.java:102)
	at org.apache.spark.sql.functions$.$anonfun$udf$93(functions.scala:5434)
	... 43 more
```


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend