### PR TITLE
tests: run spark ETL tests in parallel

### DIFF
--- a/src/data-pipeline/spark-etl/build.gradle
+++ b/src/data-pipeline/spark-etl/build.gradle
@@ -87,6 +87,14 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
+test {
+    forkEvery = 1
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+
+    maxHeapSize = "4g"
+    minHeapSize = "1g"
+}
+
 application {
     // Define the main class for the application.
     mainClass = 'software.aws.solution.clickstream.DataProcessor'

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/BaseTest.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/BaseTest.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.*;
 import com.google.common.io.*;
 import org.apache.logging.log4j.*;
 import org.apache.logging.log4j.core.config.*;
+import org.apache.spark.api.java.JavaSparkContext;
 import org.junit.jupiter.api.*;
 import software.aws.solution.clickstream.util.*;
 

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/CleanerTest.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/CleanerTest.java
@@ -16,12 +16,15 @@ package software.aws.solution.clickstream;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.transformer.*;
 
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static software.aws.solution.clickstream.util.ContextUtil.*;
 
+@Execution(ExecutionMode.CONCURRENT)
 class CleanerTest extends BaseSparkTest {
     private final Cleaner cleaner = new Cleaner();
 

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/ClickstreamDataConverterV3Test.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/ClickstreamDataConverterV3Test.java
@@ -15,6 +15,8 @@ package software.aws.solution.clickstream;
 
 import org.apache.spark.sql.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.udfconverter.ClickstreamDataConverterV3;
 
 import java.io.*;
@@ -22,6 +24,7 @@ import java.io.*;
 import static org.apache.spark.sql.functions.*;
 import static software.aws.solution.clickstream.util.ContextUtil.PROJECT_ID_PROP;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class ClickstreamDataConverterV3Test extends BaseSparkTest {
     private ClickstreamDataConverterV3 converter;
     @BeforeEach

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/ContextUtilTest.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/ContextUtilTest.java
@@ -15,6 +15,8 @@ package software.aws.solution.clickstream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.util.*;
 
 import java.net.URISyntaxException;
@@ -25,6 +27,7 @@ import java.util.Objects;
 import static com.google.common.collect.Lists.newArrayList;
 import static software.aws.solution.clickstream.util.ContextUtil.DEBUG_LOCAL_PROP;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class ContextUtilTest {
     @Test
     public void testSetContextProperties() {

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/DataProcessorTest.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/DataProcessorTest.java
@@ -16,11 +16,14 @@ package software.aws.solution.clickstream;
 import com.clearspring.analytics.util.Lists;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.util.*;
 
 import java.nio.file.Paths;
 import java.util.List;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class DataProcessorTest extends BaseSparkTest{
     @Test
     public void testMain() {

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/ETLRunnerBaseTest.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/ETLRunnerBaseTest.java
@@ -15,14 +15,19 @@ package software.aws.solution.clickstream;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.util.*;
 
+import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.*;
 import java.util.*;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Objects.requireNonNull;
 
+@Execution(ExecutionMode.CONCURRENT)
 @Slf4j
 public class ETLRunnerBaseTest extends BaseSparkTest {
 
@@ -92,8 +97,10 @@ public class ETLRunnerBaseTest extends BaseSparkTest {
                 ));
         return runnerConfig;
     }
+
     @Test
     void testGetConfig() {
         this.getRunnerConfig(newArrayList("software.aws.solution.clickstream.transformer.FakeTransformer"), "test");
     }
+
 }

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/ETLRunnerForGtmV2Test.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/ETLRunnerForGtmV2Test.java
@@ -16,6 +16,8 @@ package software.aws.solution.clickstream;
 import com.clearspring.analytics.util.*;
 import org.apache.spark.sql.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.common.Constant;
 import software.aws.solution.clickstream.util.*;
 
@@ -28,6 +30,7 @@ import static software.aws.solution.clickstream.util.ContextUtil.APP_IDS_PROP;
 import static software.aws.solution.clickstream.util.ContextUtil.PROJECT_ID_PROP;
 import static software.aws.solution.clickstream.util.ContextUtil.WAREHOUSE_DIR_PROP;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class ETLRunnerForGtmV2Test extends ETLRunnerBaseTest {
 
     @Test
@@ -37,7 +40,7 @@ public class ETLRunnerForGtmV2Test extends ETLRunnerBaseTest {
         System.setProperty(PROJECT_ID_PROP, "test_project_id_01");
         System.setProperty("force.merge", "true");
         System.setProperty(WAREHOUSE_DIR_PROP, "/tmp/warehouse/etl_runner/test_GTM_server_runner_v2_" + System.currentTimeMillis());
-        spark.sparkContext().addFile(requireNonNull(getClass().getResource("/GeoLite2-City.mmdb")).getPath());
+        addGeoLite2FileToSpark();
 
         List<String> transformers = Lists.newArrayList();
         transformers.add("software.aws.solution.clickstream.gtm.GTMServerDataTransformerV2");
@@ -90,7 +93,8 @@ public class ETLRunnerForGtmV2Test extends ETLRunnerBaseTest {
         System.setProperty(PROJECT_ID_PROP, "test_project_id_01");
         System.setProperty("force.merge", "true");
         System.setProperty(WAREHOUSE_DIR_PROP, "/tmp/warehouse/etl_runner/test_GTM_server_runner_parquet_v2");
-        spark.sparkContext().addFile(requireNonNull(getClass().getResource("/GeoLite2-City.mmdb")).getPath());
+
+        addGeoLite2FileToSpark();
 
         List<String> transformers = Lists.newArrayList();
         transformers.add("software.aws.solution.clickstream.gtm.GTMServerDataTransformerV2");

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/ETLRunnerForSensorsDataTest.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/ETLRunnerForSensorsDataTest.java
@@ -19,10 +19,15 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.util.ETLRunnerConfig;
 import software.aws.solution.clickstream.util.TableName;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
@@ -31,6 +36,7 @@ import static software.aws.solution.clickstream.util.ContextUtil.FILTER_BOT_BY_U
 import static software.aws.solution.clickstream.util.ContextUtil.PROJECT_ID_PROP;
 import static software.aws.solution.clickstream.util.ContextUtil.WAREHOUSE_DIR_PROP;
 
+@Execution(ExecutionMode.CONCURRENT)
 @Slf4j
 public class ETLRunnerForSensorsDataTest extends ETLRunnerBaseTest {
 
@@ -42,7 +48,8 @@ public class ETLRunnerForSensorsDataTest extends ETLRunnerBaseTest {
         System.setProperty(FILTER_BOT_BY_UA_PROP, "true");
         System.setProperty("force.merge", "true");
         System.setProperty(WAREHOUSE_DIR_PROP, "/tmp/warehouse/etl_runner/test_sensors_data_runner_" + System.currentTimeMillis());
-        spark.sparkContext().addFile(requireNonNull(getClass().getResource("/GeoLite2-City.mmdb")).getPath());
+
+        addGeoLite2FileToSpark();
 
         List<String> transformers = Lists.newArrayList();
         transformers.add("software.aws.solution.clickstream.sensors.SensorsDataTransformerV2");

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/ETLRunnerForTransformerV3Test.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/ETLRunnerForTransformerV3Test.java
@@ -17,6 +17,8 @@ package software.aws.solution.clickstream;
 import com.clearspring.analytics.util.*;
 import org.apache.spark.sql.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.common.Constant;
 import software.aws.solution.clickstream.util.*;
 
@@ -30,8 +32,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static software.aws.solution.clickstream.transformer.BaseTransformerV3.TABLE_VERSION_SUFFIX_V3;
 import static software.aws.solution.clickstream.util.ContextUtil.*;
 import static software.aws.solution.clickstream.util.DatasetUtil.*;
-import static software.aws.solution.clickstream.TransformerV3.ETL_USER_V2_PROPS;
 
+@Execution(ExecutionMode.CONCURRENT)
 class ETLRunnerForTransformerV3Test extends ETLRunnerBaseTest {
 
     @Test
@@ -42,7 +44,7 @@ class ETLRunnerForTransformerV3Test extends ETLRunnerBaseTest {
         System.setProperty(DEBUG_LOCAL_PROP, "true");
         setWarehouseDir("should_executeTransformers_with_TransformerV3_1");
 
-        spark.sparkContext().addFile(requireNonNull(getClass().getResource("/GeoLite2-City.mmdb")).getPath());
+        addGeoLite2FileToSpark();
 
         List<String> transformers = Lists.newArrayList();
         transformers.add("software.aws.solution.clickstream.TransformerV3");
@@ -88,7 +90,7 @@ class ETLRunnerForTransformerV3Test extends ETLRunnerBaseTest {
         System.setProperty(DEBUG_LOCAL_PROP, "true");
         setWarehouseDir("should_executeTransformers_with_TransformerV3_parquet");
 
-        spark.sparkContext().addFile(requireNonNull(getClass().getResource("/GeoLite2-City.mmdb")).getPath());
+        addGeoLite2FileToSpark();
 
         List<String> transformers = Lists.newArrayList();
         transformers.add("software.aws.solution.clickstream.TransformerV3");
@@ -139,7 +141,8 @@ class ETLRunnerForTransformerV3Test extends ETLRunnerBaseTest {
         System.setProperty("force.merge", "true");
         setWarehouseDir("should_executeTransformers_with_TransformerV3_2");
 
-        spark.sparkContext().addFile(requireNonNull(getClass().getResource("/GeoLite2-City.mmdb")).getPath());
+        addGeoLite2FileToSpark();
+
         List<String> transformers = Lists.newArrayList();
         transformers.add("software.aws.solution.clickstream.TransformerV3");
         transformers.add("software.aws.solution.clickstream.UAEnrichmentV2");

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/ETLRunnerTest.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/ETLRunnerTest.java
@@ -17,6 +17,8 @@ package software.aws.solution.clickstream;
 import com.clearspring.analytics.util.*;
 import org.apache.spark.sql.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.common.TransformConfig;
 import software.aws.solution.clickstream.util.*;
 
@@ -30,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static software.aws.solution.clickstream.util.ContextUtil.*;
 import static software.aws.solution.clickstream.util.DatasetUtil.*;
 
+@Execution(ExecutionMode.CONCURRENT)
 class ETLRunnerTest extends ETLRunnerBaseTest {
 
     @Test
@@ -109,8 +112,10 @@ class ETLRunnerTest extends ETLRunnerBaseTest {
         System.setProperty(DEBUG_LOCAL_PROP, "true");
         System.setProperty(APP_IDS_PROP, "id1,id2,uba-app");
         System.setProperty(PROJECT_ID_PROP, "projectId1");
+        String uniqueWarehouseDir = "/tmp/warehouse/" + UUID.randomUUID();
+        System.setProperty(WAREHOUSE_DIR_PROP, uniqueWarehouseDir);
 
-        spark.sparkContext().addFile(requireNonNull(getClass().getResource("/GeoLite2-City.mmdb")).getPath());
+        addGeoLite2FileToSpark();
 
         List<String> transformers = Lists.newArrayList();
 
@@ -192,8 +197,13 @@ class ETLRunnerTest extends ETLRunnerBaseTest {
     }
 
     @Test
-    public void should_executeTransformers_with_error() {
-        spark.sparkContext().addFile(requireNonNull(getClass().getResource("/GeoLite2-City.mmdb")).getPath());
+    public void should_executeTransformers_with_error() throws IOException {
+        System.setProperty(APP_IDS_PROP, "uba-app");
+        String uniqueWarehouseDir = "/tmp/warehouse/" + UUID.randomUUID();
+        System.setProperty(WAREHOUSE_DIR_PROP, uniqueWarehouseDir);
+
+        addGeoLite2FileToSpark();
+
         List<String> transformers = Lists.newArrayList();
 
         transformers.add("software.aws.solution.clickstream.Transformer");
@@ -235,7 +245,7 @@ class ETLRunnerTest extends ETLRunnerBaseTest {
         System.setProperty(DEBUG_LOCAL_PROP, "true");
         System.setProperty(WAREHOUSE_DIR_PROP, "/tmp/warehouse/TransformerV2_1");
 
-        spark.sparkContext().addFile(requireNonNull(getClass().getResource("/GeoLite2-City.mmdb")).getPath());
+        addGeoLite2FileToSpark();
 
         List<String> transformers = Lists.newArrayList();
         transformers.add("software.aws.solution.clickstream.TransformerV2");
@@ -272,7 +282,8 @@ class ETLRunnerTest extends ETLRunnerBaseTest {
         System.setProperty(PROJECT_ID_PROP, "test_project_id_01");
         System.setProperty(WAREHOUSE_DIR_PROP, "/tmp/warehouse/TransformerV2_2");
 
-        spark.sparkContext().addFile(requireNonNull(getClass().getResource("/GeoLite2-City.mmdb")).getPath());
+        addGeoLite2FileToSpark();
+
         List<String> transformers = Lists.newArrayList();
         transformers.add("software.aws.solution.clickstream.TransformerV2");
         transformers.add("software.aws.solution.clickstream.UAEnrichment");
@@ -298,7 +309,8 @@ class ETLRunnerTest extends ETLRunnerBaseTest {
         System.setProperty("force.merge", "true");
         System.setProperty(WAREHOUSE_DIR_PROP, "/tmp/warehouse/TransformerV2_3");
 
-        spark.sparkContext().addFile(requireNonNull(getClass().getResource("/GeoLite2-City.mmdb")).getPath());
+        addGeoLite2FileToSpark();
+
         List<String> transformers = Lists.newArrayList();
         transformers.add("software.aws.solution.clickstream.TransformerV2");
         transformers.add("software.aws.solution.clickstream.UAEnrichment");
@@ -348,7 +360,8 @@ class ETLRunnerTest extends ETLRunnerBaseTest {
         System.setProperty(PROJECT_ID_PROP, "test_project_id_01");
         System.setProperty(WAREHOUSE_DIR_PROP, "/tmp/warehouse/TransformerV2_user_item_params");
 
-        spark.sparkContext().addFile(requireNonNull(getClass().getResource("/GeoLite2-City.mmdb")).getPath());
+        addGeoLite2FileToSpark();
+
         List<String> transformers = Lists.newArrayList();
         transformers.add("software.aws.solution.clickstream.TransformerV2");
         transformers.add("software.aws.solution.clickstream.UAEnrichment");
@@ -399,7 +412,8 @@ class ETLRunnerTest extends ETLRunnerBaseTest {
         System.setProperty("force.merge", "true");
         System.setProperty(WAREHOUSE_DIR_PROP, "/tmp/warehouse/TransformerV2_with_empty_user");
 
-        spark.sparkContext().addFile(requireNonNull(getClass().getResource("/GeoLite2-City.mmdb")).getPath());
+        addGeoLite2FileToSpark();
+
         List<String> transformers = Lists.newArrayList();
         transformers.add("software.aws.solution.clickstream.TransformerV2");
         transformers.add("software.aws.solution.clickstream.UAEnrichment");
@@ -471,7 +485,8 @@ class ETLRunnerTest extends ETLRunnerBaseTest {
         System.setProperty(PROJECT_ID_PROP, "test_project_id_01");
         System.setProperty("force.merge", "true");
         System.setProperty(WAREHOUSE_DIR_PROP, "/tmp/warehouse/etl_runner/should_executeTransformers_with_GTM_server_transformer");
-        spark.sparkContext().addFile(requireNonNull(getClass().getResource("/GeoLite2-City.mmdb")).getPath());
+
+        addGeoLite2FileToSpark();
 
         List<String> transformers = Lists.newArrayList();
         transformers.add("software.aws.solution.clickstream.gtm.GTMServerDataTransformer");

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/EventParamsConverterTest.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/EventParamsConverterTest.java
@@ -16,6 +16,8 @@ package software.aws.solution.clickstream;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import scala.collection.Iterator;
 import software.aws.solution.clickstream.transformer.*;
 
@@ -23,6 +25,7 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static software.aws.solution.clickstream.util.ContextUtil.DEBUG_LOCAL_PROP;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class EventParamsConverterTest extends BaseSparkTest {
 
     @Test

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/ExceptionTest.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/ExceptionTest.java
@@ -15,11 +15,14 @@ package software.aws.solution.clickstream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.common.exception.*;
 import software.aws.solution.clickstream.exception.ExecuteTransformerException;
 
 import java.io.IOException;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class ExceptionTest {
     @Test
     public void testExecuteTransformerExceptionIsRuntimeException() {

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/IPEnrichmentV2Test.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/IPEnrichmentV2Test.java
@@ -15,6 +15,8 @@ package software.aws.solution.clickstream;
 
 import org.apache.spark.sql.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.common.Constant;
 import software.aws.solution.clickstream.model.*;
 
@@ -22,7 +24,7 @@ import java.io.*;
 
 import static java.util.Objects.*;
 import static software.aws.solution.clickstream.util.ContextUtil.*;
-
+@Execution(ExecutionMode.CONCURRENT)
 class IPEnrichmentV2Test extends BaseSparkTest {
 
     private final IPEnrichmentV2 ipEnrichment = new IPEnrichmentV2();
@@ -33,7 +35,7 @@ class IPEnrichmentV2Test extends BaseSparkTest {
         System.setProperty(APP_IDS_PROP, "uba-app");
         System.setProperty(PROJECT_ID_PROP, "test_project_id_01");
 
-        spark.sparkContext().addFile(requireNonNull(getClass().getResource("/GeoLite2-City.mmdb")).getPath());
+        addGeoLite2FileToSpark();
 
         Dataset<Row> dataset =
                 spark.read().schema(ModelV2.EVENT_TYPE).json(requireNonNull(getClass().getResource("/event_v2/transformed_data_event_v2.json")).getPath());

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/MaxLengthTransformerTest.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/MaxLengthTransformerTest.java
@@ -18,6 +18,8 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.transformer.*;
 
 import java.util.List;
@@ -26,6 +28,7 @@ import static java.util.Objects.requireNonNull;
 import static org.apache.spark.sql.functions.col;
 import static org.apache.spark.sql.functions.udf;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class MaxLengthTransformerTest extends BaseSparkTest {
     @Test
     public void test_transform() {

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/MaxLengthTransformerV2Test.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/MaxLengthTransformerV2Test.java
@@ -16,6 +16,8 @@ package software.aws.solution.clickstream;
 
 import org.apache.spark.sql.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.model.*;
 import software.aws.solution.clickstream.transformer.*;
 
@@ -23,6 +25,7 @@ import java.io.*;
 
 import static java.util.Objects.*;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class MaxLengthTransformerV2Test extends BaseSparkTest {
     @Test
     public void test_max_len_transform_v2() throws IOException {

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/SimpleEnrich.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/SimpleEnrich.java
@@ -15,9 +15,12 @@ package software.aws.solution.clickstream;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import static org.apache.spark.sql.functions.lit;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class SimpleEnrich {
     public Dataset<Row> transform(final Dataset<Row> dataset) {
         return dataset.withColumn("enrichBy", lit("software.aws.solution.clickstream.SimpleEnrich.transform"));

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/SimpleTransformer.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/SimpleTransformer.java
@@ -15,8 +15,12 @@ package software.aws.solution.clickstream;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
 import static org.apache.spark.sql.functions.lit;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class SimpleTransformer {
     public Dataset<Row> transform(final Dataset<Row> dataset) {
         return dataset.withColumn("transformedBy", lit("software.aws.solution.clickstream.SimpleTransformer.transform"));

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/TransformerTest.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/TransformerTest.java
@@ -16,6 +16,8 @@ package software.aws.solution.clickstream;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.sql.Date;
 import java.util.List;
@@ -26,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static software.aws.solution.clickstream.util.ContextUtil.APP_IDS_PROP;
 import static software.aws.solution.clickstream.util.ContextUtil.PROJECT_ID_PROP;
 
+@Execution(ExecutionMode.CONCURRENT)
 class TransformerTest extends BaseSparkTest {
 
     private final Transformer transformer = new Transformer();

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/TransformerV2Test.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/TransformerV2Test.java
@@ -19,6 +19,8 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.util.*;
 
 import java.io.IOException;
@@ -32,7 +34,7 @@ import static software.aws.solution.clickstream.util.ContextUtil.*;
 import static software.aws.solution.clickstream.util.DatasetUtil.*;
 import static software.aws.solution.clickstream.ETLRunner.TRANSFORM_METHOD_NAME;
 
-
+@Execution(ExecutionMode.CONCURRENT)
 @Slf4j
 class TransformerV2Test extends BaseSparkTest {
 

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/TransformerV3Test.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/TransformerV3Test.java
@@ -20,6 +20,8 @@ import org.apache.spark.sql.SaveMode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.common.Constant;
 import software.aws.solution.clickstream.model.ModelV2;
 import software.aws.solution.clickstream.util.*;
@@ -33,7 +35,7 @@ import static software.aws.solution.clickstream.transformer.BaseTransformerV3.TA
 import static software.aws.solution.clickstream.util.ContextUtil.*;
 import static software.aws.solution.clickstream.util.DatasetUtil.*;
 
-
+@Execution(ExecutionMode.CONCURRENT)
 @Slf4j
 class TransformerV3Test extends BaseSparkTest {
 

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/UAEnrichmentTest.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/UAEnrichmentTest.java
@@ -17,6 +17,8 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.io.IOException;
 
@@ -25,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static software.aws.solution.clickstream.util.ContextUtil.APP_IDS_PROP;
 import static software.aws.solution.clickstream.util.ContextUtil.PROJECT_ID_PROP;
 
+@Execution(ExecutionMode.CONCURRENT)
 class UAEnrichmentTest extends BaseSparkTest {
 
     private final UAEnrichment uaEnrichment = new UAEnrichment();

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/UAEnrichmentV2Test.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/UAEnrichmentV2Test.java
@@ -14,6 +14,8 @@
 package software.aws.solution.clickstream;
 import org.apache.spark.sql.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.common.Constant;
 
 import java.io.*;
@@ -21,6 +23,7 @@ import java.io.*;
 import static java.util.Objects.requireNonNull;
 import static software.aws.solution.clickstream.util.ContextUtil.FILTER_BOT_BY_UA_PROP;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class UAEnrichmentV2Test extends BaseSparkTest {
     UAEnrichmentV2 converter = new UAEnrichmentV2();
     @Test

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/UserPropertiesConverterTest.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/UserPropertiesConverterTest.java
@@ -16,6 +16,8 @@ package software.aws.solution.clickstream;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import scala.collection.Iterator;
 import software.aws.solution.clickstream.transformer.*;
 
@@ -23,6 +25,7 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static software.aws.solution.clickstream.util.ContextUtil.DEBUG_LOCAL_PROP;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class UserPropertiesConverterTest extends BaseSparkTest {
     @Test
     public void should_convert_user_data() {

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/gtm/GTMServerDataTransformerV2Test.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/gtm/GTMServerDataTransformerV2Test.java
@@ -17,6 +17,8 @@ import lombok.extern.slf4j.*;
 import org.apache.spark.sql.*;
 import org.apache.spark.sql.types.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.*;
 import software.aws.solution.clickstream.util.*;
 
@@ -29,7 +31,7 @@ import static java.util.Objects.*;
 import static org.apache.spark.sql.functions.*;
 import static software.aws.solution.clickstream.util.ContextUtil.*;
 
-
+@Execution(ExecutionMode.CONCURRENT)
 @Slf4j
 public class GTMServerDataTransformerV2Test extends BaseSparkTest {
     GTMServerDataTransformerV2 transformer;

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/gtm/ServerDataConverterV2Test.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/gtm/ServerDataConverterV2Test.java
@@ -16,15 +16,19 @@ package software.aws.solution.clickstream.gtm;
 
 import org.apache.spark.sql.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.*;
 
 import java.io.*;
+import java.util.UUID;
 
 import static java.util.Objects.*;
 import static org.apache.spark.sql.functions.*;
 import static software.aws.solution.clickstream.util.ContextUtil.*;
 import static software.aws.solution.clickstream.common.Util.deCodeUri;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class ServerDataConverterV2Test extends BaseSparkTest {
     ServerDataConverterV2 converter;
     @BeforeEach
@@ -142,6 +146,8 @@ public class ServerDataConverterV2Test extends BaseSparkTest {
         System.setProperty(APP_IDS_PROP, "testApp");
         System.setProperty(PROJECT_ID_PROP, "gtm_server_demo_https");
         System.setProperty(DEBUG_LOCAL_PROP, "false");
+        String uniqueWarehouseDir = "/tmp/warehouse/" + UUID.randomUUID();
+        System.setProperty(WAREHOUSE_DIR_PROP, uniqueWarehouseDir);
 
         Dataset<Row> dataset =
                 spark.read().json(requireNonNull(getClass().getResource("/gtm-server/test-convert-corrupt-v2.json")).getPath());
@@ -149,7 +155,7 @@ public class ServerDataConverterV2Test extends BaseSparkTest {
 
         Assertions.assertEquals(0, outDataset.count());
         Dataset<Row> corrupDataset =
-                spark.read().json("/tmp/warehouse/etl_corrupted_json_gtm_server_data").filter(col("rid").equalTo("ssssss9dc4d91c00000v2"));
+                spark.read().json(uniqueWarehouseDir + "/etl_corrupted_json_gtm_server_data").filter(col("rid").equalTo("ssssss9dc4d91c00000v2"));
         Assertions.assertTrue(corrupDataset.count() > 0);
 
        Assertions.assertTrue(corrupDataset.select(expr("dataOut._corrupt_record"))

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/sensors/SensorsDataTransformerV2Test.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/sensors/SensorsDataTransformerV2Test.java
@@ -19,6 +19,8 @@ import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.BaseSparkTest;
 import software.aws.solution.clickstream.util.TableName;
 
@@ -31,6 +33,7 @@ import static software.aws.solution.clickstream.util.ContextUtil.APP_IDS_PROP;
 import static software.aws.solution.clickstream.util.ContextUtil.PROJECT_ID_PROP;
 import static software.aws.solution.clickstream.util.ContextUtil.WAREHOUSE_DIR_PROP;
 
+@Execution(ExecutionMode.CONCURRENT)
 @Slf4j
 public class SensorsDataTransformerV2Test extends BaseSparkTest {
     private SensorsDataTransformerV2 transformer;

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/transformer/EventParserFactoryTest.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/transformer/EventParserFactoryTest.java
@@ -19,6 +19,8 @@ import static software.aws.solution.clickstream.transformer.TransformerNameEnum.
 import static software.aws.solution.clickstream.transformer.TransformerNameEnum.GTM_SERVER_DATA;
 import static software.aws.solution.clickstream.transformer.TransformerNameEnum.SENSORS_DATA;
 
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.aws.solution.clickstream.common.ClickstreamEventParser;
 import software.aws.solution.clickstream.common.EventParser;
 import software.aws.solution.clickstream.common.TransformConfig;
@@ -28,6 +30,7 @@ import software.aws.solution.clickstream.udfconverter.EventParserFactory;
 
 import java.util.HashMap;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class EventParserFactoryTest {
 
     @Test


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary
<img width="486" alt="image" src="https://github.com/awslabs/clickstream-analytics-on-aws/assets/23469402/eb56df6e-0431-4009-a47d-fd35705e9b82">

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend