### PR TITLE
chore: auto refresh realtime dashboard

### DIFF
--- a/frontend/public/locales/en-US/analytics.json
+++ b/frontend/public/locales/en-US/analytics.json
@@ -52,7 +52,16 @@
     "title": "Realtime",
     "description": "You can view key metrics of your apps and website in realtime here.",
     "disableMessage": "This project has not enabled real-time dashboard, please contact your admin to turn on real-time dashboard.",
-    "configProject": "Configure project"
+    "configProject": "Configure project",
+    "autoRefresh": {
+      "title": "Auto refresh",
+      "close": "Close",
+      "seconds15": "15 seconds",
+      "seconds30": "30 seconds",
+      "minute1": "1 minute",
+      "minute5": "5 minutes",
+      "minute10": "10 minutes"
+    }
   },
   "analyzes": {
     "title": "Analyses",

--- a/frontend/public/locales/zh-CN/analytics.json
+++ b/frontend/public/locales/zh-CN/analytics.json
@@ -52,7 +52,16 @@
     "title": "实时",
     "description": "您可以在此处实时查看应用程序和网站的点击流数据以及相关指标。",
     "disableMessage": "此项目尚未启用实时面板，请与管理员联系以打开实时面板。",
-    "configProject": "配置项目"
+    "configProject": "配置项目",
+    "autoRefresh": {
+      "title": "自动刷新",
+      "close": "关闭",
+      "seconds15": "15 秒",
+      "seconds30": "30 秒",
+      "minute1": "1 分钟",
+      "minute5": "5 分钟",
+      "minute10": "10 分钟"
+    }
   },
   "analyzes": {
     "title": "分析",

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -588,6 +588,10 @@ ul.menu-list li.checkbox-item {
   gap: 5px;
 }
 
+.cs-analytics-realtime-auto-refresh {
+  float: right;
+}
+
 .cs-analytics-data-range {
   display: flex;
   gap: 5px;

--- a/frontend/src/pages/analytics/realtime/AnalyticsRealtime.tsx
+++ b/frontend/src/pages/analytics/realtime/AnalyticsRealtime.tsx
@@ -198,9 +198,11 @@ const AnalyticsRealtime: React.FC = () => {
                           <Button
                             iconName="refresh"
                             variant="icon"
+                            disabled={!checked}
                             onClick={() => getRealtime(true)}
                           />
                           <ButtonDropdown
+                            disabled={!checked}
                             items={[
                               {
                                 text: defaultStr(


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

<img width="1315" alt="截屏2024-06-29 21 54 51" src="https://github.com/awslabs/clickstream-analytics-on-aws/assets/18416040/c7ec7205-ab50-4008-973b-b2ec3344cad8">


## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend