### PR TITLE
fix: ingestion NotificationsTopicArn parameter

### DIFF
--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -281,7 +281,11 @@ export class CIngestionServerStack extends JSONObject {
 
   @JSONObject.optional('')
   @JSONObject.custom( (stack:CIngestionServerStack, _key:string, _value:string) => {
-    return stack._pipeline?.ingestionServer.loadBalancer.notificationsTopicArn ?? '';
+    const notificationsTopicArn = stack._pipeline?.ingestionServer.loadBalancer.notificationsTopicArn;
+    if (isEmpty(notificationsTopicArn)) {
+      return undefined;
+    }
+    return notificationsTopicArn;
   })
     NotificationsTopicArn?: string;
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend