### PR TITLE
chore: adjust EMR initialExecutors for large volume data 

### DIFF
--- a/src/data-pipeline/lambda/emr-job-submitter/emr-client-util.ts
+++ b/src/data-pipeline/lambda/emr-job-submitter/emr-client-util.ts
@@ -536,7 +536,7 @@ export function getEstimatedSparkConfig(objectsInfo: ObjectsInfo): CustomSparkCo
     executorCore = 16;
     executorMem = 100;
     executorDisk = 200;
-    initialExecutors = 10;
+    initialExecutors = 20;
     inputRePartitions = 500;
 
   } else if (objectsInfo.sizeTotal < 500 * size_1G) {
@@ -546,7 +546,7 @@ export function getEstimatedSparkConfig(objectsInfo: ObjectsInfo): CustomSparkCo
     executorCore = 16;
     executorMem = 100;
     executorDisk = 200;
-    initialExecutors = 10;
+    initialExecutors = 30;
     inputRePartitions = 1000;
   } else if (objectsInfo.sizeTotal < 1000 * size_1G) {
     driverCore = 16;
@@ -555,7 +555,7 @@ export function getEstimatedSparkConfig(objectsInfo: ObjectsInfo): CustomSparkCo
     executorCore = 16;
     executorMem = 100;
     executorDisk = 200;
-    initialExecutors = 15;
+    initialExecutors = 40;
     inputRePartitions = 1000;
   } else {
     driverCore = 16;
@@ -564,7 +564,7 @@ export function getEstimatedSparkConfig(objectsInfo: ObjectsInfo): CustomSparkCo
     executorCore = 16;
     executorMem = 100;
     executorDisk = 200;
-    initialExecutors = 25;
+    initialExecutors = 50;
     inputRePartitions = 2000;
   }
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)
![image](https://github.com/awslabs/clickstream-analytics-on-aws/assets/23469402/78c23347-dc5f-41a5-91bf-709812fad1f7)

total file size: 291G, 218,345,393 events
if initialExecutors=10 the job ran 219 mins, then failed, changed to 20 the job completed within 21 minutes(tested twice).


## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend