### PR TITLE
chore: add RedshiftDefaultDBParam for reporting stack (#1256)

### DIFF
--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -1463,6 +1463,13 @@ export class CReportingStack extends JSONObject {
   @supportVersions([SolutionVersion.V_1_1_6, SolutionVersion.ANY])
     QuickSightTimezoneParam?: string;
 
+  @JSONObject.optional('dev')
+  @JSONObject.custom( (stack:CReportingStack, _key:string, _value:any) => {
+    return stack._pipeline?.projectId ?? 'dev';
+  })
+  @supportVersions([SolutionVersion.V_1_1_6, SolutionVersion.ANY])
+    RedshiftDefaultDBParam?: string;
+
   @JSONObject.optional('')
   @JSONObject.custom( (stack:CReportingStack, _key:string, _value:string) => {
     return getAppRegistryApplicationArn(stack._pipeline);

--- a/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
@@ -1009,6 +1009,10 @@ const BASE_REPORTING_PARAMETERS = [
     ParameterKey: 'QuickSightTimezoneParam',
     ParameterValue: '[{\"timezone\":\"Asia/Singapore\",\"appId\":\"app_7777_7777\"}]',
   },
+  {
+    ParameterKey: 'RedshiftDefaultDBParam',
+    ParameterValue: 'project_8888_8888',
+  },
 ];
 
 export const REPORTING_WITH_PROVISIONED_REDSHIFT_PARAMETERS = [
@@ -1080,6 +1084,10 @@ export const REPORTING_WITH_NEW_REDSHIFT_PARAMETERS = [
   {
     ParameterKey: 'QuickSightTimezoneParam',
     ParameterValue: '[{\"timezone\":\"Asia/Singapore\",\"appId\":\"app_7777_7777\"}]',
+  },
+  {
+    ParameterKey: 'RedshiftDefaultDBParam',
+    ParameterValue: 'project_8888_8888',
   },
 ];
 

--- a/src/control-plane/backend/lambda/api/test/api/workflow-version.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-version.test.ts
@@ -589,6 +589,9 @@ describe('Workflow test with pipeline version', () => {
                         {
                           ParameterKey: 'RedshiftIAMRoleParam.#',
                         },
+                        {
+                          ParameterKey: 'RedshiftDefaultDBParam',
+                        },
                       ],
                       ),
                     },
@@ -683,6 +686,9 @@ describe('Workflow test with pipeline version', () => {
                           {
                             ParameterKey: 'RedshiftIAMRoleParam.#',
                           },
+                          {
+                            ParameterKey: 'RedshiftDefaultDBParam',
+                          },
                         ]),
                     },
                   },
@@ -766,6 +772,9 @@ describe('Workflow test with pipeline version', () => {
                           },
                           {
                             ParameterKey: 'RedshiftIAMRoleParam.#',
+                          },
+                          {
+                            ParameterKey: 'RedshiftDefaultDBParam',
                           },
                         ],
                       ),
@@ -1231,6 +1240,9 @@ describe('Workflow test with pipeline version in China region', () => {
                           },
                           {
                             ParameterKey: 'RedshiftIAMRoleParam.#',
+                          },
+                          {
+                            ParameterKey: 'RedshiftDefaultDBParam',
                           },
                         ],
                       ),


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend