### PR TITLE
fix: retry when delete failed

### DIFF
--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -692,6 +692,10 @@ export class CPipeline {
   }
 
   public async retry(): Promise<void> {
+    if (this.pipeline.lastAction === 'Delete') {
+      await this.delete();
+      return;
+    }
     // create rule to listen CFN stack
     await this._createRules();
     const executionName = getStateMachineExecutionName(this.pipeline.pipelineId);

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -4135,6 +4135,48 @@ describe('Pipeline test', () => {
       message: 'The pipeline current status does not allow upgrade.',
     });
   });
+  it('Retry pipeline when failed', async () => {
+    tokenMock(ddbMock, false);
+    projectExistedMock(ddbMock, true);
+    pipelineExistedMock(ddbMock, true);
+    createEventRuleMock(cloudWatchEventsMock);
+    createSNSTopicMock(snsMock);
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        ...KINESIS_DATA_PROCESSING_NEW_REDSHIFT_PIPELINE_WITH_WORKFLOW,
+        lastAction: 'Delete',
+        stackDetails: [
+          {
+            ...stackDetailsWithOutputs[0],
+            stackStatus: StackStatus.DELETE_FAILED,
+          },
+          {
+            ...stackDetailsWithOutputs[1],
+          },
+          {
+            ...stackDetailsWithOutputs[2],
+          },
+          stackDetailsWithOutputs[3],
+          stackDetailsWithOutputs[4],
+          stackDetailsWithOutputs[5],
+        ],
+      },
+    });
+    sfnMock.on(StartExecutionCommand).resolves({ executionArn: 'xxx' });
+    ddbMock.on(UpdateCommand).resolves({});
+    const res = await request(app)
+      .post(`/api/pipeline/${MOCK_PIPELINE_ID}/retry?pid=${MOCK_PROJECT_ID}`)
+      .set('X-Click-Stream-Request-Id', MOCK_TOKEN);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toEqual({
+      data: null,
+      success: true,
+      message: 'Pipeline retry.',
+    });
+    expect(sfnMock).toHaveReceivedCommandTimes(StartExecutionCommand, 1);
+    expect(ddbMock).toHaveReceivedCommandTimes(UpdateCommand, 2);
+  });
   it('Delete pipeline', async () => {
     projectExistedMock(ddbMock, true);
     pipelineExistedMock(ddbMock, true);


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend