### PR TITLE
fix: add reporting stack with action error

### DIFF
--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -421,6 +421,8 @@ export class CPipeline {
     if (this._editStackTags(oldPipeline)) {
       this.stackManager.updateWorkflowTags();
     }
+    // update workflow callback
+    this.stackManager.setPipelineWorkflowCallback(executionName);
     // create new execution
     const execWorkflow = this.stackManager.getExecWorkflow();
     const executionArn = await this.stackManager.execute(execWorkflow, executionName);
@@ -527,6 +529,8 @@ export class CPipeline {
     const oldStackNames = this.stackManager.getWorkflowStacks(oldPipeline.workflow?.Workflow!);
     // update workflow
     this.stackManager.upgradeWorkflow(oldStackNames);
+    // update workflow callback
+    this.stackManager.setPipelineWorkflowCallback(executionName);
     // create new execution
     const execWorkflow = this.stackManager.getExecWorkflow();
     const executionArn = await this.stackManager.execute(execWorkflow, executionName);
@@ -670,6 +674,8 @@ export class CPipeline {
     this._setExecution(executionName);
     // update workflow
     this.stackManager.deleteWorkflow();
+    // update workflow callback
+    this.stackManager.setPipelineWorkflowCallback(executionName);
     // create new execution
     const execWorkflow = this.stackManager.getExecWorkflow();
     const executionArn = await this.stackManager.execute(execWorkflow, executionName);
@@ -697,6 +703,8 @@ export class CPipeline {
     const executionName = getStateMachineExecutionName(this.pipeline.pipelineId);
     this._setExecution(executionName);
     this.stackManager.retryWorkflow();
+    // update workflow callback
+    this.stackManager.setPipelineWorkflowCallback(executionName);
     // create new execution
     const execWorkflow = this.stackManager.getExecWorkflow();
     const executionArn = await this.stackManager.execute(execWorkflow, executionName);

--- a/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
@@ -1886,6 +1886,27 @@ export const RETRY_PIPELINE_WITH_WORKFLOW_WHEN_UPDATE_FAILED: IPipeline = {
   },
 };
 
+export const RETRY_PIPELINE_WITH_WORKFLOW_WHEN_UPDATE_EMPTY: IPipeline = {
+  ...BASE_RETRY_PIPELINE,
+  lastAction: 'Update',
+  stackDetails: [
+    BASE_STATUS.stackDetails[0],
+    {
+      ...BASE_STATUS.stackDetails[1],
+      stackStatus: undefined,
+    },
+    BASE_STATUS.stackDetails[2],
+    BASE_STATUS.stackDetails[3],
+    BASE_STATUS.stackDetails[4],
+    BASE_STATUS.stackDetails[5],
+  ],
+  executionDetail: {
+    name: MOCK_EXECUTION_ID,
+    status: ExecutionStatus.FAILED,
+    executionArn: 'arn:aws:states:us-east-1:111122223333:execution:MyPipelineStateMachine:main-5ab07c6e-b6ac-47ea-bf3a-02ede7391807',
+  },
+};
+
 export const RETRY_PIPELINE_WITH_WORKFLOW_AND_ROLLBACK_COMPLETE: IPipeline = {
   ...BASE_RETRY_PIPELINE,
   lastAction: 'Upgrade',

--- a/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
@@ -65,6 +65,7 @@ import {
   MSK_WITH_CONNECTOR_INGESTION_PIPELINE,
   RETRY_PIPELINE_WITH_WORKFLOW,
   RETRY_PIPELINE_WITH_WORKFLOW_AND_ROLLBACK_COMPLETE,
+  RETRY_PIPELINE_WITH_WORKFLOW_WHEN_UPDATE_EMPTY,
   RETRY_PIPELINE_WITH_WORKFLOW_WHEN_UPDATE_FAILED,
   S3_DATA_PROCESSING_PIPELINE,
   S3_DATA_PROCESSING_WITH_SPECIFY_PREFIX_PIPELINE,
@@ -3038,6 +3039,143 @@ describe('Workflow test', () => {
                   },
                   Input: {
                     Action: 'Update',
+                    Region: 'ap-southeast-1',
+                    Parameters: [],
+                    StackName: `${getStackPrefix()}-Ingestion-kafka-6666-6666`,
+                    TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/ingestion-server-kafka-stack.template.json',
+                  },
+                },
+                Next: 'KafkaConnector',
+                Type: 'Stack',
+              },
+              KafkaConnector: {
+                Data: {
+                  Callback: {
+                    BucketName: 'TEST_EXAMPLE_BUCKET',
+                    BucketPrefix: 'clickstream/workflow/main-3333-3333',
+                  },
+                  Input: {
+                    Action: 'Update',
+                    Region: 'ap-southeast-1',
+                    Parameters: [],
+                    StackName: `${getStackPrefix()}-KafkaConnector-6666-6666`,
+                    TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/kafka-s3-sink-stack.template.json',
+                  },
+                },
+                End: true,
+                Type: 'Stack',
+              },
+            },
+          },
+          {
+            StartAt: 'DataProcessing',
+            States: {
+              DataProcessing: {
+                Data: {
+                  Callback: {
+                    BucketName: 'TEST_EXAMPLE_BUCKET',
+                    BucketPrefix: 'clickstream/workflow/main-3333-3333',
+                  },
+                  Input: {
+                    Action: 'Create',
+                    Region: 'ap-southeast-1',
+                    Parameters: [],
+                    StackName: `${getStackPrefix()}-DataProcessing-6666-6666`,
+                    TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-pipeline-stack.template.json',
+                  },
+                },
+                Next: 'DataModelingRedshift',
+                Type: 'Pass',
+              },
+              Reporting: {
+                Type: 'Pass',
+                Data: {
+                  Input: {
+                    Region: 'ap-southeast-1',
+                    TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-reporting-quicksight-stack.template.json',
+                    Action: 'Create',
+                    Parameters: [],
+                    StackName: `${getStackPrefix()}-Reporting-6666-6666`,
+                  },
+                  Callback: {
+                    BucketPrefix: 'clickstream/workflow/main-3333-3333',
+                    BucketName: 'TEST_EXAMPLE_BUCKET',
+                  },
+                },
+                End: true,
+              },
+              DataModelingRedshift: {
+                Data: {
+                  Callback: {
+                    BucketName: 'TEST_EXAMPLE_BUCKET',
+                    BucketPrefix: 'clickstream/workflow/main-3333-3333',
+                  },
+                  Input: {
+                    Action: 'Create',
+                    Region: 'ap-southeast-1',
+                    Parameters: [
+                      {
+                        ParameterKey: 'DataProcessingCronOrRateExpression',
+                        ParameterValue: 'rate(16 minutes)',
+                      },
+                    ],
+                    StackName: `${getStackPrefix()}-DataModelingRedshift-6666-6666`,
+                    TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/data-analytics-redshift-stack.template.json',
+                  },
+                },
+                Next: 'Reporting',
+                Type: 'Pass',
+              },
+            },
+          },
+          {
+            StartAt: 'Metrics',
+            States: {
+              Metrics: {
+                Data: {
+                  Callback: {
+                    BucketName: 'TEST_EXAMPLE_BUCKET',
+                    BucketPrefix: 'clickstream/workflow/main-3333-3333',
+                  },
+                  Input: {
+                    Action: 'Create',
+                    Region: 'ap-southeast-1',
+                    Parameters: BASE_METRICS_PARAMETERS,
+                    StackName: `${getStackPrefix()}-Metrics-6666-6666`,
+                    TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/v1.0.0/default/metrics-stack.template.json',
+                  },
+                },
+                End: true,
+                Type: 'Pass',
+              },
+            },
+          },
+        ],
+        End: true,
+        Type: 'Parallel',
+      },
+    };
+    expect(stackManager.getExecWorkflow()).toEqual(expected);
+  });
+  it('Generate Retry Workflow when update stack empty', async () => {
+    dictionaryMock(ddbMock);
+    const stackManager: StackManager = new StackManager({ ...RETRY_PIPELINE_WITH_WORKFLOW_WHEN_UPDATE_EMPTY });
+    stackManager.retryWorkflow();
+    const expected = {
+      Version: '2022-03-15',
+      Workflow: {
+        Branches: [
+          {
+            StartAt: 'Ingestion',
+            States: {
+              Ingestion: {
+                Data: {
+                  Callback: {
+                    BucketName: 'TEST_EXAMPLE_BUCKET',
+                    BucketPrefix: 'clickstream/workflow/main-3333-3333',
+                  },
+                  Input: {
+                    Action: 'Create',
                     Region: 'ap-southeast-1',
                     Parameters: [],
                     StackName: `${getStackPrefix()}-Ingestion-kafka-6666-6666`,


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend