### PR TITLE
fix: ETL job failed alarm is not triggered

### DIFF
--- a/src/data-pipeline/utils/metrics.ts
+++ b/src/data-pipeline/utils/metrics.ts
@@ -48,10 +48,10 @@ export function createMetricsWidget(scope: Construct, props: {
   // Alarms
 
   const failedJobAlarm = new Alarm(scope, 'failedJobAlarm', {
-    comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+    comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
     threshold: 1,
     evaluationPeriods: 1,
-    treatMissingData: TreatMissingData.NOT_BREACHING,
+    treatMissingData: TreatMissingData.IGNORE,
     metric: new Metric({
       metricName: 'FailedJobs',
       namespace: emrServerlessNamespace,

--- a/test/data-pipeline/data-pipeline-stack.test.ts
+++ b/test/data-pipeline/data-pipeline-stack.test.ts
@@ -1619,7 +1619,7 @@ test('Should set metrics widgets', () => {
 test ('Should has alarm: data Processing Job Failed', ()=> {
   const template = nestedTemplates[0];
   template.hasResourceProperties('AWS::CloudWatch::Alarm', {
-    ComparisonOperator: 'GreaterThanThreshold',
+    ComparisonOperator: 'GreaterThanOrEqualToThreshold',
     EvaluationPeriods: 1,
     AlarmDescription: {
       'Fn::Join': Match.anyValue(),


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend