### PR TITLE
ci: specify jest workers for stabilizing the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
     env:
       CI: "true"
       iam_role_to_assume: ${{ secrets.ROLE_ARN }}
+      JEST_MAX_WORKERS: ${{ vars.JEST_MAX_WORKERS || 'auto' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/dist-scan.yml
+++ b/.github/workflows/dist-scan.yml
@@ -141,6 +141,7 @@ jobs:
     runs-on: ${{ vars.LARGE_RUNNER_S || 'ubuntu-latest' }}
     permissions:
       id-token: write
+      pull-requests: write
       contents: read
     services:
       sonarqube:
@@ -177,9 +178,10 @@ jobs:
       - name: Install dependencies
         run: pnpm i --no-frozen-lockfile
       - name: Run build and unit tests
+        env:
+          JEST_MAX_WORKERS: ${{ vars.JEST_MAX_WORKERS || 'auto' }}
+          LOCAL_TESTING: true # speed up the tests for infra
         run: |
-          export LOCAL_TESTING=true # speed up the tests for infra
-          export JEST_MAX_WORKERS=6
           bash deployment/run-unit-tests.sh
       - name: Configure sonarqube
         env:

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -3,9 +3,6 @@
     "build": {
       "name": "build",
       "description": "Full release build",
-      "env": {
-        "NODE_OPTIONS": "--max_old_space_size=6144"
-      },
       "steps": [
         {
           "spawn": "default"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -608,10 +608,6 @@ apiProject.setScript('ncc-build', 'tsc && ncc build dist/index.js -o ncc');
 apiProject.setScript('start', 'pnpm run ncc-build && node ncc/index.js');
 apiProject.addFields({ version });
 
-project.buildWorkflow.buildTask._env = {
-  NODE_OPTIONS: '--max_old_space_size=6144',
-};
-
 project.buildWorkflow.workflow.file?.addOverride(
   'jobs.build.permissions.checks',
   'write',
@@ -627,6 +623,10 @@ project.buildWorkflow.workflow.file?.addOverride(
 project.buildWorkflow.workflow.file?.addOverride(
   'jobs.build.env.iam_role_to_assume',
   '${{ secrets.ROLE_ARN }}',
+);
+project.buildWorkflow.workflow.file?.addOverride(
+  'jobs.build.env.JEST_MAX_WORKERS',
+  '${{ vars.JEST_MAX_WORKERS || \'auto\' }}',
 );
 project.buildWorkflow.preBuildSteps.push({
   name: 'Configure AWS Credentials',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend