### PR TITLE
feat: import segment

### DIFF
--- a/frontend/public/locales/en-US/analytics.json
+++ b/frontend/public/locales/en-US/analytics.json
@@ -494,7 +494,8 @@
       "export": "Export",
       "segmentUserSample": "User Samples",
       "segmentUserSampleDesc": "User samples from latest completed segment refresh",
-      "noSampleData": "No sample data available"
+      "noSampleData": "No sample data available",
+      "importedSegment": "Imported Segment"
     },
     "valid": {
       "nameEmptyError": "Please input segment name.",

--- a/frontend/public/locales/en-US/analytics.json
+++ b/frontend/public/locales/en-US/analytics.json
@@ -469,7 +469,9 @@
       "selectUserGroup": "Please select user segment group",
       "segmentDescPlaceholder": "Provide a short description",
       "filterByTimeRange": "Filter by a date and time range",
-      "appTimezone": "the app's timezone"
+      "appTimezone": "the app's timezone",
+      "importSegmentTitle": "Import Segment",
+      "importSegmentDesc": "Define a segment, then import the segment manually"
     },
     "details": {
       "title": "Segment Details",

--- a/frontend/public/locales/en-US/common.json
+++ b/frontend/public/locales/en-US/common.json
@@ -26,6 +26,7 @@
     "segments": "Segments",
     "createSegment": "Create Segment",
     "editSegment": "Edit Segment",
+    "importSegment": "Import Segment",
     "data-management": "Data Management"
   },
   "nav": {
@@ -215,6 +216,7 @@
     "reorder": "Reorder",
     "apply": "Apply",
     "newGroup": "Add Group",
+    "import": "Import",
     "export": "Export",
     "refreshSegment": "Refresh Segment",
     "streamEnable": "Streaming Enable",

--- a/frontend/public/locales/zh-CN/analytics.json
+++ b/frontend/public/locales/zh-CN/analytics.json
@@ -494,7 +494,8 @@
       "export": "导出",
       "segmentUserSample": "用户取样",
       "segmentUserSampleDesc": "从最近一次分群刷新结果中取样的用户",
-      "noSampleData": "无可用样例数据"
+      "noSampleData": "无可用样例数据",
+      "importedSegment": "导入分群"
     },
     "valid": {
       "nameEmptyError": "请输入分群名称。",

--- a/frontend/public/locales/zh-CN/analytics.json
+++ b/frontend/public/locales/zh-CN/analytics.json
@@ -469,7 +469,9 @@
       "selectUserGroup": "请选择用户分群组",
       "segmentDescPlaceholder": "提供简短描述",
       "filterByTimeRange": "按日期和时间范围过滤",
-      "appTimezone": "应用程序使用时区"
+      "appTimezone": "应用程序使用时区",
+      "importSegmentTitle": "导入分群",
+      "importSegmentDesc": "自定义分群，并手动导入分群用户"
     },
     "details": {
       "title": "分群详细信息",

--- a/frontend/public/locales/zh-CN/common.json
+++ b/frontend/public/locales/zh-CN/common.json
@@ -26,6 +26,7 @@
     "segments": "分群",
     "createSegment": "创建分群",
     "editSegment": "编辑分群",
+    "importSegment": "导入分群",
     "data-management": "数据管理"
   },
   "nav": {
@@ -215,6 +216,7 @@
     "reorder": "重新排序",
     "apply": "应用",
     "newGroup": "添加分组",
+    "import": "导入",
     "export": "导出",
     "refreshSegment": "刷新分群",
     "streamEnable": "开启实时流",

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -13,9 +13,9 @@
 
 import { Alert } from '@cloudscape-design/components';
 import { getUserDetails } from 'apis/user';
+import CommonAlert from 'components/common/alert';
 import Loading from 'components/common/Loading';
 import RoleRoute from 'components/common/RoleRoute';
-import CommonAlert from 'components/common/alert';
 import { UserContext } from 'context/UserContext';
 import AlarmsList from 'pages/alarms/AlarmList';
 import AnalyticsHome from 'pages/analytics/AnalyticsHome';
@@ -27,17 +27,19 @@ import AnalyticsDashboardFullWindow from 'pages/analytics/dashboard/full/Analyti
 import AnalyticsDataManagement from 'pages/analytics/data-management/AnalyticsDataManagement';
 import AnalyticsExplore from 'pages/analytics/explore/AnalyticsExplore';
 import AnalyticsRealtime from 'pages/analytics/realtime/AnalyticsRealtime';
-import AddUserSegments from 'pages/analytics/segments/AddUserSegment';
+import AddUserSegment from 'pages/analytics/segments/AddUserSegment';
+import ImportUserSegment from 'pages/analytics/segments/ImportUserSegment';
 import UserSegmentDetails from 'pages/analytics/segments/UserSegmentDetails';
 import UserSegments from 'pages/analytics/segments/UserSegments';
 import CreateApplication from 'pages/application/create/CreateApplication';
 import ApplicationDetail from 'pages/application/detail/ApplicationDetail';
+import Home from 'pages/home/Home';
 import CreatePipeline from 'pages/pipelines/create/CreatePipeline';
 import PipelineDetail from 'pages/pipelines/detail/PipelineDetail';
-import PluginList from 'pages/plugins/PluginList';
 import CreatePlugin from 'pages/plugins/create/CreatePlugin';
-import Projects from 'pages/projects/Projects';
+import PluginList from 'pages/plugins/PluginList';
 import ProjectDetail from 'pages/projects/detail/ProjectDetail';
+import Projects from 'pages/projects/Projects';
 import UserList from 'pages/user/UserList';
 import React, { Suspense, useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -45,7 +47,6 @@ import { AuthContextProps } from 'react-oidc-context';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import { IUserRole, LAST_VISIT_URL } from 'ts/const';
 import { getIntersectArrays, getUserInfoFromLocalStorage } from 'ts/utils';
-import Home from './pages/home/Home';
 
 interface LoginCallbackProps {
   auth: AuthContextProps;
@@ -462,7 +463,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.ANALYST]}
               >
-                <AddUserSegments actionType="new" />
+                <AddUserSegment actionType="new" />
               </RoleRoute>
             }
           />
@@ -475,7 +476,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.ANALYST]}
               >
-                <AddUserSegments actionType="duplicate" />
+                <AddUserSegment actionType="duplicate" />
               </RoleRoute>
             }
           />
@@ -488,7 +489,7 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
                 auth={auth}
                 roles={[IUserRole.ADMIN, IUserRole.ANALYST]}
               >
-                <AddUserSegments actionType="edit" />
+                <AddUserSegment actionType="edit" />
               </RoleRoute>
             }
           />
@@ -502,6 +503,19 @@ const AppRouter: React.FC<AppRouterProps> = (props: AppRouterProps) => {
                 roles={[IUserRole.ADMIN, IUserRole.ANALYST]}
               >
                 <UserSegmentDetails />
+              </RoleRoute>
+            }
+          />
+          <Route
+            path="/analytics/:projectId/app/:appId/segments/import"
+            element={
+              <RoleRoute
+                sessionExpired={sessionExpired}
+                layout="analytics"
+                auth={auth}
+                roles={[IUserRole.ADMIN, IUserRole.ANALYST]}
+              >
+                <ImportUserSegment />
               </RoleRoute>
             }
           />

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -13,9 +13,9 @@
 
 import { Alert } from '@cloudscape-design/components';
 import { getUserDetails } from 'apis/user';
-import CommonAlert from 'components/common/alert';
 import Loading from 'components/common/Loading';
 import RoleRoute from 'components/common/RoleRoute';
+import CommonAlert from 'components/common/alert';
 import { UserContext } from 'context/UserContext';
 import AlarmsList from 'pages/alarms/AlarmList';
 import AnalyticsHome from 'pages/analytics/AnalyticsHome';
@@ -36,10 +36,10 @@ import ApplicationDetail from 'pages/application/detail/ApplicationDetail';
 import Home from 'pages/home/Home';
 import CreatePipeline from 'pages/pipelines/create/CreatePipeline';
 import PipelineDetail from 'pages/pipelines/detail/PipelineDetail';
-import CreatePlugin from 'pages/plugins/create/CreatePlugin';
 import PluginList from 'pages/plugins/PluginList';
-import ProjectDetail from 'pages/projects/detail/ProjectDetail';
+import CreatePlugin from 'pages/plugins/create/CreatePlugin';
 import Projects from 'pages/projects/Projects';
+import ProjectDetail from 'pages/projects/detail/ProjectDetail';
 import UserList from 'pages/user/UserList';
 import React, { Suspense, useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/apis/segments.ts
+++ b/frontend/src/apis/segments.ts
@@ -38,8 +38,12 @@ export const getSegmentById = async (params: {
 };
 
 export const createSegment = async (segmentObj: Segment) => {
-  return await apiRequest('post', `/segments`, segmentObj);
+  return await apiRequest('post', '/segments', segmentObj);
 };
+
+export const importSegment = async (segmentObj: Segment) => {
+  return await apiRequest('post', '/segments/import', segmentObj);
+}
 
 export const updateSegment = async (segmentObj: Segment) => {
   return await apiRequest(

--- a/frontend/src/apis/segments.ts
+++ b/frontend/src/apis/segments.ts
@@ -43,7 +43,7 @@ export const createSegment = async (segmentObj: Segment) => {
 
 export const importSegment = async (segmentObj: Segment) => {
   return await apiRequest('post', '/segments/import', segmentObj);
-}
+};
 
 export const updateSegment = async (segmentObj: Segment) => {
   return await apiRequest(

--- a/frontend/src/pages/analytics/segments/AddUserSegment.tsx
+++ b/frontend/src/pages/analytics/segments/AddUserSegment.tsx
@@ -36,7 +36,7 @@ import SegmentEditor from './components/SegmentEditor';
 type AddUserSegmentsProps = {
   actionType: string;
 };
-const AddUserSegments: React.FC<AddUserSegmentsProps> = ({
+const AddUserSegment: React.FC<AddUserSegmentsProps> = ({
   actionType,
 }: AddUserSegmentsProps) => {
   const { t } = useTranslation();
@@ -151,4 +151,4 @@ const AddUserSegments: React.FC<AddUserSegmentsProps> = ({
     </div>
   );
 };
-export default AddUserSegments;
+export default AddUserSegment;

--- a/frontend/src/pages/analytics/segments/ImportUserSegment.tsx
+++ b/frontend/src/pages/analytics/segments/ImportUserSegment.tsx
@@ -1,0 +1,175 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { Segment } from '@aws/clickstream-base-lib';
+import {
+  AppLayout,
+  Button,
+  Container,
+  ContentLayout,
+  Form,
+  FormField,
+  Header,
+  Input,
+  SpaceBetween,
+} from '@cloudscape-design/components';
+import { importSegment } from 'apis/segments';
+import AnalyticsNavigation from 'components/layouts/AnalyticsNavigation';
+import CustomBreadCrumb from 'components/layouts/CustomBreadCrumb';
+import HelpInfo from 'components/layouts/HelpInfo';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router-dom';
+import { defaultStr } from 'ts/utils';
+import { INIT_SEGMENT_OBJ } from '../../../ts/const';
+
+const ImportUserSegment: React.FC = () => {
+  const { t } = useTranslation();
+  const { projectId, appId } = useParams();
+  const navigate = useNavigate();
+  const [segmentName, setSegmentName] = useState<string>('');
+  const [segmentNameError, setSegmentNameError] = useState<string>('');
+  const [segmentDesc, setSegmentDesc] = useState<string>('');
+  const [loadingCreate, setLoadingCreate] = useState<boolean>(false);
+
+  const breadcrumbItems = [
+    {
+      text: t('breadCrumb.name'),
+      href: '/',
+    },
+    {
+      text: t('breadCrumb.segments'),
+      href: `/analytics/${projectId}/app/${appId}/segments`,
+    },
+    {
+      text: t('breadCrumb.importSegment'),
+      href: '',
+    },
+  ];
+
+  const saveUserSegment = async () => {
+    if (!segmentName.trim()) {
+      setSegmentNameError(defaultStr(t('analytics:segment.valid.nameEmptyError')));
+      return;
+    }
+
+    try {
+      setLoadingCreate(true);
+      const request: Segment = {
+        ...INIT_SEGMENT_OBJ,
+        name: segmentName,
+        description: segmentDesc,
+        projectId: defaultStr(projectId),
+        appId: defaultStr(appId),
+        isImported: true,
+      };
+      await importSegment(request);
+      navigate(`/analytics/${projectId}/app/${appId}/segments`);
+    } catch (error) {
+      console.info(error);
+    } finally {
+      setLoadingCreate(false);
+    }
+  };
+
+  return (
+    <div className="flex">
+      <AnalyticsNavigation
+        activeHref={`/analytics/${projectId}/app/${appId}/segments`}
+      />
+      <div className="flex-1">
+        <AppLayout
+          headerVariant="high-contrast"
+          tools={<HelpInfo/>}
+          navigationHide
+          content={
+            <ContentLayout
+              headerVariant="high-contrast"
+              header={
+                <Header description={t('analytics:segment.comp.importSegmentDesc')}>
+                  {t('analytics:segment.comp.importSegmentTitle')}
+                </Header>
+              }
+            >
+              <Form
+                actions={
+                  <SpaceBetween direction="horizontal" size="xs">
+                    <Button
+                      onClick={() => {
+                        navigate(`/analytics/${projectId}/app/${appId}/segments`);
+                      }}
+                    >
+                      {t('button.cancel')}
+                    </Button>
+                    <Button
+                      loading={loadingCreate}
+                      onClick={() => {
+                        saveUserSegment();
+                      }}
+                      variant="primary"
+                    >
+                      {t('button.save')}
+                    </Button>
+                  </SpaceBetween>
+                }
+              >
+                <Container
+                  header={
+                    <Header>{t('analytics:segment.comp.userSegmentSettings')}</Header>
+                  }
+                >
+                  <SpaceBetween direction="vertical" size="m">
+                    <FormField
+                      label={t('analytics:segment.comp.segmentName')}
+                      description={t('analytics:segment.comp.segmentNameDesc')}
+                      errorText={t(defaultStr(segmentNameError))}
+                    >
+                      <Input
+                        value={segmentName}
+                        placeholder={defaultStr(
+                          t('analytics:segment.comp.segmentNamePlaceholder'),
+                        )}
+                        onChange={(e) => {
+                          setSegmentName(e.detail.value);
+                          setSegmentNameError('');
+                        }}
+                      />
+                    </FormField>
+                    <FormField
+                      label={t('analytics:segment.comp.segmentDescription')}
+                      description={t('analytics:segment.comp.segmentDescriptionDesc')}
+                    >
+                      <Input
+                        value={segmentDesc}
+                        placeholder={defaultStr(
+                          t('analytics:segment.comp.segmentDescriptionPlaceholder'),
+                        )}
+                        onChange={(e) => {
+                          setSegmentDesc(e.detail.value);
+                        }}
+                      />
+                    </FormField>
+                  </SpaceBetween>
+                </Container>
+              </Form>
+            </ContentLayout>
+          }
+          headerSelector="#header"
+          breadcrumbs={<CustomBreadCrumb breadcrumbItems={breadcrumbItems}/>}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ImportUserSegment;

--- a/frontend/src/pages/analytics/segments/ImportUserSegment.tsx
+++ b/frontend/src/pages/analytics/segments/ImportUserSegment.tsx
@@ -59,7 +59,9 @@ const ImportUserSegment: React.FC = () => {
 
   const saveUserSegment = async () => {
     if (!segmentName.trim()) {
-      setSegmentNameError(defaultStr(t('analytics:segment.valid.nameEmptyError')));
+      setSegmentNameError(
+        defaultStr(t('analytics:segment.valid.nameEmptyError'))
+      );
       return;
     }
 
@@ -90,13 +92,15 @@ const ImportUserSegment: React.FC = () => {
       <div className="flex-1">
         <AppLayout
           headerVariant="high-contrast"
-          tools={<HelpInfo/>}
+          tools={<HelpInfo />}
           navigationHide
           content={
             <ContentLayout
               headerVariant="high-contrast"
               header={
-                <Header description={t('analytics:segment.comp.importSegmentDesc')}>
+                <Header
+                  description={t('analytics:segment.comp.importSegmentDesc')}
+                >
                   {t('analytics:segment.comp.importSegmentTitle')}
                 </Header>
               }
@@ -106,7 +110,9 @@ const ImportUserSegment: React.FC = () => {
                   <SpaceBetween direction="horizontal" size="xs">
                     <Button
                       onClick={() => {
-                        navigate(`/analytics/${projectId}/app/${appId}/segments`);
+                        navigate(
+                          `/analytics/${projectId}/app/${appId}/segments`
+                        );
                       }}
                     >
                       {t('button.cancel')}
@@ -125,7 +131,9 @@ const ImportUserSegment: React.FC = () => {
               >
                 <Container
                   header={
-                    <Header>{t('analytics:segment.comp.userSegmentSettings')}</Header>
+                    <Header>
+                      {t('analytics:segment.comp.userSegmentSettings')}
+                    </Header>
                   }
                 >
                   <SpaceBetween direction="vertical" size="m">
@@ -137,7 +145,7 @@ const ImportUserSegment: React.FC = () => {
                       <Input
                         value={segmentName}
                         placeholder={defaultStr(
-                          t('analytics:segment.comp.segmentNamePlaceholder'),
+                          t('analytics:segment.comp.segmentNamePlaceholder')
                         )}
                         onChange={(e) => {
                           setSegmentName(e.detail.value);
@@ -147,12 +155,16 @@ const ImportUserSegment: React.FC = () => {
                     </FormField>
                     <FormField
                       label={t('analytics:segment.comp.segmentDescription')}
-                      description={t('analytics:segment.comp.segmentDescriptionDesc')}
+                      description={t(
+                        'analytics:segment.comp.segmentDescriptionDesc'
+                      )}
                     >
                       <Input
                         value={segmentDesc}
                         placeholder={defaultStr(
-                          t('analytics:segment.comp.segmentDescriptionPlaceholder'),
+                          t(
+                            'analytics:segment.comp.segmentDescriptionPlaceholder'
+                          )
                         )}
                         onChange={(e) => {
                           setSegmentDesc(e.detail.value);
@@ -165,7 +177,7 @@ const ImportUserSegment: React.FC = () => {
             </ContentLayout>
           }
           headerSelector="#header"
-          breadcrumbs={<CustomBreadCrumb breadcrumbItems={breadcrumbItems}/>}
+          breadcrumbs={<CustomBreadCrumb breadcrumbItems={breadcrumbItems} />}
         />
       </div>
     </div>

--- a/frontend/src/pages/analytics/segments/UserSegments.tsx
+++ b/frontend/src/pages/analytics/segments/UserSegments.tsx
@@ -50,7 +50,6 @@ const UserSegments: React.FC = () => {
 
   const [loadingData, setLoadingData] = useState(false);
   const [segmentList, setSegmentList] = useState<Segment[]>([]);
-  const [disableAction, setDisableAction] = useState(true);
   const [selectedSegment, setSelectedSegment] = useState<Segment[]>([]);
   const [loadingDelete, setLoadingDelete] = useState(false);
 
@@ -136,14 +135,6 @@ const UserSegments: React.FC = () => {
     }
   }, [projectId, appId]);
 
-  useEffect(() => {
-    if (selectedSegment.length > 0) {
-      setDisableAction(false);
-    } else {
-      setDisableAction(true);
-    }
-  }, [selectedSegment]);
-
   return (
     <div className="flex">
       <AnalyticsNavigation
@@ -184,7 +175,9 @@ const UserSegments: React.FC = () => {
                             } else if (e.detail.id === 'detail') {
                               navigate(hrefPath + 'details');
                             } else if (e.detail.id === 'import') {
-                              navigate(`/analytics/${projectId}/app/${appId}/segments/import`);
+                              navigate(
+                                `/analytics/${projectId}/app/${appId}/segments/import`
+                              );
                             }
                           }}
                           loading={loadingDelete}
@@ -192,27 +185,31 @@ const UserSegments: React.FC = () => {
                             {
                               text: defaultStr(t('button.viewDetails')),
                               id: 'detail',
-                              disabled: disableAction,
+                              disabled: selectedSegment.length === 0,
                             },
                             {
                               text: defaultStr(t('button.duplicate')),
                               id: 'duplicate',
-                              disabled: disableAction,
+                              disabled:
+                                selectedSegment.length === 0 ||
+                                selectedSegment[0].isImported,
                             },
                             {
                               text: defaultStr(t('button.edit')),
                               id: 'edit',
-                              disabled: disableAction,
+                              disabled:
+                                selectedSegment.length === 0 ||
+                                selectedSegment[0].isImported,
                             },
                             {
                               text: defaultStr(t('button.delete')),
                               id: 'delete',
-                              disabled: disableAction,
+                              disabled: selectedSegment.length === 0,
                             },
                             {
                               text: defaultStr(t('button.import')),
                               id: 'import',
-                            }
+                            },
                           ]}
                         >
                           {t('button.actions')}

--- a/frontend/src/pages/analytics/segments/UserSegments.tsx
+++ b/frontend/src/pages/analytics/segments/UserSegments.tsx
@@ -173,7 +173,7 @@ const UserSegments: React.FC = () => {
                       <SpaceBetween direction="horizontal" size="xs">
                         <ButtonDropdown
                           onItemClick={(e) => {
-                            const hrefPath = `/analytics/${projectId}/app/${appId}/segments/${selectedSegment[0].segmentId}/`;
+                            const hrefPath = `/analytics/${projectId}/app/${appId}/segments/${selectedSegment[0]?.segmentId}/`;
 
                             if (e.detail.id === 'delete') {
                               confirmDeleteSegments();
@@ -182,7 +182,9 @@ const UserSegments: React.FC = () => {
                             } else if (e.detail.id === 'edit') {
                               window.location.href = hrefPath + 'edit';
                             } else if (e.detail.id === 'detail') {
-                              window.location.href = hrefPath + 'details';
+                              navigate(hrefPath + 'details');
+                            } else if (e.detail.id === 'import') {
+                              navigate(`/analytics/${projectId}/app/${appId}/segments/import`);
                             }
                           }}
                           loading={loadingDelete}
@@ -207,6 +209,10 @@ const UserSegments: React.FC = () => {
                               id: 'delete',
                               disabled: disableAction,
                             },
+                            {
+                              text: defaultStr(t('button.import')),
+                              id: 'import',
+                            }
                           ]}
                         >
                           {t('button.actions')}

--- a/frontend/src/ts/const.ts
+++ b/frontend/src/ts/const.ts
@@ -560,6 +560,7 @@ export const INIT_SEGMENT_OBJ: ExtendSegment = {
     filterGroups: [],
     operator: 'and',
   },
+  isImported: false,
   // extends fields
   refreshType: 'manual',
   autoRefreshOption: SEGMENT_AUTO_REFRESH_OPTIONS[0],

--- a/src/base-lib/src/model/segment.ts
+++ b/src/base-lib/src/model/segment.ts
@@ -35,6 +35,7 @@ export interface Segment {
   eventBridgeRuleArn?: string;
   sql?: string;
   uiRenderingObject?: any;
+  isImported?: boolean;
 }
 
 export interface RefreshSchedule {

--- a/src/control-plane/backend/lambda/api/router/segment.ts
+++ b/src/control-plane/backend/lambda/api/router/segment.ts
@@ -54,7 +54,7 @@ router_segment.post(
   ]),
   async (req: Request, res: Response, next: NextFunction) => {
     return segmentServ.import(req, res, next);
-  }
+  },
 );
 
 // List segments of an app

--- a/src/control-plane/backend/lambda/api/router/segment.ts
+++ b/src/control-plane/backend/lambda/api/router/segment.ts
@@ -41,6 +41,22 @@ router_segment.post(
   },
 );
 
+// Import segment
+router_segment.post(
+  '/import',
+  validate([
+    body().custom(isValidEmpty).custom(isXSSRequest),
+    body('segmentType').isIn(['User', 'Session', 'Event']),
+    body('name').notEmpty().trim(),
+    body('description').isString().trim(),
+    body('projectId').notEmpty(),
+    body('appId').notEmpty(),
+  ]),
+  async (req: Request, res: Response, next: NextFunction) => {
+    return segmentServ.import(req, res, next);
+  }
+);
+
 // List segments of an app
 router_segment.get(
   '',

--- a/src/control-plane/backend/lambda/api/service/segments/segment.ts
+++ b/src/control-plane/backend/lambda/api/service/segments/segment.ts
@@ -73,6 +73,41 @@ export class SegmentServ {
     }
   }
 
+  public async import(req: Request, res: Response, next: NextFunction) {
+    try {
+      const now = Date.now();
+      const input = req.body;
+      const operator = res.get('X-Click-Stream-Operator') ?? 'Unknown operator';
+
+      const segment: Segment = {
+        segmentId: uuidv4(),
+        segmentType: input.segmentType,
+        name: input.name,
+        description: input.description ?? '',
+        projectId: input.projectId,
+        appId: input.appId,
+        createBy: operator,
+        createAt: now,
+        lastUpdateBy: operator,
+        lastUpdateAt: now,
+        refreshSchedule: input.refreshSchedule,
+        criteria: input.criteria,
+        eventBridgeRuleArn: '',
+        uiRenderingObject: input.uiRenderingObject ?? {},
+        sql: '',
+        isImported: true,
+      };
+
+      // Save segment setting to DDB
+      const id = await segmentStore.create(segment);
+      logger.info('Create new segment setting, id: ' + id);
+
+      return res.status(201).json(new ApiSuccess({ id }, 'Segment created successfully.'));
+    } catch (error) {
+      return next(error);
+    }
+  }
+
   public async list(req: Request, res: Response, next: NextFunction) {
     try {
       const { appId } = req.query;
@@ -276,6 +311,7 @@ export class SegmentServ {
       criteria: input.criteria,
       eventBridgeRuleArn: '',
       uiRenderingObject: input.uiRenderingObject ?? {},
+      isImported: input.isImported,
     };
   }
 

--- a/src/control-plane/backend/lambda/api/test/api/segments/segments.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/segments/segments.test.ts
@@ -112,6 +112,34 @@ describe('Segments test', () => {
     expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 0);
   });
 
+  test('Import segment', async () => {
+    const input = {
+      segmentType: 'User',
+      name: 'Test_user_segment',
+      description: 'For test',
+      projectId: MOCK_PROJECT_ID,
+      appId: MOCK_APP_ID,
+      refreshSchedule: {
+        cron: 'Manual',
+      },
+      criteria: {
+        operator: 'and',
+        filterGroups: [],
+      },
+    };
+
+    const res = await request(app).post('/api/segments/import').send(input);
+
+    expect(res.statusCode).toBe(201);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.body.success).toEqual(true);
+    expect(res.body.message).toEqual('Segment created successfully.');
+    expect(eventBridgeClientMock).toHaveReceivedCommandTimes(PutRuleCommand, 0);
+    expect(eventBridgeClientMock).toHaveReceivedCommandTimes(PutTargetsCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(QueryCommand, 0);
+    expect(ddbMock).toHaveReceivedCommandTimes(PutCommand, 1);
+  });
+
   test('List segments', async () => {
     ddbMock.on(QueryCommand).resolves({
       Items: [MOCK_USER_SEGMENT_DDB_ITEM],


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Support user imported segment by adding a new page and import api. User can import segment user to database manually later. For simplicity, import segment only supports CREATE and DELETE operations.

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend