### PR TITLE
fix: redshift serverless link in GCR

### DIFF
--- a/frontend/src/pages/pipelines/detail/comps/Processing.tsx
+++ b/frontend/src/pages/pipelines/detail/comps/Processing.tsx
@@ -22,7 +22,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ExecutionType } from 'ts/const';
 import {
-  buildReshiftLink,
+  buildRedshiftLink,
   buildSFNExecutionLink,
   buildSecurityGroupLink,
   buildSubnetLink,
@@ -48,7 +48,7 @@ const Processing: React.FC<TabContentProps> = (props: TabContentProps) => {
         return (
           <Link
             external
-            href={buildReshiftLink(
+            href={buildRedshiftLink(
               pipelineInfo?.region || '',
               pipelineInfo?.dataModeling?.redshift?.provisioned
                 ?.clusterIdentifier || '',
@@ -68,7 +68,7 @@ const Processing: React.FC<TabContentProps> = (props: TabContentProps) => {
         return (
           <Link
             external
-            href={buildReshiftLink(
+            href={buildRedshiftLink(
               pipelineInfo?.region || '',
               '',
               'serverless'
@@ -81,7 +81,7 @@ const Processing: React.FC<TabContentProps> = (props: TabContentProps) => {
         return (
           <Link
             external
-            href={buildReshiftLink(
+            href={buildRedshiftLink(
               pipelineInfo?.region || '',
               pipelineInfo?.dataModeling?.redshift?.provisioned
                 ?.clusterIdentifier || '',

--- a/frontend/src/ts/url.ts
+++ b/frontend/src/ts/url.ts
@@ -138,9 +138,6 @@ export const buildReshiftLink = (
   cluster: string,
   type: string
 ) => {
-  if (region.startsWith('cn')) {
-    return `https://${region}.${CONSOLE_CHINA_DOMAIN}/redshiftv2/home?region=${region}#cluster-details?cluster=${cluster}`;
-  }
   if (type === 'serverless') {
     return `https://${region}.${CONSOLE_GLOBAL_DOMAIN}/redshiftv2/home?region=${region}#serverless-dashboard`;
   }

--- a/frontend/src/ts/url.ts
+++ b/frontend/src/ts/url.ts
@@ -133,21 +133,20 @@ export const buildSubnetLink = (region: string, subnetId: string): string => {
   return `https://${region}.${CONSOLE_GLOBAL_DOMAIN}/vpc/home?region=${region}#subnets:subnetId=${subnetId}`;
 };
 
-export const buildReshiftLink = (
+export const buildRedshiftLink = (
   region: string,
   cluster: string,
   type: string
 ) => {
+  let domainSuffix = CONSOLE_GLOBAL_DOMAIN;
   if (region.startsWith('cn')) {
-    if (type === 'serverless') {
-      return `https://${region}.${CONSOLE_CHINA_DOMAIN}/redshiftv2/home?region=${region}#serverless-dashboard`;
-    }
-    return `https://${region}.${CONSOLE_CHINA_DOMAIN}/redshiftv2/home?region=${region}#cluster-details?cluster=${cluster}`;
+    domainSuffix = CONSOLE_CHINA_DOMAIN;
   }
+  let query = `region=${region}#cluster-details?cluster=${cluster}`;
   if (type === 'serverless') {
-    return `https://${region}.${CONSOLE_GLOBAL_DOMAIN}/redshiftv2/home?region=${region}#serverless-dashboard`;
+    query = `region=${region}#serverless-dashboard`;
   }
-  return `https://${region}.${CONSOLE_GLOBAL_DOMAIN}/redshiftv2/home?region=${region}#cluster-details?cluster=${cluster}`;
+  return `https://${region}.${domainSuffix}/redshiftv2/home?${query}`;
 };
 
 export const buildSFNExecutionLink = (region: string, executionArn: string) => {

--- a/frontend/src/ts/url.ts
+++ b/frontend/src/ts/url.ts
@@ -138,6 +138,12 @@ export const buildReshiftLink = (
   cluster: string,
   type: string
 ) => {
+  if (region.startsWith('cn')) {
+    if (type === 'serverless') {
+      return `https://${region}.${CONSOLE_CHINA_DOMAIN}/redshiftv2/home?region=${region}#serverless-dashboard`;
+    }
+    return `https://${region}.${CONSOLE_CHINA_DOMAIN}/redshiftv2/home?region=${region}#cluster-details?cluster=${cluster}`;
+  }
   if (type === 'serverless') {
     return `https://${region}.${CONSOLE_GLOBAL_DOMAIN}/redshiftv2/home?region=${region}#serverless-dashboard`;
   }


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend