### PR TITLE
fix: traffic source medium for internal referrer

### DIFF
--- a/src/data-pipeline/etl-common/src/main/java/software/aws/solution/clickstream/common/enrich/RuleBasedTrafficSourceHelper.java
+++ b/src/data-pipeline/etl-common/src/main/java/software/aws/solution/clickstream/common/enrich/RuleBasedTrafficSourceHelper.java
@@ -378,14 +378,20 @@ public final class RuleBasedTrafficSourceHelper implements TrafficSourceHelper {
             }
         }
 
+        boolean isFromInternal = isInternalReferrer || isInternalLatestReferrer;
+
         if (categoryTrafficSource.getSource() == null) {
             categoryTrafficSource.setSource(DIRECT);
             categoryTrafficSource.setCategory(DIRECT);
-            if (isInternalReferrer || isInternalLatestReferrer) {
+            if (isFromInternal) {
                 categoryTrafficSource.setChannelGroup(INTERNAL);
             } else {
                 categoryTrafficSource.setChannelGroup(DIRECT);
             }
+        }
+
+        if (categoryTrafficSource.getMedium() == null && isFromInternal) {
+            categoryTrafficSource.setMedium(NONE);
         }
 
         if (categoryTrafficSource.getSource() != null && categoryTrafficSource.getMedium() == null) {
@@ -393,7 +399,7 @@ public final class RuleBasedTrafficSourceHelper implements TrafficSourceHelper {
         }
 
         if (categoryTrafficSource.getMedium() == null) {
-            categoryTrafficSource.setMedium(getMediumByReferrer(pageReferrer, latestReferrer, isInternalReferrer));
+            categoryTrafficSource.setMedium(getMediumByReferrer(pageReferrer, latestReferrer, isFromInternal));
         }
     }
 
@@ -408,10 +414,10 @@ public final class RuleBasedTrafficSourceHelper implements TrafficSourceHelper {
         return null;
     }
 
-    String getMediumByReferrer(final String pageReferrer, final String latestReferrer, final boolean isInternalReferrer) {
-        log.debug("getMediumByReferrer() enter pageReferrer: {}, latestReferrer: {}, isInternalReferrer: {}", pageReferrer, latestReferrer, isInternalReferrer);
+    String getMediumByReferrer(final String pageReferrer, final String latestReferrer, final boolean isFromInternal) {
+        log.debug("getMediumByReferrer() enter pageReferrer: {}, latestReferrer: {}, isFromInternal: {}", pageReferrer, latestReferrer, isFromInternal);
 
-        if (isAllEmpty(pageReferrer, latestReferrer)) {
+        if (isAllEmpty(pageReferrer, latestReferrer) || isFromInternal) {
             return NONE;
         }
 
@@ -432,10 +438,6 @@ public final class RuleBasedTrafficSourceHelper implements TrafficSourceHelper {
             if (knownSearchEngineDomains.contains(referrerHost)) {
                 return ORGANIC;
             }
-        }
-
-        if (isInternalReferrer) {
-            return NONE;
         }
 
         if (pageReferrer != null && !pageReferrer.isEmpty()) {

--- a/src/data-pipeline/etl-common/src/test/java/software/aws/solution/clickstream/common/enrich/RuleBasedTrafficSourceHelperTest.java
+++ b/src/data-pipeline/etl-common/src/test/java/software/aws/solution/clickstream/common/enrich/RuleBasedTrafficSourceHelperTest.java
@@ -374,7 +374,7 @@ public class RuleBasedTrafficSourceHelperTest extends BaseTest {
         RuleBasedTrafficSourceHelper parser = RuleBasedTrafficSourceHelper.getInstance("testApp", getRuleConfigV0());
         String pageReferrer = "https://example.com";
         String latestReferrer = "https://www.google.com/search?q=flowers&hl=en&biw=1366&bih=667&source=lnms&tbm=isch&sa=X&ei=0f8yU5r6E8mSyAGFhoGwDw&ved=0CAcQ_AUoAg";
-        boolean internalReferrer = true;
+        boolean internalReferrer = false;
 
         String medium = parser.getMediumByReferrer(pageReferrer, latestReferrer, internalReferrer);
         Assertions.assertEquals(RuleBasedTrafficSourceHelper.ORGANIC, medium);
@@ -437,6 +437,49 @@ public class RuleBasedTrafficSourceHelperTest extends BaseTest {
                 "    }";
         String value = prettyJson(Util.objectToJsonString(cts));
         Assertions.assertEquals(prettyJson(expectedValue), value);
+    }
+
+    @Test
+    void testGetMediumByReferrer10() throws IOException {
+        // ./gradlew clean test --info --tests software.aws.solution.clickstream.common.enrich.RuleBasedTrafficSourceHelperTest.testGetMediumByReferrer10
+
+        RuleBasedTrafficSourceHelper parser = RuleBasedTrafficSourceHelper.getInstance("testApp", getRuleConfigV0());
+        String pageUrl = "https://test.com/posts/2024/redshift-serverless-cost-deep-dive/";
+        String pageReferrer = null;
+        String latestReferrer = "https://test.com/";
+        String latestReferrerHost = "test.com";
+
+        CategoryTrafficSource cts = parser.parse(pageUrl, pageReferrer, latestReferrer, latestReferrerHost);
+
+        String expectedValue = "{\n" +
+                "      \"source\" : \"Direct\",\n" +
+                "      \"medium\" : \"None\",\n" +
+                "      \"campaign\" : \"Direct\",\n" +
+                "      \"content\" : null,\n" +
+                "      \"term\" : null,\n" +
+                "      \"campaignId\" : null,\n" +
+                "      \"clidPlatform\" : null,\n" +
+                "      \"clid\" : null,\n" +
+                "      \"channelGroup\" : \"Internal\",\n" +
+                "      \"category\" : \"Direct\"\n" +
+                "    }";
+        String value = prettyJson(Util.objectToJsonString(cts));
+        Assertions.assertEquals(prettyJson(expectedValue), value);
+    }
+
+
+    @Test
+    void testGetMediumByReferrer11() throws IOException {
+        //./gradlew clean test --info --tests software.aws.solution.clickstream.common.enrich.RuleBasedTrafficSourceHelperTest.testGetMediumByReferrer11
+
+        RuleBasedTrafficSourceHelper parser = RuleBasedTrafficSourceHelper.getInstance("testApp", getRuleConfigV0());
+        String pageReferrer = "https://example.com";
+        String latestReferrer = "https://www.example.com/search?q=flowers&hl=en&biw=1366&bih=667&source=lnms&tbm=isch&sa=X&ei=0f8yU5r6E8mSyAGFhoGwDw&ved=0CAcQ_AUoAg";
+        boolean internalReferrer = true;
+
+        String medium = parser.getMediumByReferrer(pageReferrer, latestReferrer, internalReferrer);
+        Assertions.assertEquals(RuleBasedTrafficSourceHelper.NONE, medium);
+
     }
 
 }


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend