### PR TITLE
tests: limit max parallel in ETL test

### DIFF
--- a/src/data-pipeline/spark-etl/build.gradle
+++ b/src/data-pipeline/spark-etl/build.gradle
@@ -89,8 +89,7 @@ tasks.named('test') {
 
 test {
     forkEvery = 1
-    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
-
+    maxParallelForks = Math.min(Runtime.runtime.availableProcessors().intdiv(2) ?: 1, 6)
     maxHeapSize = "4g"
     minHeapSize = "1g"
 }


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

- tested on Instance with 64 vCPU EC2 instance, the build succeed in 8 mins.
- tested on Instance with 16 vCPU EC2 instance, the build succeed in 10 mins.

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend