### PR TITLE
fix: use incorrect log table in migration sql

### DIFF
--- a/src/analytics/lambdas/clear-expired-events-workflow/check-clear-status.ts
+++ b/src/analytics/lambdas/clear-expired-events-workflow/check-clear-status.ts
@@ -13,12 +13,10 @@
 
 import { logger } from '@aws/clickstream-base-lib';
 import { StatusString } from '@aws-sdk/client-redshift-data';
-import { SP_CLEAR_EXPIRED_DATA } from '../../private/constant';
 import { ClearExpiredEventsEventDetail } from '../../private/model';
-import { describeStatement, executeStatementsWithWait, getRedshiftClient, getRedshiftProps, getStatementResult } from '../redshift-data';
+import { describeStatement, getRedshiftClient } from '../redshift-data';
 
 const REDSHIFT_DATA_API_ROLE_ARN = process.env.REDSHIFT_DATA_API_ROLE!;
-const REDSHIFT_DATABASE = process.env.REDSHIFT_DATABASE!;
 
 // Create an Amazon service client object.
 const redshiftDataApiClient = getRedshiftClient(REDSHIFT_DATA_API_ROLE_ARN);
@@ -43,12 +41,11 @@ export const handler = async (event: ClearExpiredEventsEvent) => {
 
   if (response.Status == StatusString.FINISHED) {
     logger.info('Clear expired events success.');
-    const queryResult = await queryClearLog(appId);
     return {
       detail: {
         appId: appId,
         status: response.Status,
-        message: queryResult.detail.message,
+        message: 'clearing expired events ran successfully.',
       },
     };
   } else if (response.Status == StatusString.FAILED || response.Status == StatusString.ABORTED) {
@@ -70,44 +67,5 @@ export const handler = async (event: ClearExpiredEventsEvent) => {
         status: response.Status,
       },
     };
-  }
-};
-
-export const queryClearLog = async (appId: string) => {
-  const redshiftProps = getRedshiftProps(
-    process.env.REDSHIFT_MODE!,
-    REDSHIFT_DATABASE,
-    REDSHIFT_DATA_API_ROLE_ARN,
-    process.env.REDSHIFT_DB_USER!,
-    process.env.REDSHIFT_SERVERLESS_WORKGROUP_NAME!,
-    process.env.REDSHIFT_CLUSTER_IDENTIFIER!,
-  );
-
-  const schema = appId;
-
-  try {
-    const querySqlStatement = `SELECT * FROM ${schema}.clickstream_log WHERE log_name='${SP_CLEAR_EXPIRED_DATA}' ORDER BY log_date, id`;
-    const queryId = await executeStatementsWithWait(
-      redshiftDataApiClient, [querySqlStatement], redshiftProps.serverlessRedshiftProps, redshiftProps.provisionedRedshiftProps);
-
-    const response = await getStatementResult(redshiftDataApiClient, queryId!);
-
-    logger.info('Clear log response:', { response });
-
-    const delSqlStatement = `DELETE FROM ${schema}.clickstream_log WHERE log_name='${SP_CLEAR_EXPIRED_DATA}'`;
-    await executeStatementsWithWait(
-      redshiftDataApiClient, [delSqlStatement], redshiftProps.serverlessRedshiftProps, redshiftProps.provisionedRedshiftProps);
-    return {
-      detail: {
-        appId: schema,
-        message: response.Records,
-      },
-    };
-
-  } catch (err) {
-    if (err instanceof Error) {
-      logger.error('Error when query clear expired events log.', err);
-    }
-    throw err;
   }
 };

--- a/src/analytics/private/sqls/redshift/migrate/sp-migrate-data-to-v2.sql
+++ b/src/analytics/private/sqls/redshift/migrate/sp-migrate-data-to-v2.sql
@@ -30,7 +30,7 @@ BEGIN
         SELECT
             1
         FROM
-            {{schema}}.clickstream_log
+            {{schema}}.{{table_clickstream_log}}
         WHERE
             log_msg = 'backfill event_v2 is done'
             AND log_date > start_dt
@@ -85,7 +85,7 @@ BEGIN
             SELECT
                 1
             FROM
-                {{schema}}.clickstream_log
+                {{schema}}.{{table_clickstream_log}}
             WHERE
                 log_msg = 'backfill item_v2 is done'
                 AND log_date > start_dt

--- a/test/analytics/analytics-on-redshift/lambda/clear-expire-events/check-clear-status.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/clear-expire-events/check-clear-status.test.ts
@@ -54,7 +54,7 @@ describe('Lambda - check the clear status in Redshift Serverless', () => {
       detail: {
         appId: 'app1',
         status: StatusString.FINISHED,
-        message: [],
+        message: 'clearing expired events ran successfully.',
       },
     });
     expect(redshiftDataMock).toHaveReceivedCommandWith(DescribeStatementCommand, {
@@ -179,7 +179,7 @@ describe('Lambda - check the clear status in Redshift Provisioned', () => {
       detail: {
         appId: 'app1',
         status: StatusString.FINISHED,
-        message: [],
+        message: 'clearing expired events ran successfully.',
       },
     });
     expect(redshiftDataMock).toHaveReceivedCommandWith(DescribeStatementCommand, {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend