### PR TITLE
fix: improve ETL performance

### DIFF
--- a/src/data-pipeline/spark-etl/src/main/java/software/aws/solution/clickstream/ETLRunner.java
+++ b/src/data-pipeline/spark-etl/src/main/java/software/aws/solution/clickstream/ETLRunner.java
@@ -452,7 +452,10 @@ public class ETLRunner {
         if ("json".equalsIgnoreCase(runConfig.getOutPutFormat())) {
             partitionedDataset.write().partitionBy(partitionBy).mode(SaveMode.Append).json(saveOutputPath);
         } else {
-            int numPartitions = Math.max((int) (resultCount / 100_000), 1);
+            long partitionCount = partitionedDataset.select(PARTITION_APP, PARTITION_YEAR, PARTITION_MONTH, PARTITION_DAY).distinct().count();
+            log.info("partitionCount: " + partitionCount);
+
+            int numPartitions = Math.max((int) (resultCount / (100_000 * partitionCount)), 1);
             int outPartitions = Integer.parseInt(System.getProperty(OUTPUT_COALESCE_PARTITIONS_PROP, "-1"));
             log.info("calculated numPartitions: " + numPartitions + ", outPartitions:" + outPartitions);
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)
<img width="490" alt="image" src="https://github.com/awslabs/clickstream-analytics-on-aws/assets/23469402/add0eb4e-18a6-49a5-bb07-b751dce09591">

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend