### PR TITLE
chore: clean KDS after removing ingestion module

### DIFF
--- a/src/ingestion-server/kinesis-data-stream/private/kinesis.ts
+++ b/src/ingestion-server/kinesis-data-stream/private/kinesis.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-import { Duration, Stack, Fn, CfnResource } from 'aws-cdk-lib';
+import { Duration, Stack, Fn, CfnResource, RemovalPolicy } from 'aws-cdk-lib';
 import { StreamMode, Stream, StreamEncryption } from 'aws-cdk-lib/aws-kinesis';
 import { Construct } from 'constructs';
 import { addCfnNagSuppressRules } from '../../../common/cfn-nag';
@@ -34,6 +34,7 @@ export function createKinesisDataStream(scope: Construct, props: KinesisDataStre
       streamMode: StreamMode.ON_DEMAND,
       retentionPeriod: Duration.hours(props.dataRetentionHours),
       encryption: StreamEncryption.MANAGED,
+      removalPolicy: RemovalPolicy.DESTROY,
     });
   } else {
     kinesisDataStream = new Stream(scope, 'kinesisStreamProvisioned', {
@@ -42,6 +43,7 @@ export function createKinesisDataStream(scope: Construct, props: KinesisDataStre
       streamMode: StreamMode.PROVISIONED,
       retentionPeriod: Duration.hours(props.dataRetentionHours),
       encryption: StreamEncryption.MANAGED,
+      removalPolicy: RemovalPolicy.DESTROY,
     });
   }
   addCfnNagSuppressRules(

--- a/test/ingestion-server/server/ingestion-server-stack.test.ts
+++ b/test/ingestion-server/server/ingestion-server-stack.test.ts
@@ -1106,6 +1106,20 @@ test('Each of kinesis nested templates has Kinesis::Stream', () => {
   }
 });
 
+test('Each of kinesis nested templates has AWS::Kinesis::Stream with correct properties', () => {
+  if (kinesisStack.kinesisNestedStacks) {
+    [
+      kinesisStack.kinesisNestedStacks.onDemandStack,
+      kinesisStack.kinesisNestedStacks.provisionedStack,
+    ]
+      .map((s) => Template.fromStack(s))
+      .forEach((t) => {
+        t.hasResource('AWS::Kinesis::Stream', {
+          DeletionPolicy: 'Delete',
+        });
+      });
+  }
+});
 
 test('Lambda has POWERTOOLS ENV set', () => {
   if (kinesisStack.kinesisNestedStacks) {

--- a/test/ingestion-server/server/ingestion-server-v2-stack.test.ts
+++ b/test/ingestion-server/server/ingestion-server-v2-stack.test.ts
@@ -945,6 +945,20 @@ test('Each of kinesis nested templates has Kinesis::Stream', () => {
   }
 });
 
+test('Each of kinesis nested templates has AWS::Kinesis::Stream with correct properties', () => {
+  if (v2Stack.kinesisNestedStacks) {
+    [
+      v2Stack.kinesisNestedStacks.onDemandStack,
+      v2Stack.kinesisNestedStacks.provisionedStack,
+    ]
+      .map((s) => Template.fromStack(s))
+      .forEach((t) => {
+        t.hasResource('AWS::Kinesis::Stream', {
+          DeletionPolicy: 'Delete',
+        });
+      });
+  }
+});
 
 test('Lambda has POWERTOOLS ENV set', () => {
   if (v2Stack.kinesisNestedStacks) {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

clean KDS after removing ingestion module

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [x] deploy ingestion server
    - [ ] with MSK sink
    - [x] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend