### PR TITLE
chore: remove deleting clickstream log in scanning metadata to mitigate timeout

### DIFF
--- a/src/analytics/private/scan-metadata-workflow.ts
+++ b/src/analytics/private/scan-metadata-workflow.ts
@@ -361,7 +361,7 @@ export class ScanMetadataWorkflow extends Construct {
       ),
       handler: 'handler',
       memorySize: 128,
-      timeout: Duration.minutes(2),
+      timeout: Duration.minutes(5),
       logConf: {
         retention: RetentionDays.ONE_WEEK,
       },

--- a/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/check-scan-metadata-status.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/scan-metadata-workflow/check-scan-metadata-status.test.ts
@@ -54,12 +54,13 @@ describe('Lambda - check the scan metadata status in Redshift Serverless', () =>
       detail: {
         appId: 'app1',
         status: StatusString.FINISHED,
-        message: [],
+        message: 'Scan metadata success.',
       },
     });
     expect(redshiftDataMock).toHaveReceivedCommandWith(DescribeStatementCommand, {
       Id: checkScanMetadataStatusEvent.detail.id,
     });
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 1);
   });
 
   test('Check scan metadata status with response STARTED', async () => {
@@ -179,12 +180,13 @@ describe('Lambda - check the scan metadata status in Redshift Provisioned', () =
       detail: {
         appId: 'app1',
         status: StatusString.FINISHED,
-        message: [],
+        message: 'Scan metadata success.',
       },
     });
     expect(redshiftDataMock).toHaveReceivedCommandWith(DescribeStatementCommand, {
       Id: checkScanMetadataStatusEvent.detail.id,
     });
+    expect(redshiftDataMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 1);
   });
 
   test('Check scan metadata status with response STARTED', async () => {


### PR DESCRIPTION
…data status timeout


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

remove operation of deleting clickstream log to avoid check scan metadata timeout
the clickstream log should be deteted by clear history data workflow

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend