### PR TITLE
chore: use refresh start time to refresh base view

### DIFF
--- a/src/analytics/private/refresh-materialized-views-workflow.ts
+++ b/src/analytics/private/refresh-materialized-views-workflow.ts
@@ -98,6 +98,7 @@ export class RefreshMaterializedViewsWorkflow extends Construct {
       payload: TaskInput.fromObject({
         'view.$': '$.view',
         'timezoneWithAppId.$': '$.timezoneWithAppId',
+        'originalInput.$': '$$.Execution.Input',
       }),
       outputPath: '$.Payload',
     });

--- a/test/analytics/analytics-on-redshift/lambda/refresh-materialized-views-workflow/refresh-basic-view.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/refresh-materialized-views-workflow/refresh-basic-view.test.ts
@@ -92,6 +92,33 @@ describe('Lambda - do refresh job in Redshift Serverless', () => {
     jest.useRealTimers();
   });
 
+  test('Executed Redshift refresh custom-mv command with RefreshStartTime bigger than current', async () => {
+    const exeuteId = 'Id-1';
+    refreshBasicViewEvent.view.type = 'custom-mv';
+    refreshBasicViewEvent.originalInput = {
+      refreshStartTime: '1715470905000',
+    };
+    jest
+      .useFakeTimers()
+      .setSystemTime(1715450905000);
+    const dataFreshnessInHour = 72;
+    redshiftDataMock.on(ExecuteStatementCommand).resolvesOnce({ Id: exeuteId });
+    const resp = await handler(refreshBasicViewEvent);
+    expect(resp).toEqual({
+      detail: {
+        viewName: refreshBasicViewEvent.view.name,
+        queryId: exeuteId,
+      },
+      timezoneWithAppId: refreshBasicViewEvent.timezoneWithAppId,
+    });
+    expect(redshiftDataMock).toHaveReceivedCommandWith(ExecuteStatementCommand, {
+      WorkgroupName: workGroupName,
+      Sql: `CALL ${refreshBasicViewEvent.timezoneWithAppId.appId}.${refreshBasicViewEvent.view.name}(NULL, NULL, ${dataFreshnessInHour});`,
+      Database: expect.any(String),
+    });
+    jest.useRealTimers();
+  });
+
   test('Executed Redshift refresh custom-mv command without input refreshStartTime', async () => {
     const exeuteId = 'Id-1';
     refreshBasicViewEvent.view.type = 'custom-mv';

--- a/test/analytics/analytics-on-redshift/lambda/refresh-materialized-views-workflow/refresh-basic-view.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/refresh-materialized-views-workflow/refresh-basic-view.test.ts
@@ -26,7 +26,10 @@ const refreshBasicViewEvent: RefreshBasicViewEvent = {
   },
   timezoneWithAppId: {
     appId: 'app1',
-    timezone: 'America/Noronha',
+    timezone: 'UTC',
+  },
+  originalInput: {
+    refreshStartTime: '',
   },
 };
 
@@ -62,8 +65,59 @@ describe('Lambda - do refresh job in Redshift Serverless', () => {
     });
   });
 
+  test('Executed Redshift refresh custom-mv command', async () => {
+    const exeuteId = 'Id-1';
+    refreshBasicViewEvent.view.type = 'custom-mv';
+    refreshBasicViewEvent.originalInput = {
+      refreshStartTime: '1715470905000',
+    };
+    jest
+      .useFakeTimers()
+      .setSystemTime(1715490905000);
+    const dataFreshnessInHour = 6;
+    redshiftDataMock.on(ExecuteStatementCommand).resolvesOnce({ Id: exeuteId });
+    const resp = await handler(refreshBasicViewEvent);
+    expect(resp).toEqual({
+      detail: {
+        viewName: refreshBasicViewEvent.view.name,
+        queryId: exeuteId,
+      },
+      timezoneWithAppId: refreshBasicViewEvent.timezoneWithAppId,
+    });
+    expect(redshiftDataMock).toHaveReceivedCommandWith(ExecuteStatementCommand, {
+      WorkgroupName: workGroupName,
+      Sql: `CALL ${refreshBasicViewEvent.timezoneWithAppId.appId}.${refreshBasicViewEvent.view.name}(NULL, NULL, ${dataFreshnessInHour});`,
+      Database: expect.any(String),
+    });
+    jest.useRealTimers();
+  });
+
+  test('Executed Redshift refresh custom-mv command without input refreshStartTime', async () => {
+    const exeuteId = 'Id-1';
+    refreshBasicViewEvent.view.type = 'custom-mv';
+    refreshBasicViewEvent.originalInput = {
+      refreshStartTime: '',
+    };
+    const dataFreshnessInHour = 72;
+    redshiftDataMock.on(ExecuteStatementCommand).resolvesOnce({ Id: exeuteId });
+    const resp = await handler(refreshBasicViewEvent);
+    expect(resp).toEqual({
+      detail: {
+        viewName: refreshBasicViewEvent.view.name,
+        queryId: exeuteId,
+      },
+      timezoneWithAppId: refreshBasicViewEvent.timezoneWithAppId,
+    });
+    expect(redshiftDataMock).toHaveReceivedCommandWith(ExecuteStatementCommand, {
+      WorkgroupName: workGroupName,
+      Sql: `CALL ${refreshBasicViewEvent.timezoneWithAppId.appId}.${refreshBasicViewEvent.view.name}(NULL, NULL, ${dataFreshnessInHour});`,
+      Database: expect.any(String),
+    });
+  });
+
   test('Execute command error in Redshift when doing refresh', async () => {
     redshiftDataMock.on(ExecuteStatementCommand).rejects();
+    refreshBasicViewEvent.view.type = 'basic';
     try {
       await handler(refreshBasicViewEvent);
       fail('The error in executing statement of Redshift data was caught');
@@ -79,7 +133,6 @@ describe('Lambda - do refresh job in Redshift Serverless', () => {
     redshiftDataMock.on(ExecuteStatementCommand)
       .rejectsOnce()
       .resolves({ Id: exeuteId });
-
     const resp = await handler(refreshBasicViewEvent);
     expect(resp).toEqual({
       detail: {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend