### PR TITLE
chore: ETL common java 11 compatibility

### DIFF
--- a/src/data-pipeline/etl-common/build.gradle
+++ b/src/data-pipeline/etl-common/build.gradle
@@ -24,8 +24,8 @@ apply from: "${rootProject.projectDir}/gradle/config/scripts/coverage.gradle"
 group = "$group"
 version = "$projectVersion"
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
 
 repositories {
     mavenCentral()

--- a/src/data-pipeline/etl-common/src/main/java/software/aws/solution/clickstream/common/ingest/User.java
+++ b/src/data-pipeline/etl-common/src/main/java/software/aws/solution/clickstream/common/ingest/User.java
@@ -33,12 +33,14 @@ public class User {
 
     @JsonAnySetter
     public void setCustomProperties(final String name, final Object value) {
-        if (value instanceof Map<?, ?> valueMap) {
+        if (value instanceof Map<?, ?>) {
+            Map<?, ?> valueMap = (Map<?, ?>) value;
             Object valObj = valueMap.getOrDefault("value", null);
             Object setTimestampObj = valueMap.getOrDefault("set_timestamp", null);
 
             Long setTimestamp = null;
-            if (setTimestampObj instanceof Number setTimestampNum) {
+            if (setTimestampObj instanceof Number) {
+                Number setTimestampNum = (Number) setTimestampObj;
                 setTimestamp = setTimestampNum.longValue();
             }
             if (valObj == null) {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

change ETL common to java 11 compatibility, so we can use it in Flink (java11)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend