### PR TITLE
chore: keep users state to 10 years in ETL

### DIFF
--- a/src/data-pipeline/lambda/emr-job-submitter/emr-client-util.ts
+++ b/src/data-pipeline/lambda/emr-job-submitter/emr-client-util.ts
@@ -345,8 +345,8 @@ export class EMRServerlessUtil {
       outputFormat: process.env.OUTPUT_FORMAT!,
       outputPartitions: process.env.OUTPUT_PARTITIONS ?? '-1',
       rePartitions: process.env.RE_PARTITIONS ?? '200',
-      userKeepDays: process.env.USER_KEEP_DAYS ?? '180',
-      itemKeepDays: process.env.ITEM_KEEP_DAYS ?? '360',
+      userKeepDays: process.env.USER_KEEP_DAYS ?? '3650',
+      itemKeepDays: process.env.ITEM_KEEP_DAYS ?? '3650',
       filterBotEvent: process.env.FILTER_BOT_EVENT ?? 'true',
     };
   }


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend