### PR TITLE
fix: backward compatible for alb updating custom resource

### DIFF
--- a/src/ingestion-server/custom-resource/update-alb-rules/index.ts
+++ b/src/ingestion-server/custom-resource/update-alb-rules/index.ts
@@ -124,13 +124,18 @@ async function _handler(
     const oldEndpointPath = oldProps.endpointPath;
     const oldDomainName = oldProps.domainName;
     const oldAuthenticationSecretArn = oldProps.authenticationSecretArn;
-    const oldEnableAuthentication: FeatureFlag = oldProps.enableAuthentication;
+    let oldEnableAuthentication: FeatureFlag = oldProps.enableAuthentication;
     const newUpdateProps : UpdatePropType = {
       endpointPath,
       hostHeader: domainName,
       enableAuthentication,
       authenticationSecretArn,
     };
+
+    if (!oldEnableAuthentication) {
+      oldEnableAuthentication = oldAuthenticationSecretArn ? FeatureFlag.ENABLED : FeatureFlag.DISABLED;
+    }
+
     const oldUpdateProps : UpdatePropType = {
       endpointPath: oldEndpointPath,
       hostHeader: oldDomainName,


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

compatible from v1 upgrading to v2

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [x] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [x] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend