### PR TITLE
fix: use caffeine cache in ETL

### DIFF
--- a/src/data-pipeline/etl-common/build.gradle
+++ b/src/data-pipeline/etl-common/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:$fasterxmlJacksonDatabindVersion"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$fasterxmlJacksonAnnotationsVersion"
 
+    // cache
+    implementation  "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
+
     // lombok related.
     compileOnly("org.projectlombok:lombok:$lombokVersion")
     annotationProcessor("org.projectlombok:lombok:$lombokVersion")

--- a/src/data-pipeline/etl-common/gradle.properties
+++ b/src/data-pipeline/etl-common/gradle.properties
@@ -19,3 +19,4 @@ fasterxmlJacksonCoreVersion=2.14.2
 fasterxmlJacksonDatabindVersion=2.14.2
 log4j2Version=2.17.1
 slf4jVersion=2.0.6
+caffeineVersion=3.1.8

--- a/src/data-pipeline/etl-common/src/main/java/software/aws/solution/clickstream/common/Cache.java
+++ b/src/data-pipeline/etl-common/src/main/java/software/aws/solution/clickstream/common/Cache.java
@@ -12,31 +12,33 @@
  */
 
 package software.aws.solution.clickstream.common;
-import java.util.HashMap;
-import java.util.Map;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import java.time.Duration;
 
 public class Cache<T> {
-    private final Map<String, T> dataCached;
-    private final int size;
+    private final com.github.benmanes.caffeine.cache.Cache<String, T> dataCached;
 
     public Cache() {
-        this(Integer.MAX_VALUE/2);
+        this(Integer.MAX_VALUE/8); //255M
     }
+
     public Cache(final int size) {
-        this.dataCached = new HashMap<>(1024 * 1024);
-        this.size = size;
+        this.dataCached =  Caffeine.newBuilder()
+                .maximumSize(size)
+                .expireAfterWrite(Duration.ofMinutes(5))
+                .expireAfterAccess(Duration.ofMinutes(5))
+                .build();
     }
     public boolean containsKey(final String key) {
-        return dataCached.containsKey(key);
+        return dataCached.getIfPresent(key) != null;
     }
     public T get(final String key) {
-        return dataCached.get(key);
+        return dataCached.getIfPresent(key);
     }
 
     public void put(final String key, final T data) {
-        if (dataCached.size() >= size) {
-            dataCached.remove(dataCached.keySet().iterator().next());
-        }
         dataCached.put(key, data);
     }
 }

--- a/src/data-pipeline/etl-common/src/main/java/software/aws/solution/clickstream/common/enrich/UAEnrichHelper.java
+++ b/src/data-pipeline/etl-common/src/main/java/software/aws/solution/clickstream/common/enrich/UAEnrichHelper.java
@@ -31,7 +31,6 @@ public final class UAEnrichHelper {
     public static final String UA_STRING = "string";
     public static final String BOT = "Bot";
     private static final Cache<ClickstreamUA> CACHED_UA = new Cache<>();
-
     private UAEnrichHelper() {
     }
     public static ClickstreamUA parserUA(final String userAgent) {

--- a/src/data-pipeline/etl-common/src/test/java/software/aws/solution/clickstream/common/CacheTest.java
+++ b/src/data-pipeline/etl-common/src/test/java/software/aws/solution/clickstream/common/CacheTest.java
@@ -41,12 +41,11 @@ class CacheTest {
     }
 
     @Test
-    void shouldNotRemoveOldestDataImmediatelyWhenCacheIsFull() {
+    void latestPutKeyShouldExistWhenCacheIsFull() {
         Cache<String> cache = new Cache<>(2);
         cache.put("key1", "data1");
         cache.put("key2", "data2");
         cache.put("key3", "data3");
-        assertTrue(cache.containsKey("key1"));
         assertTrue(cache.containsKey("key2"));
         assertTrue(cache.containsKey("key3"));
     }

--- a/src/data-pipeline/etl-common/src/test/java/software/aws/solution/clickstream/common/CacheTest.java
+++ b/src/data-pipeline/etl-common/src/test/java/software/aws/solution/clickstream/common/CacheTest.java
@@ -15,6 +15,7 @@ package software.aws.solution.clickstream.common;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class CacheTest {
@@ -40,11 +41,12 @@ class CacheTest {
     }
 
     @Test
-    void shouldRemoveOldestDataWhenCacheIsFull() {
+    void shouldNotRemoveOldestDataImmediatelyWhenCacheIsFull() {
+        Cache<String> cache = new Cache<>(2);
         cache.put("key1", "data1");
         cache.put("key2", "data2");
         cache.put("key3", "data3");
-        assertFalse(cache.containsKey("key1"));
+        assertTrue(cache.containsKey("key1"));
         assertTrue(cache.containsKey("key2"));
         assertTrue(cache.containsKey("key3"));
     }

--- a/src/data-pipeline/etl-common/src/test/java/software/aws/solution/clickstream/common/CacheTest.java
+++ b/src/data-pipeline/etl-common/src/test/java/software/aws/solution/clickstream/common/CacheTest.java
@@ -46,7 +46,6 @@ class CacheTest {
         cache.put("key1", "data1");
         cache.put("key2", "data2");
         cache.put("key3", "data3");
-        assertTrue(cache.containsKey("key2"));
         assertTrue(cache.containsKey("key3"));
     }
 

--- a/src/data-pipeline/spark-etl/build.gradle
+++ b/src/data-pipeline/spark-etl/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     // For UA.
     implementation "com.github.ua-parser:uap-java:$uapJavaVersion"
 
+    // cache
+    implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
+
     // lombok related.
     compileOnly("org.projectlombok:lombok:$lombokVersion")
     annotationProcessor("org.projectlombok:lombok:$lombokVersion")
@@ -103,7 +106,10 @@ jar {
         configurations
                 .runtimeClasspath
                 .collect {
-                    if (it.name.contains("maxmind-db") || it.name.contains("uap-java") || it.name.contains("etl-common")) {
+                    if (it.name.contains("maxmind-db")
+                            || it.name.contains("uap-java")
+                            || it.name.contains("etl-common")
+                            || it.name.contains("caffeine")) {
                         zipTree(it)
                     }
                 }

--- a/src/data-pipeline/spark-etl/gradle.properties
+++ b/src/data-pipeline/spark-etl/gradle.properties
@@ -15,3 +15,4 @@ guavaVersion=32.1.2-jre
 sparkVersion=3.4.1
 uapJavaVersion=1.5.3
 maxmindDbVersion=3.1.0
+caffeineVersion=3.1.8


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend