### PR TITLE
fix: support warmup sql in shared database

### DIFF
--- a/src/control-plane/backend/lambda/api/service/quicksight/reporting-utils.ts
+++ b/src/control-plane/backend/lambda/api/service/quicksight/reporting-utils.ts
@@ -1731,8 +1731,8 @@ export async function warmupRedshift(pipeline: IPipeline, appId: string, execute
   const queryId = await waitExecuteWarmupStatement(
     redshiftData,
     workgroupName,
-    redshiftDatabaseName,
-    `select * from ${appId}.${EVENT_USER_VIEW} limit 1`,
+    'dev',
+    `select * from ${redshiftDatabaseName}.${appId}.${EVENT_USER_VIEW} limit 1`,
     executeId,
   );
   return queryId;

--- a/src/control-plane/backend/lambda/api/test/api/reporting.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/reporting.test.ts
@@ -2338,9 +2338,9 @@ describe('reporting test', () => {
     expect(redshiftClientMock).toHaveReceivedCommandTimes(ExecuteStatementCommand, 1);
     expect(redshiftClientMock).toHaveReceivedCommandTimes(DescribeStatementCommand, 1);
     expect(redshiftClientMock).toHaveReceivedNthSpecificCommandWith(1, ExecuteStatementCommand, {
-      Sql: `select * from app1.${EVENT_USER_VIEW} limit 1`,
+      Sql: `select * from mock-database-name.app1.${EVENT_USER_VIEW} limit 1`,
       WorkgroupName: 'redshift-workgroup-1',
-      Database: 'mock-database-name',
+      Database: 'dev',
     });
   });
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend