### PR TITLE
fix: ETL job failure when input dataset is empty

### DIFF
--- a/src/data-pipeline/spark-etl/src/main/java/software/aws/solution/clickstream/TransformerV3.java
+++ b/src/data-pipeline/spark-etl/src/main/java/software/aws/solution/clickstream/TransformerV3.java
@@ -261,11 +261,6 @@ public class TransformerV3 extends BaseTransformerV3 {
         Dataset<Row> userDataset = convertedDataset.select(expr("dataOut.user.*"))
                 .select(toColumnArray(ModelV2.getUserFields()));
 
-        if (userDataset.count() == 0) {
-            log.info("extractUser return empty dataset");
-            return userDataset;
-        }
-
         userDataset = userDataset.withColumn(USER_FIRST_EVENT_NAME, col(Constant.EVENT_NAME))
                 .withColumn(USER_LATEST_EVENT_NAME, col(Constant.EVENT_NAME))
                 .drop(Constant.EVENT_NAME);
@@ -278,6 +273,11 @@ public class TransformerV3 extends BaseTransformerV3 {
         DatasetUtil.PathInfo pathInfo = addSchemaToMap(newUserAggDataset, tableName, TABLE_VERSION_SUFFIX_V3);
         log.info("tableName: {}", tableName);
         log.info("pathInfo - incremental: " + pathInfo.getIncremental() + ", full: " + pathInfo.getFull());
+
+        if (userDataset.count() == 0) {
+            log.info("extractUser return empty dataset");
+            return userDataset;
+        }
 
         // save new (append)
         String path = saveIncrementalDatasetToPath(pathInfo.getIncremental(), newUserAggDataset);

--- a/src/data-pipeline/spark-etl/src/main/java/software/aws/solution/clickstream/transformer/BaseThirdPartyTransformer.java
+++ b/src/data-pipeline/spark-etl/src/main/java/software/aws/solution/clickstream/transformer/BaseThirdPartyTransformer.java
@@ -217,11 +217,6 @@ public abstract class BaseThirdPartyTransformer extends BaseTransformerV3 {
         Dataset<Row> userDataset = convertedDataset.select(expr("dataOut.user.*"))
                 .select(toColumnArray(ModelV2.getUserFields()));
 
-        if (userDataset.count() == 0) {
-            log.info("extractUser return empty dataset");
-            return userDataset;
-        }
-
         // agg new
         Dataset<Row> newUserAggDataset = aggUserDataset(userDataset, "newUserAggDataset");
         log.info("newUserAggDataset count: {}", newUserAggDataset.count());
@@ -230,6 +225,11 @@ public abstract class BaseThirdPartyTransformer extends BaseTransformerV3 {
         DatasetUtil.PathInfo pathInfo = addSchemaToMap(newUserAggDataset, tableName, TABLE_VERSION_SUFFIX_V3);
         log.info("tableName: {}", tableName);
         log.info("pathInfo - incremental: " + pathInfo.getIncremental() + ", full: " + pathInfo.getFull());
+
+        if (userDataset.count() == 0) {
+            log.info("extractUser return empty dataset");
+            return userDataset;
+        }
 
         // save new (append)
         String path = saveIncrementalDatasetToPath(pathInfo.getIncremental(), newUserAggDataset);


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend