### PR TITLE
chore: set timeout longer to handle large ods file number

### DIFF
--- a/src/analytics/private/load-ods-data-workflow.ts
+++ b/src/analytics/private/load-ods-data-workflow.ts
@@ -664,8 +664,8 @@ export class LoadOdsDataToRedshiftWorkflow extends Construct {
         'skip-running-workflow.ts',
       ),
       handler: 'handler',
-      memorySize: 128,
-      timeout: Duration.minutes(2),
+      memorySize: 512,
+      timeout: Duration.minutes(15),
       logConf: {
         retention: RetentionDays.ONE_WEEK,
       },

--- a/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
+++ b/test/analytics/analytics-on-redshift/data-analytics-redshift-stack.test.ts
@@ -931,6 +931,38 @@ describe('DataAnalyticsRedshiftStack lambda function test', () => {
     }
   });
 
+  test('Check lambda CheckSkippingRunningWorkflowFn', () => {
+    for (const nestedTemplate of allNestedTemplates) {
+      nestedTemplate.hasResourceProperties('AWS::Lambda::Function', {
+        Code: {
+          S3Bucket: Match.anyValue(),
+          S3Key: Match.anyValue(),
+        },
+        Role: {
+          'Fn::GetAtt': [
+            Match.anyValue(),
+            'Arn',
+          ],
+        },
+        Environment: {
+          Variables: {
+            PROJECT_ID: Match.anyValue(),
+            DYNAMODB_TABLE_NAME: Match.anyValue(),
+            DYNAMODB_TABLE_INDEX_NAME: Match.anyValue(),
+          },
+        },
+        Handler: 'index.handler',
+        MemorySize: 512,
+        ReservedConcurrentExecutions: 1,
+        Runtime: Match.anyValue(),
+        Timeout: 900,
+        LoggingConfig: {
+          ApplicationLogLevel: 'WARN',
+          LogFormat: 'JSON',
+        },
+      });
+    }
+  });
 
   test('Check LoadODSEventToRedshiftWorkflowODSEventProcessorFn', () => {
     for (const nestedTemplate of allNestedTemplates) {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

set timeout longer to handle large ods file number

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend