### PR TITLE
fix: create built-in user base on Quicksight auth type

### DIFF
--- a/frontend/public/locales/en-US/pipeline.json
+++ b/frontend/public/locales/en-US/pipeline.json
@@ -228,7 +228,7 @@
     "quickSightNotEnterprise": "QuickSight edition is not enterprise in your account",
     "quickSightNotEnterpriseDesc": "The solution dashboard need the QuickSight Enterprise, you can upgrade edition in QuickSight Management Console.",
     "quickSightSubscription": "Subscription",
-    "quickSIghtPlaceholder": "Select a quicksight user",
+    "quickSightPlaceholder": "Select a quicksight user",
     "quickSightUser": "QuickSight user",
     "quickSightUserDesc": "Select a QuickSight user for the solution to create datasets and analyses.",
     "ingestSettings": "Ingestion setting",

--- a/frontend/public/locales/zh-CN/pipeline.json
+++ b/frontend/public/locales/zh-CN/pipeline.json
@@ -228,7 +228,7 @@
     "quickSightNotEnterprise": "您的账户中的 QuickSight 版本不是企业版",
     "quickSightNotEnterpriseDesc": "解决方案控制面板需要 QuickSight Enterprise，你可以在 QuickSight 管理控制台中升级版本。",
     "quickSightSubscription": "订阅",
-    "quickSIghtPlaceholder": "选择 quicksight 用户",
+    "quickSightPlaceholder": "选择 quicksight 用户",
     "quickSightUser": "QuickSight 用户",
     "quickSightUserDesc": "为解决方案选择一个QuickSight管理员用户以创建数据集和分析。",
     "ingestSettings": "摄取设置",

--- a/frontend/src/pages/pipelines/create/steps/Reporting.tsx
+++ b/frontend/src/pages/pipelines/create/steps/Reporting.tsx
@@ -259,7 +259,7 @@ const Reporting: React.FC<ReportingProps> = (props: ReportingProps) => {
                                   'finished'
                                 )}
                                 placeholder={defaultStr(
-                                  t('pipeline:create.quickSIghtPlaceholder')
+                                  t('pipeline:create.quickSightPlaceholder')
                                 )}
                                 selectedOption={
                                   pipelineInfo.selectedQuickSightUser

--- a/frontend/src/pages/pipelines/create/steps/Reporting.tsx
+++ b/frontend/src/pages/pipelines/create/steps/Reporting.tsx
@@ -68,6 +68,7 @@ const Reporting: React.FC<ReportingProps> = (props: ReportingProps) => {
   const [loadingQuickSight, setLoadingQuickSight] = useState(false);
   const [quickSightEnabled, setQuickSightEnabled] = useState(false);
   const [quickSightEnterprise, setQuickSightEnterprise] = useState(false);
+  const [authenticationType, setAuthenticationType] = useState('');
   const [quickSightUserOptions, setQuickSightUserOptions] =
     useState<SelectProps.Options>([]);
 
@@ -84,10 +85,12 @@ const Reporting: React.FC<ReportingProps> = (props: ReportingProps) => {
       ) {
         setQuickSightEnabled(true);
         changeQuickSightDisabled(false);
+        setAuthenticationType(data.authenticationType);
         changeQuickSightAccountName(data.accountName);
       } else {
         changeEnableReporting(false);
         setQuickSightEnabled(false);
+        setAuthenticationType('');
         changeQuickSightDisabled(true);
       }
       if (success && data && data.edition.includes('ENTERPRISE')) {
@@ -95,6 +98,7 @@ const Reporting: React.FC<ReportingProps> = (props: ReportingProps) => {
       }
     } catch (error) {
       setLoadingQuickSight(false);
+      setAuthenticationType('');
     }
   };
 
@@ -163,136 +167,127 @@ const Reporting: React.FC<ReportingProps> = (props: ReportingProps) => {
           {loadingQuickSight ? (
             <Spinner />
           ) : (
-            <>
-              <SpaceBetween direction="vertical" size="l">
-                <FormField>
-                  <Toggle
-                    controlId="test-quicksight-id"
-                    disabled={isReportingDisabled(update, pipelineInfo)}
-                    onChange={({ detail }) =>
-                      changeEnableReporting(detail.checked)
-                    }
-                    checked={pipelineInfo.enableReporting}
-                    description={
-                      <div>
-                        <Trans
-                          i18nKey="pipeline:create.createSampleQuickSightDesc"
-                          components={{
-                            learnmore_anchor: (
-                              <Link
-                                external
-                                href={buildDocumentLink(
-                                  i18n.language,
-                                  PIPELINE_QUICKSIGHT_LEARNMORE_LINK_EN,
-                                  PIPELINE_QUICKSIGHT_LEARNMORE_LINK_CN
-                                )}
-                              />
-                            ),
-                            guide_anchor: (
-                              <Link
-                                external
-                                href={buildDocumentLink(
-                                  i18n.language,
-                                  PIPELINE_QUICKSIGHT_GUIDE_LINK_EN,
-                                  PIPELINE_QUICKSIGHT_GUIDE_LINK_CN
-                                )}
-                              />
-                            ),
-                          }}
-                        />
-                      </div>
-                    }
-                  >
-                    <b>{t('pipeline:create.createSampleQuickSight')}</b>
-                  </Toggle>
-                </FormField>
-
-                {pipelineInfo.enableReporting &&
-                  (loadingQuickSight ? (
-                    <Spinner />
-                  ) : (
-                    <>
-                      {!quickSightEnabled && (
-                        <Alert
-                          type="warning"
-                          header={t('pipeline:create.quickSightNotSub')}
-                        >
-                          {t('pipeline:create.quickSightNotSubDesc1')}
-                          <Link
-                            external
-                            href={buildQuickSightSubscriptionLink()}
-                          >
-                            {t('pipeline:create.quickSightSubscription')}
-                          </Link>
-                          {t('pipeline:create.quickSightNotSubDesc2')}
-                        </Alert>
-                      )}
-
-                      {quickSightEnabled && !quickSightEnterprise && (
-                        <Alert
-                          type="warning"
-                          header={t('pipeline:create.quickSightNotEnterprise')}
-                        >
-                          {t('pipeline:create.quickSightNotEnterpriseDesc')}
-                        </Alert>
-                      )}
-
-                      {pipelineInfo.region.startsWith('cn') &&
-                        pipelineInfo.enableReporting &&
-                        quickSightEnabled &&
-                        quickSightEnterprise && (
-                          <>
-                            <FormField
-                              label={t('pipeline:create.quickSightUser')}
-                              description={t(
-                                'pipeline:create.quickSightUserDesc'
+            <SpaceBetween direction="vertical" size="l">
+              <FormField>
+                <Toggle
+                  controlId="test-quicksight-id"
+                  disabled={isReportingDisabled(update, pipelineInfo)}
+                  onChange={({ detail }) =>
+                    changeEnableReporting(detail.checked)
+                  }
+                  checked={pipelineInfo.enableReporting}
+                  description={
+                    <div>
+                      <Trans
+                        i18nKey="pipeline:create.createSampleQuickSightDesc"
+                        components={{
+                          learnmore_anchor: (
+                            <Link
+                              external
+                              href={buildDocumentLink(
+                                i18n.language,
+                                PIPELINE_QUICKSIGHT_LEARNMORE_LINK_EN,
+                                PIPELINE_QUICKSIGHT_LEARNMORE_LINK_CN
                               )}
-                              errorText={ternary(
-                                quickSightUserEmptyError,
-                                t('pipeline:valid.quickSightUserEmptyError'),
-                                ''
+                            />
+                          ),
+                          guide_anchor: (
+                            <Link
+                              external
+                              href={buildDocumentLink(
+                                i18n.language,
+                                PIPELINE_QUICKSIGHT_GUIDE_LINK_EN,
+                                PIPELINE_QUICKSIGHT_GUIDE_LINK_CN
                               )}
-                            >
-                              <div className="flex">
-                                <div className="flex-1">
-                                  <Select
-                                    statusType={ternary(
-                                      loadingUsers,
-                                      'loading',
-                                      'finished'
-                                    )}
-                                    placeholder={defaultStr(
-                                      t('pipeline:create.quickSIghtPlaceholder')
-                                    )}
-                                    selectedOption={
-                                      pipelineInfo.selectedQuickSightUser
-                                    }
-                                    onChange={({ detail }) =>
-                                      changeQuickSightSelectedUser(
-                                        detail.selectedOption
-                                      )
-                                    }
-                                    options={quickSightUserOptions}
-                                    filteringType="auto"
-                                  />
-                                </div>
-                                <div className="ml-10">
-                                  <Button
-                                    loading={loadingUsers}
-                                    onClick={() => {
-                                      getQuickSightUserList();
-                                    }}
-                                    iconName="refresh"
-                                  />
-                                </div>
-                              </div>
-                            </FormField>
-                          </>
-                        )}
-                    </>
-                  ))}
-              </SpaceBetween>
-            </>
+                            />
+                          ),
+                        }}
+                      />
+                    </div>
+                  }
+                >
+                  <b>{t('pipeline:create.createSampleQuickSight')}</b>
+                </Toggle>
+              </FormField>
+
+              {pipelineInfo.enableReporting &&
+                (loadingQuickSight ? (
+                  <Spinner />
+                ) : (
+                  <>
+                    {!quickSightEnabled && (
+                      <Alert
+                        type="warning"
+                        header={t('pipeline:create.quickSightNotSub')}
+                      >
+                        {t('pipeline:create.quickSightNotSubDesc1')}
+                        <Link external href={buildQuickSightSubscriptionLink()}>
+                          {t('pipeline:create.quickSightSubscription')}
+                        </Link>
+                        {t('pipeline:create.quickSightNotSubDesc2')}
+                      </Alert>
+                    )}
+
+                    {quickSightEnabled && !quickSightEnterprise && (
+                      <Alert
+                        type="warning"
+                        header={t('pipeline:create.quickSightNotEnterprise')}
+                      >
+                        {t('pipeline:create.quickSightNotEnterpriseDesc')}
+                      </Alert>
+                    )}
+
+                    {authenticationType !== 'IDENTITY_POOL' &&
+                      pipelineInfo.enableReporting &&
+                      quickSightEnabled &&
+                      quickSightEnterprise && (
+                        <FormField
+                          label={t('pipeline:create.quickSightUser')}
+                          description={t('pipeline:create.quickSightUserDesc')}
+                          errorText={ternary(
+                            quickSightUserEmptyError,
+                            t('pipeline:valid.quickSightUserEmptyError'),
+                            ''
+                          )}
+                        >
+                          <div className="flex">
+                            <div className="flex-1">
+                              <Select
+                                statusType={ternary(
+                                  loadingUsers,
+                                  'loading',
+                                  'finished'
+                                )}
+                                placeholder={defaultStr(
+                                  t('pipeline:create.quickSIghtPlaceholder')
+                                )}
+                                selectedOption={
+                                  pipelineInfo.selectedQuickSightUser
+                                }
+                                onChange={({ detail }) =>
+                                  changeQuickSightSelectedUser(
+                                    detail.selectedOption
+                                  )
+                                }
+                                options={quickSightUserOptions}
+                                filteringType="auto"
+                              />
+                            </div>
+                            <div className="ml-10">
+                              <Button
+                                loading={loadingUsers}
+                                onClick={() => {
+                                  getQuickSightUserList();
+                                }}
+                                iconName="refresh"
+                              />
+                            </div>
+                          </div>
+                        </FormField>
+                      )}
+                  </>
+                ))}
+            </SpaceBetween>
           )}
         </>
       ) : (

--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -92,7 +92,7 @@ import { createRuleAndAddTargets } from '../store/aws/events';
 import { listMSKClusterBrokers } from '../store/aws/kafka';
 
 import { getKeyArnByAlias } from '../store/aws/kms';
-import { QuickSightUserArns, getClickstreamUserArn, registerClickstreamUser } from '../store/aws/quicksight';
+import { QuickSightUserArns, getClickstreamUserArn, listUsers, registerClickstreamUser } from '../store/aws/quicksight';
 import { getRedshiftInfo } from '../store/aws/redshift';
 import { isBucketExist } from '../store/aws/s3';
 import { getExecutionDetail, listExecutions } from '../store/aws/sfn';
@@ -786,6 +786,14 @@ export class CPipeline {
     }
 
     if (this.pipeline.reporting) {
+      if (this.pipeline.reporting.quickSight?.user) {
+        const qsUsers = await listUsers();
+        const qsUserArns = qsUsers?.map(u => u.Arn);
+        // check if the user not exists
+        if (!qsUserArns?.includes(this.pipeline.reporting.quickSight?.user)) {
+          throw new ClickStreamBadRequestError(`Validation error: QuickSight user ${this.pipeline.reporting.quickSight?.user} not found. Please check and try again.`);
+        }
+      }
       await registerClickstreamUser();
       const quickSightUser = await getClickstreamUserArn(
         SolutionVersion.Of(this.pipeline.templateVersion ?? FULL_SOLUTION_VERSION),

--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -789,7 +789,7 @@ export class CPipeline {
       await registerClickstreamUser();
       const quickSightUser = await getClickstreamUserArn(
         SolutionVersion.Of(this.pipeline.templateVersion ?? FULL_SOLUTION_VERSION),
-        this.pipeline.reporting.quickSight?.user ?? '',
+        this.pipeline.reporting.quickSight?.user,
       );
       this.resources = {
         ...this.resources,

--- a/src/control-plane/backend/lambda/api/service/project.ts
+++ b/src/control-plane/backend/lambda/api/service/project.ts
@@ -228,7 +228,7 @@ export class ProjectServ {
       }
       const principals = await getClickstreamUserArn(
         SolutionVersion.Of(pipeline.templateVersion ?? FULL_SOLUTION_VERSION),
-        pipeline.reporting?.quickSight?.user ?? '',
+        pipeline.reporting?.quickSight?.user,
       );
       const embed = await generateEmbedUrlForRegisteredUser(
         pipeline.region,
@@ -310,7 +310,7 @@ export class ProjectServ {
       }
       const principals = await getClickstreamUserArn(
         SolutionVersion.Of(pipeline.templateVersion ?? FULL_SOLUTION_VERSION),
-        pipeline.reporting?.quickSight?.user ?? '',
+        pipeline.reporting?.quickSight?.user,
       );
       const embed = await generateEmbedUrlForRegisteredUser(
         pipeline.region,

--- a/src/control-plane/backend/lambda/api/service/reporting.ts
+++ b/src/control-plane/backend/lambda/api/service/reporting.ts
@@ -1041,7 +1041,7 @@ export class ReportingService {
     const quickSight = sdkClient.QuickSight({ region: dashboardCreateParameters.region });
     const principals = await getClickstreamUserArn(
       SolutionVersion.Of(pipeline?.templateVersion ?? FULL_SOLUTION_VERSION),
-      pipeline?.reporting?.quickSight?.user ?? '',
+      pipeline?.reporting?.quickSight?.user,
     );
 
     //create quicksight dataset
@@ -1263,7 +1263,7 @@ export class ReportingService {
       //warmup principal
       await getClickstreamUserArn(
         SolutionVersion.Of(latestPipeline.templateVersion ?? FULL_SOLUTION_VERSION),
-        latestPipeline.reporting?.quickSight?.user ?? '',
+        latestPipeline.reporting?.quickSight?.user,
       );
 
       //warm up redshift serverless

--- a/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
@@ -269,15 +269,14 @@ export interface QuickSightUserArns {
   exploreUserName: string;
 }
 
-export const getClickstreamUserArn = async (templateVersion: SolutionVersion, userArn: string): Promise<QuickSightUserArns> => {
+export const getClickstreamUserArn = async (templateVersion: SolutionVersion, userArn: string | undefined): Promise<QuickSightUserArns> => {
   const identityRegion = await sdkClient.QuickSightIdentityRegion();
   const isChinaRegion = process.env.AWS_REGION?.startsWith('cn');
   const quickSightEmbedRoleName = QuickSightEmbedRoleArn?.split(':role/')[1];
   const partition = isChinaRegion ? 'aws-cn' : 'aws';
-  const publishUserName = isChinaRegion ? userArn?.split('/').pop() :
+  const publishUserName = userArn ? userArn.split('/').pop() :
     `${quickSightEmbedRoleName}/${QUICKSIGHT_PUBLISH_USER_NAME}`;
-  const publishUserArn = isChinaRegion ? userArn :
-    `arn:${partition}:quicksight:${identityRegion}:${awsAccountId}:user/${QUICKSIGHT_NAMESPACE}/${publishUserName}`;
+  const publishUserArn = userArn ?? `arn:${partition}:quicksight:${identityRegion}:${awsAccountId}:user/${QUICKSIGHT_NAMESPACE}/${publishUserName}`;
 
   if (templateVersion.greaterThan(SolutionVersion.V_1_1_4)) {
     // remove explore user
@@ -289,10 +288,9 @@ export const getClickstreamUserArn = async (templateVersion: SolutionVersion, us
     };
   }
 
-  const exploreUserName = isChinaRegion ? userArn?.split('/').pop() :
+  const exploreUserName = userArn ? userArn.split('/').pop() :
     `${quickSightEmbedRoleName}/${QUICKSIGHT_EXPLORE_USER_NAME}`;
-  const exploreUserArn = isChinaRegion ? userArn :
-    `arn:${partition}:quicksight:${identityRegion}:${awsAccountId}:user/${QUICKSIGHT_NAMESPACE}/${exploreUserName}`;
+  const exploreUserArn = userArn ?? `arn:${partition}:quicksight:${identityRegion}:${awsAccountId}:user/${QUICKSIGHT_NAMESPACE}/${exploreUserName}`;
   return {
     publishUserArn: publishUserArn ?? '',
     publishUserName: publishUserName ?? '',

--- a/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
@@ -43,7 +43,8 @@ const promisePool = pLimit(3);
 
 export const registerClickstreamUser = async () => {
   try {
-    if (awsRegion.startsWith('cn')) {
+    const accountSubscription = await describeClickstreamAccountSubscription();
+    if (accountSubscription?.authenticationType !== 'IDENTITY_POOL') {
       return;
     }
     const identityRegion = await sdkClient.QuickSightIdentityRegion();

--- a/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/ddb-mock.ts
@@ -25,7 +25,7 @@ import {
 import { PolicyEvaluationDecisionType, SimulateCustomPolicyCommand } from '@aws-sdk/client-iam';
 import { ListNodesCommand } from '@aws-sdk/client-kafka';
 import { ListAliasesCommand } from '@aws-sdk/client-kms';
-import { DescribeAccountSubscriptionCommand, Edition, RegisterUserCommand, ResourceExistsException } from '@aws-sdk/client-quicksight';
+import { DescribeAccountSubscriptionCommand, Edition, ListUsersCommand, RegisterUserCommand, ResourceExistsException } from '@aws-sdk/client-quicksight';
 import { DescribeClustersCommand, DescribeClusterSubnetGroupsCommand } from '@aws-sdk/client-redshift';
 import { GetNamespaceCommand, GetWorkgroupCommand } from '@aws-sdk/client-redshift-serverless';
 import { BucketLocationConstraint, GetBucketLocationCommand, GetBucketPolicyCommand } from '@aws-sdk/client-s3';
@@ -967,6 +967,19 @@ function mockQuickSight(quickSightMock: any, standard?: boolean, userExisted?: b
       AccountName: 'ck',
       Edition: standard ? Edition.STANDARD : Edition.ENTERPRISE,
     },
+  });
+  quickSightMock.on(ListUsersCommand).resolves({
+    UserList: [
+      {
+        Arn: 'arn:aws:quicksight:us-east-1:555555555555:user/default/QuickSightEmbeddingRole/GCRUser',
+      },
+      {
+        Arn: 'arn:aws-cn:quicksight:cn-north-1:555555555555:user/default/GCRUser',
+      },
+      {
+        Arn: 'arn:aws:quicksight:us-east-1:123456789012:user/clickstream-acc-xxx/clickstream-user-xxx',
+      },
+    ],
   });
   if (userExisted) {
     quickSightMock.on(RegisterUserCommand).rejects(

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -4374,7 +4374,7 @@ describe('Pipeline test', () => {
       success: true,
       message: 'Pipeline upgraded.',
     });
-    expect(quickSightMock).toHaveReceivedCommandTimes(DescribeAccountSubscriptionCommand, 0);
+    expect(quickSightMock).toHaveReceivedCommandTimes(DescribeAccountSubscriptionCommand, 1);
   });
   it('Upgrade pipeline without some app timezone', async () => {
     tokenMock(ddbMock, false);

--- a/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
@@ -1728,6 +1728,170 @@ describe('Workflow test', () => {
     };
     expect(wf).toEqual(expected);
   });
+  it('Generate Workflow with specify reporting user', async () => {
+    dictionaryMock(ddbMock);
+    createPipelineMock(mockClients, {
+      publicAZContainPrivateAZ: true,
+      noVpcEndpoint: true,
+    });
+    const pipeline: CPipeline = new CPipeline({
+      ...cloneDeep(KINESIS_DATA_PROCESSING_PROVISIONED_REDSHIFT_QUICKSIGHT_PIPELINE),
+      templateVersion: FULL_SOLUTION_VERSION,
+      reporting: {
+        quickSight: {
+          accountName: 'clickstream-acc-xxx',
+          user: 'arn:aws:quicksight:us-east-1:123456789012:user/clickstream-acc-xxx/clickstream-user-xxx',
+        },
+      },
+    });
+    await pipeline.resourcesCheck();
+    const wf = await generateWorkflow(pipeline.getPipeline(), pipeline.getResources()!);
+    const expected = {
+      Version: '2022-03-15',
+      Workflow: {
+        Branches: [
+          {
+            StartAt: 'ServiceCatalogAppRegistry',
+            States: {
+              ServiceCatalogAppRegistry: ServiceCatalogAppRegistryStack as WorkflowState,
+              [LEVEL1]: {
+                Branches: [
+                  {
+                    StartAt: 'Metrics',
+                    States: {
+                      Metrics: replaceStackInputProps(MetricsStack,
+                        {
+                          Parameters: [
+                            ...BASE_METRICS_EMAILS_PARAMETERS,
+                            APPREGISTRY_APPLICATION_ARN_PARAMETER,
+                          ],
+                          Tags: Tags,
+                        },
+                      ),
+                    },
+                  },
+                  {
+                    StartAt: 'Ingestion',
+                    States: {
+                      Ingestion: replaceStackInputProps(IngestionStack,
+                        {
+                          StackName: `${getStackPrefix()}-Ingestion-kinesis-6666-6666`,
+                          Parameters: [
+                            ...INGESTION_KINESIS_ON_DEMAND_PARAMETERS,
+                            APPREGISTRY_APPLICATION_ARN_PARAMETER,
+                          ],
+                          Tags: Tags,
+                          TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/v1.0.0/default/ingestion-server-kinesis-stack.template.json',
+                        },
+                      ),
+                    },
+                  },
+                  {
+                    StartAt: 'DataProcessing',
+                    States: {
+                      DataProcessing: replaceStackInputProps(DataProcessingStack,
+                        {
+                          Parameters: [
+                            ...DATA_PROCESSING_PLUGIN3_PARAMETERS,
+                            APPREGISTRY_APPLICATION_ARN_PARAMETER,
+                          ],
+                          Tags: Tags,
+                          TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/v1.0.0/default/data-pipeline-stack.template.json',
+                        },
+                      ),
+                    },
+                  },
+                ],
+                Next: LEVEL2,
+                Type: WorkflowStateType.PARALLEL,
+              },
+              [LEVEL2]: {
+                Branches: [
+                  {
+                    StartAt: 'DataModelingAthena',
+                    States: {
+                      DataModelingAthena: replaceStackInputProps(DataModelingAthenaStack,
+                        {
+                          StackName: `${getStackPrefix()}-DataModelingAthena-6666-6666`,
+                          Parameters: [
+                            ...BASE_ATHENA_PARAMETERS,
+                            APPREGISTRY_APPLICATION_ARN_PARAMETER,
+                          ],
+                          Tags: Tags,
+                          TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/v1.0.0/default/data-modeling-athena-stack.template.json',
+                        },
+                      ),
+                    },
+                  },
+                  {
+                    StartAt: 'DataModelingRedshift',
+                    States: {
+                      DataModelingRedshift: replaceStackInputProps(DataModelingRedshiftStack,
+                        {
+                          StackName: `${getStackPrefix()}-DataModelingRedshift-6666-6666`,
+                          Parameters: [
+                            ...MSK_DATA_PROCESSING_PROVISIONED_REDSHIFT_DATAANALYTICS_PARAMETERS,
+                            APPREGISTRY_APPLICATION_ARN_PARAMETER,
+                          ],
+                          Tags: Tags,
+                          TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/v1.0.0/default/data-analytics-redshift-stack.template.json',
+                        },
+                      ),
+                    },
+                  },
+                ],
+                Next: LEVEL3,
+                Type: WorkflowStateType.PARALLEL,
+              },
+              [LEVEL3]: {
+                Branches: [
+                  {
+                    StartAt: 'Reporting',
+                    States: {
+                      Reporting: replaceStackInputProps(ReportingStack,
+                        {
+                          StackName: `${getStackPrefix()}-Reporting-6666-6666`,
+                          Parameters: mergeParameters(
+                            removeParameters(
+                              [
+                                ...REPORTING_WITH_PROVISIONED_REDSHIFT_PARAMETERS,
+                                APPREGISTRY_APPLICATION_ARN_PARAMETER,
+                              ],
+                              [
+                                {
+                                  ParameterKey: 'QuickSightPrincipalParam',
+                                },
+                              ]),
+                            [
+                              {
+                                ParameterKey: 'QuickSightUserParam',
+                                ParameterValue: 'clickstream-user-xxx',
+                              },
+                              {
+                                ParameterKey: 'QuickSightOwnerPrincipalParam',
+                                ParameterValue: 'arn:aws:quicksight:us-east-1:123456789012:user/clickstream-acc-xxx/clickstream-user-xxx',
+                              },
+                            ],
+                          ),
+                          Tags: Tags,
+                          TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/v1.0.0/default/data-reporting-quicksight-stack.template.json',
+                        },
+                      ),
+                    },
+                  },
+                ],
+                End: true,
+                Type: WorkflowStateType.PARALLEL,
+              },
+            },
+          },
+        ],
+        End: true,
+        Type: WorkflowStateType.PARALLEL,
+      },
+    };
+    expect(wf).toEqual(expected);
+  });
   it('Generate Workflow ingestion-server-kinesis ON_DEMAND + DataProcessing + provisioned redshift + quicksight', async () => {
     dictionaryMock(ddbMock);
     createPipelineMock(mockClients, {

--- a/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
@@ -1781,7 +1781,7 @@ describe('Workflow test', () => {
                             APPREGISTRY_APPLICATION_ARN_PARAMETER,
                           ],
                           Tags: Tags,
-                          TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/v1.0.0/default/ingestion-server-kinesis-stack.template.json',
+                          TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/v1.0.0/default/ingestion-server-v2-stack.template.json',
                         },
                       ),
                     },


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend