### PR TITLE
chore: set default forceRefresh as true

### DIFF
--- a/src/analytics/lambdas/refresh-materialized-views-workflow/check-start-sp-refresh.ts
+++ b/src/analytics/lambdas/refresh-materialized-views-workflow/check-start-sp-refresh.ts
@@ -65,7 +65,7 @@ export const handler = async (event: CheckStartRefreshSpEvent) => {
   const refreshDateString = getDateStringFromEndTimeAndTimezone(event.originalInput.refreshEndTime, timezoneWithAppId.timezone);
 
   let skipSpRefresh = false;
-  if (forceRefresh !== 'true') {
+  if (forceRefresh && forceRefresh === 'false') {
     skipSpRefresh = await isSkipSpRefresh(timezoneWithAppId.appId, refreshDateString);
   }
   if (skipSpRefresh) {

--- a/test/analytics/analytics-on-redshift/lambda/refresh-materialized-views-workflow/check-start-sp-refresh.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/refresh-materialized-views-workflow/check-start-sp-refresh.test.ts
@@ -64,6 +64,35 @@ describe('Lambda - check next refresh task', () => {
     });
   });
 
+  test('the end refresh time is not more than latest refresh time, but forceRefresh is empty', async () => {
+    checkNextRefreshViewEvent.originalInput.forceRefresh = '';
+    redshiftDataMock.on(GetStatementResultCommand).resolvesOnce({
+      Records: [
+        [{ stringValue: '2024-05-08' }],
+      ],
+    });
+    const resp = await handler(checkNextRefreshViewEvent);
+    expect(resp).toEqual({
+      nextStep: RefreshWorkflowSteps.REFRESH_SP_STEP,
+      refreshDate: '2024-05-08',
+      refreshSpDays: 8,
+      spList: expect.arrayContaining([
+        {
+          name: CLICKSTREAM_ACQUISITION_COUNTRY_NEW_USER_SP,
+          type: 'sp',
+          timezoneSensitive: 'true',
+          viewName: CLICKSTREAM_ACQUISITION_COUNTRY_NEW_USER,
+        },
+        {
+          name: CLICKSTREAM_ACQUISITION_DAY_TRAFFIC_SOURCE_USER_SP,
+          type: 'sp',
+          timezoneSensitive: 'true',
+          viewName: CLICKSTREAM_ACQUISITION_DAY_TRAFFIC_SOURCE_USER,
+        },
+      ]),
+    });
+  });
+
   test('the end refresh time is not more than latest refresh time, but forceRefresh is true', async () => {
     checkNextRefreshViewEvent.originalInput.forceRefresh = 'true';
     redshiftDataMock.on(GetStatementResultCommand).resolvesOnce({


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

set default forceRefresh as true

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [x] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend