### PR TITLE
chore: add refresh button on segment detail page

### DIFF
--- a/frontend/src/pages/analytics/segments/UserSegmentDetails.tsx
+++ b/frontend/src/pages/analytics/segments/UserSegmentDetails.tsx
@@ -28,6 +28,7 @@ import {
   ContentLayout,
   Header,
   MixedLineBarChart,
+  SpaceBetween,
   Spinner,
   StatusIndicator,
 } from '@cloudscape-design/components';
@@ -272,66 +273,80 @@ const UserSegmentDetails: React.FC = () => {
                         variant="h2"
                         description={defaultStr(segment?.description)}
                         actions={
-                          <ButtonDropdown
-                            items={[
-                              {
-                                text: defaultStr(t('button.edit')),
-                                id: 'edit',
-                              },
-                              {
-                                text: defaultStr(t('button.duplicate')),
-                                id: 'duplicate',
-                              },
-                              {
-                                text: defaultStr(t('button.delete')),
-                                id: 'delete',
-                              },
-                              {
-                                text: defaultStr(t('button.refreshSegment')),
-                                id: 'refresh',
-                              },
-                            ]}
-                            onItemClick={async (e) => {
-                              const hrefPath = `/analytics/${projectId}/app/${appId}/segments/${segmentId}/`;
+                          <SpaceBetween direction="horizontal" size="s">
+                            <Button
+                              iconName="refresh"
+                              onClick={() => {
+                                getSegmentJobHistory();
+                                getSegmentSampleData();
+                              }}
+                            />
+                            <ButtonDropdown
+                              items={[
+                                {
+                                  text: defaultStr(t('button.edit')),
+                                  id: 'edit',
+                                },
+                                {
+                                  text: defaultStr(t('button.duplicate')),
+                                  id: 'duplicate',
+                                },
+                                {
+                                  text: defaultStr(t('button.delete')),
+                                  id: 'delete',
+                                },
+                                {
+                                  text: defaultStr(t('button.refreshSegment')),
+                                  id: 'refresh',
+                                },
+                              ]}
+                              onItemClick={async (e) => {
+                                const hrefPath = `/analytics/${projectId}/app/${appId}/segments/${segmentId}/`;
 
-                              switch (e.detail.id) {
-                                case 'delete':
-                                  try {
-                                    setIsLoading(true);
-                                    await deleteSegment({
-                                      segmentId,
-                                      appId,
-                                    });
-                                    window.location.href = `/analytics/${projectId}/app/${appId}/segments`;
-                                  } catch (error) {
-                                    console.error('Failed to delete segment.');
-                                  }
-                                  break;
-                                case 'duplicate':
-                                  window.location.href = hrefPath + 'duplicate';
-                                  break;
-                                case 'edit':
-                                  window.location.href = hrefPath + 'edit';
-                                  break;
-                                case 'refresh':
-                                  try {
-                                    setIsJobsLoading(true);
-                                    await refreshSegment({
-                                      segmentId,
-                                      appId,
-                                    });
-                                    await getSegmentJobHistory();
-                                  } catch (error) {
-                                    console.error('Failed to refresh segment.');
-                                  }
-                                  break;
-                                default:
-                                  break;
-                              }
-                            }}
-                          >
-                            {t('button.actions')}
-                          </ButtonDropdown>
+                                switch (e.detail.id) {
+                                  case 'delete':
+                                    try {
+                                      setIsLoading(true);
+                                      await deleteSegment({
+                                        segmentId,
+                                        appId,
+                                      });
+                                      window.location.href = `/analytics/${projectId}/app/${appId}/segments`;
+                                    } catch (error) {
+                                      console.error(
+                                        'Failed to delete segment.'
+                                      );
+                                    }
+                                    break;
+                                  case 'duplicate':
+                                    window.location.href =
+                                      hrefPath + 'duplicate';
+                                    break;
+                                  case 'edit':
+                                    window.location.href = hrefPath + 'edit';
+                                    break;
+                                  case 'refresh':
+                                    try {
+                                      setIsJobsLoading(true);
+                                      await refreshSegment({
+                                        segmentId,
+                                        appId,
+                                      });
+                                      await getSegmentJobHistory();
+                                    } catch (error) {
+                                      console.error(
+                                        'Failed to refresh segment.'
+                                      );
+                                    }
+                                    break;
+                                  default:
+                                    break;
+                                }
+                              }}
+                            >
+                              {t('button.actions')}
+                            </ButtonDropdown>
+                          </SpaceBetween>
                         }
                       >
                         {defaultStr(segment?.name)}


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Add refresh button on segment detail page

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend