### PR TITLE
chore: ETL add metrics filtered by appIds, freshness, future, bot

### DIFF
--- a/src/common/model.ts
+++ b/src/common/model.ts
@@ -105,7 +105,11 @@ export enum DataPipelineCustomMetricsName {
   CORRUPTED='Data Processing corrupted count',
   RUN_TIME='Data Processing job run time seconds',
   INPUT_FILE_COUNT='Data Processing input file count',
+  FILTERED_BY_APP_IDS='Data count filtered by appIds',
+  FILTERED_BY_DATA_FRESHNESS_AND_FUTURE = 'Data count filtered by freshness and future time',
+  FILTERED_BY_BOT = 'Data count filtered by bot',
 };
+
 
 export enum AnalyticsCustomMetricsName {
   FILE_NEW='New files count',

--- a/src/data-pipeline/spark-etl/src/main/java/software/aws/solution/clickstream/UAEnrichmentV2.java
+++ b/src/data-pipeline/spark-etl/src/main/java/software/aws/solution/clickstream/UAEnrichmentV2.java
@@ -81,11 +81,13 @@ public class UAEnrichmentV2 {
         }
         Dataset<Row> enrichedDatasetFiltered = enrichedDataset;
         String filterBotByUAStr = System.getProperty(FILTER_BOT_BY_UA_PROP);
-        if (Boolean.parseBoolean(filterBotByUAStr)) {
+        if (filterBotByUAStr == null || Boolean.parseBoolean(filterBotByUAStr)) {
+            long beforeFilterCount = enrichedDataset.count();
             enrichedDatasetFiltered = enrichedDataset.filter(
                     col(Constant.DEVICE_UA_DEVICE_CATEGORY).notEqual(UAEnrichHelper.BOT)
             );
-            log.info("UA Enriched enrichedDatasetFiltered(BOT) count: {}", enrichedDatasetFiltered.count());
+            long afterFilterCount = enrichedDatasetFiltered.count();
+            log.info(new ETLMetric(beforeFilterCount - afterFilterCount, "filtered by Bot").toString());
         }
         return enrichedDatasetFiltered;
     }

--- a/src/data-pipeline/spark-etl/src/main/java/software/aws/solution/clickstream/transformer/Cleaner.java
+++ b/src/data-pipeline/spark-etl/src/main/java/software/aws/solution/clickstream/transformer/Cleaner.java
@@ -196,11 +196,19 @@ public class Cleaner {
     }
 
     private Dataset<Row> filter(final Dataset<Row> dataset) {
+        long beforeCount = dataset.count();
+        log.info("dataset before filter count: {}", beforeCount);
+
         Dataset<Row> freshDataset = filterByDataFreshnessAndFuture(dataset);
-        log.info(new ETLMetric(freshDataset, "after filterByDataFreshnessAndFuture").toString());
+        long afterFilterFreshCount = freshDataset.count();
+
+        log.info(new ETLMetric(beforeCount - afterFilterFreshCount, "filtered by DataFreshnessAndFuture").toString());
 
         Dataset<Row> filteredDataset = filterByAppIds(freshDataset);
-        log.info(new ETLMetric(filteredDataset, "after filterByAppIds").toString());
+        long afterFilterAppIdsCount = filteredDataset.count();
+
+        log.info(new ETLMetric(afterFilterFreshCount - afterFilterAppIdsCount , "filtered by AppIds").toString());
+        log.info("dataset after filter count: {}", afterFilterAppIdsCount);
         return filteredDataset;
     }
 

--- a/src/data-pipeline/utils/metrics.ts
+++ b/src/data-pipeline/utils/metrics.ts
@@ -227,6 +227,21 @@ export function createMetricsWidget(scope: Construct, props: {
             DataPipelineCustomMetricsName.SINK,
             '.', '.', '.', '.',
           ],
+          [
+            dataPipelineNamespace,
+            DataPipelineCustomMetricsName.FILTERED_BY_APP_IDS,
+            '.', '.', '.', '.',
+          ],
+          [
+            dataPipelineNamespace,
+            DataPipelineCustomMetricsName.FILTERED_BY_DATA_FRESHNESS_AND_FUTURE,
+            '.', '.', '.', '.',
+          ],
+          [
+            dataPipelineNamespace,
+            DataPipelineCustomMetricsName.FILTERED_BY_BOT,
+            '.', '.', '.', '.',
+          ],
         ],
       },
     },

--- a/test/data-pipeline/emr-job-listener.test.ts
+++ b/test/data-pipeline/emr-job-listener.test.ts
@@ -133,6 +133,8 @@ test('lambda should record SUCCESS job state', async () => {
     '23/04/04 02:43:36 INFO Cleaner: [ETLMetric]after processDataColumnSchema dataset count:123',
     '23/04/04 02:43:42 INFO Cleaner: [ETLMetric]after filterByDataFreshness dataset count:123',
     '23/04/04 02:43:46 INFO Cleaner: [ETLMetric]after filterByAppIds dataset count:123',
+    '23/04/04 02:43:46 INFO Cleaner: [ETLMetric]filtered by AppIds dataset count:126',
+    '23/04/04 02:43:50 INFO Cleaner: [ETLMetric]filtered by DataFreshnessAndFuture dataset count:12',
     '23/04/04 02:43:50 INFO Cleaner: [ETLMetric]after filter dataset count:123',
     '23/04/04 02:43:54 INFO Transformer: [ETLMetric]after clean dataset count:999',
     '23/04/04 02:43:59 INFO Transformer: [ETLMetric]transform return dataset count:123',
@@ -143,6 +145,7 @@ test('lambda should record SUCCESS job state', async () => {
     '23/09/15 06:37:01 INFO TransformerV2: DROP TABLE IF EXISTS test_project_007_13158910.etl_user_device_id_430162815_tmp_w_ PURGE',
     '23/09/15 06:37:04 INFO TransformerV2: DROP TABLE IF EXISTS test_project_007_13158910.etl_user_device_id_430162815_tmp_ PURGE',
     '23/09/15 06:36:17 INFO ETLRunner: [ETLMetric]sink event_parameter dataset count:55305',
+    '23/09/15 06:36:17 INFO UAEnrichmentV2: [ETLMetric]filtered by Bot dataset count:16',
     '23/09/15 06:36:17 INFO ETLRunner: [ETLMetric]sink item dataset count:37119',
     '23/09/15 06:36:17 INFO ETLRunner: [ETLMetric]sink user dataset count:7818',
 
@@ -218,6 +221,9 @@ test('lambda should record SUCCESS job state', async () => {
       [DataPipelineCustomMetricsName.CORRUPTED, 'Count', 4],
       [DataPipelineCustomMetricsName.RUN_TIME, 'Seconds', 3600],
       [DataPipelineCustomMetricsName.INPUT_FILE_COUNT, 'Count', 41],
+      [DataPipelineCustomMetricsName.FILTERED_BY_APP_IDS, 'Count', 126],
+      [DataPipelineCustomMetricsName.FILTERED_BY_DATA_FRESHNESS_AND_FUTURE, 'Count', 12],
+      [DataPipelineCustomMetricsName.FILTERED_BY_BOT, 'Count', 16],
     ],
   );
   expect(publishStoredMetricsMock).toBeCalledTimes(1);


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend