### PR TITLE
fix: app_version is null after migrating old data

### DIFF
--- a/src/analytics/private/sqls/redshift/migrate/sp-migrate-event-to-v2.sql
+++ b/src/analytics/private/sqls/redshift/migrate/sp-migrate-event-to-v2.sql
@@ -427,7 +427,7 @@ SELECT
     NULL AS user_first_touch_time_msec,
     app_info.id::varchar AS app_package_id,
     app_info.app_id::varchar AS app_id,
-    app_info.app_version::varchar AS app_version,
+    app_info.version::varchar AS app_version,
     app_info.install_source::varchar AS app_install_source,
     CASE
         WHEN platform IS NULL THEN 'Web'


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend