### PR TITLE
chore: refactor pattern to support backslash in authenticationSecretArnParam

### DIFF
--- a/src/ingestion-server/server/parameter.ts
+++ b/src/ingestion-server/server/parameter.ts
@@ -573,9 +573,9 @@ function createCommonParameters(scope: Construct) {
       description: 'The AuthenticationSecretArn of OIDC provider',
       type: 'String',
       default: '',
-      allowedPattern: '^$|^arn:aws(-cn|-us-gov)?:secretsmanager:[a-z0-9-]+:[0-9]{12}:secret:[a-zA-Z0-9-]+$',
+      allowedPattern: '^$|^arn:aws(-cn|-us-gov)?:secretsmanager:[a-z0-9-]+:[0-9]{12}:secret:[a-zA-Z0-9-\/]+$',
       constraintDescription:
-      'AuthenticationSecretArn must match pattern ^$|^arn:aws(-cn|-us-gov)?:secretsmanager:[a-z0-9-]+:[0-9]{12}:secret:[a-zA-Z0-9-]+$',
+      'AuthenticationSecretArn must match pattern ^$|^arn:aws(-cn|-us-gov)?:secretsmanager:[a-z0-9-]+:[0-9]{12}:secret:[a-zA-Z0-9-\/]+$',
     },
   );
 

--- a/test/ingestion-server/server/ingestion-server-stack.test.ts
+++ b/test/ingestion-server/server/ingestion-server-stack.test.ts
@@ -1203,6 +1203,7 @@ test('check AuthenticationSecretArn pattern', () => {
       'arn:aws:secretsmanager:us-east-1:111111111111:secret:fake-xxxxxx',
       'arn:aws-cn:secretsmanager:cn-northwest-1:111111111111:secret:fake-xxxxxx',
       'arn:aws-us-gov:secretsmanager:us-gov-west-1:111111111111:secret:fake-xxxxxx',
+      'arn:aws:secretsmanager:us-east-1:111111111111:secret:prefix/fake-xxxxxx',
     ];
     for (const v of validValues) {
       expect(v).toMatch(regex);

--- a/test/ingestion-server/server/ingestion-server-v2-stack.test.ts
+++ b/test/ingestion-server/server/ingestion-server-v2-stack.test.ts
@@ -1174,11 +1174,12 @@ test('check AuthenticationSecretArn pattern', () => {
       'arn:aws:secretsmanager:us-east-1:111111111111:secret:fake-xxxxxx',
       'arn:aws-cn:secretsmanager:cn-northwest-1:111111111111:secret:fake-xxxxxx',
       'arn:aws-us-gov:secretsmanager:us-gov-west-1:111111111111:secret:fake-xxxxxx',
+      'arn:aws:secretsmanager:us-east-1:111111111111:secret:prefix/fake-xxxxxx',
     ];
     for (const v of validValues) {
       expect(v).toMatch(regex);
     }
-    const invalidValues = ['abc', 'arn:aws-cx:secretsmanager:us-east-1:111111111111:secret:fake', 'arn:aws:secretsmanagers:us-east-1:111111111111:certificate/fake-xxxxxx'];
+    const invalidValues = ['abc', 'arn:aws-cx:secretsmanager:us-east-1:111111111111:secret:fake', 'arn:aws:secretsmanager:us-east-1:111111111111:certificate/fake-xxxxxx'];
     for (const v of invalidValues) {
       expect(v).not.toMatch(regex);
     }


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

refactor pattern to support backslash in authenticationSecretArnParam

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend