### PR TITLE
chore: specify coverage provider for frontend

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -483,6 +483,7 @@ const frontendProject = new typescript.TypeScriptProject({
   pnpmVersion,
   jestOptions: {
     jestConfig: {
+      coverageProvider: 'babel',
       roots: ['<rootDir>/src', '<rootDir>/test'],
       testEnvironment: 'jsdom',
       moduleDirectories: ['node_modules', 'src'],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -141,7 +141,7 @@
   "license": "Apache-2.0",
   "version": "1.2.0",
   "jest": {
-    "coverageProvider": "v8",
+    "coverageProvider": "babel",
     "roots": [
       "<rootDir>/src",
       "<rootDir>/test"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -33,6 +33,7 @@ src/base-lib/lib/**/*,\
 src/control-plane/backend/lambda/api/coverage/**/*,\
 src/streaming-ingestion/flink-etl/**/*.java,\
 *-ln.ts
+sonar.text.excluded.file.suffixes=.parquet
 
 sonar.issue.ignore.multicriteria=e1,e2,e3
 # exclude False Positive findings for instantiating CDK objects only


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend