### PR TITLE
chore: start/stop flink app after enabling/disabling streaming report in analysis studio  

### DIFF
--- a/frontend/public/locales/en-US/common.json
+++ b/frontend/public/locales/en-US/common.json
@@ -219,8 +219,8 @@
     "import": "Import",
     "export": "Export",
     "refreshSegment": "Refresh Segment",
-    "streamEnable": "Streaming Enable",
-    "streamDisable": "Streaming Disable"
+    "streamEnable": "Enable Streaming",
+    "streamDisable": "Disable Streaming"
   },
   "item": "item",
   "items": "items",

--- a/frontend/src/pages/analytics/realtime/AnalyticsRealtime.tsx
+++ b/frontend/src/pages/analytics/realtime/AnalyticsRealtime.tsx
@@ -51,7 +51,7 @@ const AnalyticsRealtime: React.FC = () => {
   );
   const [autoRefreshInterval, setAutoRefreshInterval] = useState(0);
 
-  const getRealtime = async (refresh: boolean) => {
+  const getRealtime = async () => {
     setLoadingFrameData(true);
     try {
       const { success, data }: ApiResponse<any> = await embedRealtimeUrl(
@@ -64,9 +64,6 @@ const AnalyticsRealtime: React.FC = () => {
         setDashboardEmbedUrl(data.EmbedUrl);
       }
     } catch (error) {
-      if (!refresh) {
-        setChecked(!checked);
-      }
       setDashboardEmbedUrl('');
       setLoadingFrameData(false);
     }
@@ -105,7 +102,7 @@ const AnalyticsRealtime: React.FC = () => {
     window.clearInterval(intervalId);
     if (autoRefreshInterval > 0) {
       intervalId = setInterval(() => {
-        getRealtime(true);
+        getRealtime();
       }, autoRefreshInterval);
     }
   };
@@ -128,7 +125,7 @@ const AnalyticsRealtime: React.FC = () => {
       setDashboardEmbedUrl('');
     }
     if (projectId && appId && enableStreamModule) {
-      getRealtime(false);
+      getRealtime();
     }
   }, [checked]);
 
@@ -199,7 +196,7 @@ const AnalyticsRealtime: React.FC = () => {
                             iconName="refresh"
                             variant="icon"
                             disabled={!checked}
-                            onClick={() => getRealtime(true)}
+                            onClick={() => getRealtime()}
                           />
                           <ButtonDropdown
                             disabled={!checked}

--- a/frontend/src/pages/pipelines/detail/comps/Ingestion.tsx
+++ b/frontend/src/pages/pipelines/detail/comps/Ingestion.tsx
@@ -92,7 +92,9 @@ const Ingestion: React.FC<TabContentProps> = (props: TabContentProps) => {
   };
 
   const isStreamingEnable = () => {
-    return pipelineInfo?.enableStreaming || pipelineInfo?.streaming?.appIdStreamList;
+    return (
+      pipelineInfo?.enableStreaming || pipelineInfo?.streaming?.appIdStreamList
+    );
   };
 
   return (
@@ -367,7 +369,7 @@ const Ingestion: React.FC<TabContentProps> = (props: TabContentProps) => {
                   <StatusIndicator type="success">
                     {t('enabled')}
                   </StatusIndicator>
-                  <br/>
+                  <br />
                   {pipelineInfo?.streaming?.appIdStreamList &&
                   pipelineInfo.streamApplication
                     ? pipelineInfo.streamApplication

--- a/frontend/src/pages/pipelines/detail/comps/Ingestion.tsx
+++ b/frontend/src/pages/pipelines/detail/comps/Ingestion.tsx
@@ -16,6 +16,7 @@ import {
   ColumnLayout,
   SpaceBetween,
   Link,
+  StatusIndicator,
 } from '@cloudscape-design/components';
 import InfoTitle from 'components/common/title/InfoTitle';
 import DomainNameWithStatus from 'pages/common/DomainNameWithStatus';
@@ -88,6 +89,10 @@ const Ingestion: React.FC<TabContentProps> = (props: TabContentProps) => {
     }
 
     return '-';
+  };
+
+  const isStreamingEnable = () => {
+    return pipelineInfo?.enableStreaming || pipelineInfo?.streaming?.appIdStreamList;
   };
 
   return (
@@ -356,9 +361,24 @@ const Ingestion: React.FC<TabContentProps> = (props: TabContentProps) => {
             {t('pipeline:detail.streamingApplication')}
           </Box>
           <div>
-            {pipelineInfo?.streaming?.appIdStreamList
-              ? pipelineInfo.streamApplication
-              : t('no')}
+            <div>
+              {isStreamingEnable() ? (
+                <div>
+                  <StatusIndicator type="success">
+                    {t('enabled')}
+                  </StatusIndicator>
+                  <br/>
+                  {pipelineInfo?.streaming?.appIdStreamList &&
+                  pipelineInfo.streamApplication
+                    ? pipelineInfo.streamApplication
+                    : '-'}
+                </div>
+              ) : (
+                <StatusIndicator type="stopped">
+                  {t('disabled')}
+                </StatusIndicator>
+              )}
+            </div>
           </div>
         </div>
       </SpaceBetween>

--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -682,6 +682,19 @@ function getStackOutputFromPipelineStatus(stackDetails: PipelineStatusDetail[] |
   return '';
 }
 
+function getStreamEnableAppIdsFromPipeline(oldAppIdList: string[], appId: string, enable: boolean) {
+  const streamEnableAppIds = cloneDeep(oldAppIdList);
+  if (enable && !streamEnableAppIds.includes(appId)) {
+    streamEnableAppIds.push(appId);
+  } else if (!enable && streamEnableAppIds.includes(appId)) {
+    const index = streamEnableAppIds.indexOf(appId);
+    if (index > -1) {
+      streamEnableAppIds.splice(index, 1);
+    }
+  }
+  return streamEnableAppIds;
+}
+
 function getVersionFromTags(tags: Tag[] | undefined) {
   let version = '';
   if (!tags) {
@@ -1566,4 +1579,5 @@ export {
   getAppRegistryStackTags,
   readMetadataFromSqlFile,
   getTemplateUrl,
+  getStreamEnableAppIdsFromPipeline,
 };

--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -79,6 +79,7 @@ import {
   getStackPrefix,
   getStackTags,
   getStateMachineExecutionName,
+  getStreamEnableAppIdsFromPipeline,
   getTemplateUrl,
   getUpdateTags,
   isEmpty,
@@ -1051,17 +1052,11 @@ export class CPipeline {
       throw new ClickStreamBadRequestError('Streaming not enabled.');
     }
     // Save pipeline status
-    const appIdRealtimeList = this.pipeline.streaming?.appIdRealtimeList ?? [];
-    if (enable && !appIdRealtimeList.includes(appId)) {
-      if (!this.pipeline.streaming.appIdStreamList.includes(appId)) {
-        throw new ClickStreamBadRequestError('AppId not found in stream list.');
-      }
-      appIdRealtimeList.push(appId);
-    }
-    if (!enable && appIdRealtimeList.includes(appId)) {
-      const index = appIdRealtimeList.indexOf(appId);
-      appIdRealtimeList.splice(index, 1);
-    }
+    const appIdRealtimeList = getStreamEnableAppIdsFromPipeline(
+      this.pipeline.streaming?.appIdRealtimeList ?? [],
+      appId,
+      enable,
+    );
     this.pipeline.streaming = {
       ...this.pipeline.streaming,
       appIdRealtimeList,

--- a/src/control-plane/backend/lambda/api/test/api/application.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/application.test.ts
@@ -1331,8 +1331,8 @@ describe('Application test', () => {
       success: true,
       message: 'Application streaming updated.',
     });
-    expect(mockClients.kinesisAnalyticsV2Mock).toHaveReceivedCommandTimes(DescribeApplicationCommand, 1);
-    expect(mockClients.kinesisAnalyticsV2Mock).toHaveReceivedCommandTimes(UpdateApplicationCommand, 1);
+    expect(mockClients.kinesisAnalyticsV2Mock).toHaveReceivedCommandTimes(DescribeApplicationCommand, 0);
+    expect(mockClients.kinesisAnalyticsV2Mock).toHaveReceivedCommandTimes(UpdateApplicationCommand, 0);
   });
   afterAll((done) => {
     server.close();


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend