### PR TITLE
chore: remove custom kms after stack is deleted

### DIFF
--- a/src/metrics-stack.ts
+++ b/src/metrics-stack.ts
@@ -12,7 +12,7 @@
  */
 
 import { EMAIL_PATTERN, OUTPUT_METRICS_OBSERVABILITY_DASHBOARD_NAME, OUTPUT_METRICS_SNS_TOPIC_ARN_NAME, PROJECT_ID_PATTERN, SolutionInfo } from '@aws/clickstream-base-lib';
-import { Aspects, CfnOutput, CfnParameter, Fn, Stack, StackProps } from 'aws-cdk-lib';
+import { Aspects, CfnOutput, CfnParameter, Fn, Stack, StackProps, RemovalPolicy, Duration } from 'aws-cdk-lib';
 import { PolicyStatement, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { Key } from 'aws-cdk-lib/aws-kms';
 import { Topic } from 'aws-cdk-lib/aws-sns';
@@ -72,6 +72,8 @@ export class MetricsStack extends Stack {
 
     const snsKey = new Key(this, 'snsKey', {
       enableKeyRotation: true,
+      removalPolicy: RemovalPolicy.DESTROY,
+      pendingWindow: Duration.days(7),
     });
 
     snsKey.addToResourcePolicy(new PolicyStatement({

--- a/test/metrics/metrics-stack.test.ts
+++ b/test/metrics/metrics-stack.test.ts
@@ -242,6 +242,11 @@ test('has Key for cloudwatch to Decrypt', () => {
       Version: '2012-10-17',
     },
     EnableKeyRotation: true,
+    PendingWindowInDays: 7,
+  });
+  template.hasResource('AWS::KMS::Key', {
+    DeletionPolicy: 'Delete',
+    UpdateReplacePolicy: 'Delete',
   });
 });
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

remove custom kms after stack is deleted
Deploy metric stack and delete successfully

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend