### PR TITLE
fix: segment jobs got stuck when multiple jobs were submitted

### DIFF
--- a/frontend/src/pages/analytics/segments/UserSegmentDetails.tsx
+++ b/frontend/src/pages/analytics/segments/UserSegmentDetails.tsx
@@ -17,6 +17,7 @@ import {
   SegmentJobStatus,
   SegmentJobStatusItem,
   SegmentUserItem,
+  sleep,
 } from '@aws/clickstream-base-lib';
 import {
   AppLayout,
@@ -77,7 +78,7 @@ const UserSegmentDetails: React.FC = () => {
       href: `/analytics/${projectId}/app/${appId}/segments`,
     },
     {
-      text: segmentId,
+      text: defaultStr(segment?.name),
       href: `/analytics/${projectId}/app/${appId}/segments/${segmentId}`,
     },
   ];
@@ -335,6 +336,9 @@ const UserSegmentDetails: React.FC = () => {
                                         segmentId,
                                         appId,
                                       });
+
+                                      // Wait a few second for the segment job being recorded in ddb by the segment job sfn
+                                      await sleep(3000);
                                       await getSegmentJobHistory();
                                     } catch (error) {
                                       console.error(

--- a/frontend/src/pages/analytics/segments/components/SegmentEditor.tsx
+++ b/frontend/src/pages/analytics/segments/components/SegmentEditor.tsx
@@ -87,12 +87,7 @@ const SegmentEditor: React.FC<SegmentEditorProps> = (
 
   useEffect(() => {
     const cron = segmentObject.refreshSchedule.cron;
-    if (
-      cron === 'Manual' ||
-      cron === 'Custom' ||
-      !autoRefreshDay ||
-      !autoRefreshTime
-    ) {
+    if (cron === 'Manual' || cron === 'Custom' || !autoRefreshTime) {
       return;
     }
 

--- a/src/analytics/private/segments/user-segments-workflow.ts
+++ b/src/analytics/private/segments/user-segments-workflow.ts
@@ -90,14 +90,18 @@ export class UserSegmentsWorkflow extends Construct {
     props.clickstreamMetadataDdbTable.grantReadWriteData(segmentJobInitFunc);
 
     // Define task for checking state machine status
-    const stateMachineStatusFunc = this.constructNodejsFunction('state-machine-status', [], {
+    const stateMachineStatusFunc = this.constructNodejsFunction('state-machine-status', [
+      new PolicyStatement({
+        actions: ['dynamodb:Query'],
+        resources: [`${props.clickstreamMetadataDdbTable.tableArn}/index/prefix-time-index`],
+      }),
+    ], {
       CLICKSTREAM_METADATA_DDB_ARN: props.clickstreamMetadataDdbTable.tableArn,
     });
     const stateMachineStatusTask = new LambdaInvoke(this, 'WorkflowTask-StateMachineStatus', {
       lambdaFunction: stateMachineStatusFunc,
       outputPath: '$.Payload',
     });
-    props.clickstreamMetadataDdbTable.grantReadData(stateMachineStatusFunc);
 
     // Define task for segment query execution
     const executeSegmentQueryFunc = this.constructNodejsFunction('execute-segment-query', [], {

--- a/test/analytics/analytics-on-redshift/lambda/user-segments-workflow/state-machine-status.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/user-segments-workflow/state-machine-status.test.ts
@@ -33,13 +33,10 @@ describe('User segments workflow segment-job-status lambda tests', () => {
 
   beforeEach(() => {
     event = {
-      input: {
-        appId: 'app-id',
-        segmentId: 'segment-id',
-        jobRunId: 'job-run-id',
-        scheduleIsExpired: false,
-      },
-      stateMachineArn: 'arn:aws:states:us-east-1:111122223333:workflow/abc',
+      appId: 'app-id',
+      segmentId: 'segment-id',
+      jobRunId: 'job-run-id',
+      scheduleIsExpired: false,
     };
   });
 

--- a/test/analytics/analytics-on-redshift/lambda/user-segments-workflow/state-machine-status.test.ts
+++ b/test/analytics/analytics-on-redshift/lambda/user-segments-workflow/state-machine-status.test.ts
@@ -11,26 +11,24 @@
  *  and limitations under the License.
  */
 
-import { ListExecutionsCommand, SFNClient } from '@aws-sdk/client-sfn';
+import { SegmentJobStatus } from '@aws/clickstream-base-lib';
+import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
+
 import {
   handler,
   StateMachineStatus,
   StateMachineStatusEvent,
 } from '../../../../../src/analytics/lambdas/user-segments-workflow/state-machine-status';
+import {
+  MOCK_SEGMENT_JOB_STATUS_ITEM,
+} from '../../../../../src/control-plane/backend/lambda/api/test/api/segments/segments-mock';
 import { getMockContext } from '../../../../common/lambda-context';
 
 describe('User segments workflow segment-job-status lambda tests', () => {
-  const sfnClientMock = mockClient(SFNClient);
+  const ddbDocClientMock = mockClient(DynamoDBDocumentClient);
   const contextMock = getMockContext();
-  const executionListItem = {
-    executionArn: 'arn:aws:states:us-east-1:111122223333:execution/abc',
-    stateMachineArn: 'arn:aws:states:us-east-1:111122223333:workflow/abc',
-    name: 'abc',
-    status: undefined,
-    startDate: new Date(),
-  };
   let event: StateMachineStatusEvent;
 
   beforeEach(() => {
@@ -46,8 +44,13 @@ describe('User segments workflow segment-job-status lambda tests', () => {
   });
 
   test('state machine is busy on the first invocation', async () => {
-    sfnClientMock.on(ListExecutionsCommand).resolves({
-      executions: [executionListItem, executionListItem],
+    ddbDocClientMock.on(QueryCommand).resolves({
+      Items: [
+        {
+          ...MOCK_SEGMENT_JOB_STATUS_ITEM,
+          jobStatus: SegmentJobStatus.IN_PROGRESS,
+        },
+      ],
     });
 
     const resp = await handler(event, contextMock);
@@ -65,8 +68,8 @@ describe('User segments workflow segment-job-status lambda tests', () => {
   });
 
   test('state machine is idle on the 5th invocation', async () => {
-    sfnClientMock.on(ListExecutionsCommand).resolves({
-      executions: [executionListItem],
+    ddbDocClientMock.on(QueryCommand).resolves({
+      Items: [],
     });
 
     const resp = await handler({

--- a/test/analytics/analytics-on-redshift/workflow/user-segments-sfn.json
+++ b/test/analytics/analytics-on-redshift/workflow/user-segments-sfn.json
@@ -24,7 +24,7 @@
           "Arn"
         ]
       },
-      "\",\"Payload\":{\"stateMachineArn.$\":\"$$.StateMachine.Id\",\"input.$\":\"$\"}}},\"WorkflowWait-StateMachineStatus\":{\"Type\":\"Wait\",\"SecondsPath\":\"$.waitTimeInfo.waitTime\",\"Next\":\"WorkflowTask-StateMachineStatus\"},\"WorkflowChoice-StateMachineStatus\":{\"Type\":\"Choice\",\"Choices\":[{\"Variable\":\"$.stateMachineStatus\",\"StringEquals\":\"IDLE\",\"Next\":\"WorkflowTask-ExecuteSegmentQuery\"}],\"Default\":\"WorkflowWait-StateMachineStatus\"},\"WorkflowTask-ExecuteSegmentQuery\":{\"Next\":\"WorkflowTask-SegmentJobStatus\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2}],\"Type\":\"Task\",\"OutputPath\":\"$.Payload\",\"Resource\":\"arn:",
+      "\",\"Payload.$\":\"$\"}},\"WorkflowWait-StateMachineStatus\":{\"Type\":\"Wait\",\"SecondsPath\":\"$.waitTimeInfo.waitTime\",\"Next\":\"WorkflowTask-StateMachineStatus\"},\"WorkflowChoice-StateMachineStatus\":{\"Type\":\"Choice\",\"Choices\":[{\"Variable\":\"$.stateMachineStatus\",\"StringEquals\":\"IDLE\",\"Next\":\"WorkflowTask-ExecuteSegmentQuery\"}],\"Default\":\"WorkflowWait-StateMachineStatus\"},\"WorkflowTask-ExecuteSegmentQuery\":{\"Next\":\"WorkflowTask-SegmentJobStatus\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2}],\"Type\":\"Task\",\"OutputPath\":\"$.Payload\",\"Resource\":\"arn:",
       {
         "Ref": "AWS::Partition"
       },

--- a/test/analytics/analytics-on-redshift/workflow/user-segments-sfn.test.ts
+++ b/test/analytics/analytics-on-redshift/workflow/user-segments-sfn.test.ts
@@ -152,6 +152,9 @@ describe('DataAnalyticsRedshiftStack user segment workflow tests', () => {
             POWERTOOLS_LOGGER_SAMPLE_RATE: '1',
             POWERTOOLS_LOGGER_LOG_EVENT: 'true',
             LOG_LEVEL: 'WARN',
+            CLICKSTREAM_METADATA_DDB_ARN: {
+              Ref: Match.stringLikeRegexp('ClickstreamMetadataDdbArn'),
+            },
           },
         },
         Handler: 'index.handler',
@@ -185,24 +188,25 @@ describe('DataAnalyticsRedshiftStack user segment workflow tests', () => {
               Resource: '*',
             },
             {
-              Action: 'states:ListExecutions',
+              Action: [
+                'dynamodb:BatchGetItem',
+                'dynamodb:GetRecords',
+                'dynamodb:GetShardIterator',
+                'dynamodb:Query',
+                'dynamodb:GetItem',
+                'dynamodb:Scan',
+                'dynamodb:ConditionCheckItem',
+                'dynamodb:DescribeTable',
+              ],
               Effect: 'Allow',
-              Resource: {
-                'Fn::Join': [
-                  '',
-                  [
-                    'arn:',
-                    {
-                      Ref: 'AWS::Partition',
-                    },
-                    ':states:*:',
-                    {
-                      Ref: 'AWS::AccountId',
-                    },
-                    ':stateMachine:ClickstreamUserSegmentsWorkflowStateMachine*',
-                  ],
-                ],
-              },
+              Resource: [
+                {
+                  Ref: Match.stringLikeRegexp('ClickstreamMetadataDdbArn'),
+                },
+                {
+                  Ref: 'AWS::NoValue',
+                },
+              ],
             },
           ],
           Version: '2012-10-17',

--- a/test/analytics/analytics-on-redshift/workflow/user-segments-sfn.test.ts
+++ b/test/analytics/analytics-on-redshift/workflow/user-segments-sfn.test.ts
@@ -188,25 +188,19 @@ describe('DataAnalyticsRedshiftStack user segment workflow tests', () => {
               Resource: '*',
             },
             {
-              Action: [
-                'dynamodb:BatchGetItem',
-                'dynamodb:GetRecords',
-                'dynamodb:GetShardIterator',
-                'dynamodb:Query',
-                'dynamodb:GetItem',
-                'dynamodb:Scan',
-                'dynamodb:ConditionCheckItem',
-                'dynamodb:DescribeTable',
-              ],
+              Action: 'dynamodb:Query',
               Effect: 'Allow',
-              Resource: [
-                {
-                  Ref: Match.stringLikeRegexp('ClickstreamMetadataDdbArn'),
-                },
-                {
-                  Ref: 'AWS::NoValue',
-                },
-              ],
+              Resource: {
+                'Fn::Join': [
+                  '',
+                  [
+                    {
+                      Ref: Match.stringLikeRegexp('ClickstreamMetadataDdbArn'),
+                    },
+                    '/index/prefix-time-index',
+                  ],
+                ],
+              },
             },
           ],
           Version: '2012-10-17',


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. Fix segment jobs got stuck when multiple jobs were submitted
2. Fix segment job is not showing up in the job list table in segment detail page
3. Fix segment refresh schedule cron is incorrect for daily refresh
4. Display segment name instead of segment id in the breadcrums

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend