### PR TITLE
chore: add redshift retry

### DIFF
--- a/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/custom-resources/create-schemas.test.ts
@@ -431,7 +431,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
     try {
       await handler(createServerlessEvent, context, callback);
     } catch (e) {
-      expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 1);
+      expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 4);
       expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 0);
       return;
     }
@@ -533,7 +533,7 @@ describe('Custom resource - Create schemas for applications in Redshift database
     try {
       await handler(createProvisionedEvent, context, callback);
     } catch (e) {
-      expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 1);
+      expect(redshiftDataMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 4);
       expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 0);
 
       expect(s3ClientMock).toHaveReceivedCommandTimes(PutObjectCommand, 0);


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend