### PR TITLE
fix: realtime dashboard using wrong template definition

### DIFF
--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -780,7 +780,7 @@ const updateQuickSightDashboard = async (quickSight: QuickSight, commonParams: R
         schema: commonParams.schema,
         dashboardDefProps: dashboardDef,
       });
-      realtimeDashboard = await createDashboard(quickSight, commonParams, sourceEntity, dashboardDef, true);
+      realtimeDashboard = await createDashboard(quickSight, commonParams, sourceEntityRT, dashboardDef, true);
       logger.info(`Dashboard ${dashboard?.DashboardId} create completed.`);
     }
   }

--- a/src/reporting/lambda/custom-resource/quicksight/index.ts
+++ b/src/reporting/lambda/custom-resource/quicksight/index.ts
@@ -514,7 +514,7 @@ const createQuickSightDashboard = async (quickSight: QuickSight,
   }
 
   let realtimeDashboard = undefined;
-  if (realtimeDatasetRefs.length > 0 && dashboardDef.realtimeTemplateArn.length > 0) {
+  if (dashboardDef.realtimeTemplateId.length > 0) {
     const realtimeSourceEntity = {
       SourceTemplate: {
         Arn: dashboardDef.realtimeTemplateArn,
@@ -774,14 +774,14 @@ const updateQuickSightDashboard = async (quickSight: QuickSight, commonParams: R
     const dashboardExistRT = await existDashboard(quickSight, commonParams.awsAccountId, dashboardIdRT.id);
     if (dashboardExistRT) {
       realtimeDashboard = await updateDashboard(quickSight, commonParams, sourceEntityRT, dashboardDef);
-      logger.info(`Dashboard ${dashboard?.DashboardId} update completed.`);
+      logger.info(`Dashboard ${realtimeDashboard?.DashboardId} update completed.`);
     } else {
       createdQuickSightResources.createdSchemas.push({
         schema: commonParams.schema,
         dashboardDefProps: dashboardDef,
       });
       realtimeDashboard = await createDashboard(quickSight, commonParams, sourceEntityRT, dashboardDef, true);
-      logger.info(`Dashboard ${dashboard?.DashboardId} create completed.`);
+      logger.info(`Dashboard ${realtimeDashboard?.DashboardId} create completed.`);
     }
   }
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend