### PR TITLE
chore: polish realtime switcher

### DIFF
--- a/frontend/public/locales/en-US/analytics.json
+++ b/frontend/public/locales/en-US/analytics.json
@@ -63,7 +63,7 @@
       "minute10": "10 minutes"
     },
     "costTipTitle": "Cost reminder",
-    "costTipContent": "Please note that opening real-time reports will incur additional fees, as detailed in the documentation: ",
+    "costTipContent": "Please note that opening real-time reports will incur additional cost, refer to the following documentation for more details: ",
     "costTipLink": "Cost"
   },
   "analyzes": {

--- a/frontend/public/locales/en-US/analytics.json
+++ b/frontend/public/locales/en-US/analytics.json
@@ -61,7 +61,10 @@
       "minute1": "1 minute",
       "minute5": "5 minutes",
       "minute10": "10 minutes"
-    }
+    },
+    "costTipTitle": "Cost reminder",
+    "costTipContent": "Please note that opening real-time reports will incur additional fees, as detailed in the documentation: ",
+    "costTipLink": "Cost"
   },
   "analyzes": {
     "title": "Analyses",

--- a/frontend/public/locales/zh-CN/analytics.json
+++ b/frontend/public/locales/zh-CN/analytics.json
@@ -61,7 +61,10 @@
       "minute1": "1 分钟",
       "minute5": "5 分钟",
       "minute10": "10 分钟"
-    }
+    },
+    "costTipTitle": "费用提示",
+    "costTipContent": "请注意，开启实时报表后将产生额外费用，具体见文档: ",
+    "costTipLink": "费用"
   },
   "analyzes": {
     "title": "分析",

--- a/frontend/src/apis/analytics.ts
+++ b/frontend/src/apis/analytics.ts
@@ -277,15 +277,26 @@ export const embedAnalyzesUrl = async (
   return result;
 };
 
-export const embedRealtimeUrl = async (
+export const realtimeDryRun = async (
   projectId: string,
   appId: string,
-  allowedDomain: string,
   enable: boolean
 ) => {
   const result: any = await apiRequest(
     'get',
-    `project/${projectId}/${appId}/realtime?enable=${enable}&allowedDomain=${allowedDomain}`
+    `project/${projectId}/${appId}/realtimeDryRun?enable=${enable}`
+  );
+  return result;
+};
+
+export const embedRealtimeUrl = async (
+  projectId: string,
+  appId: string,
+  allowedDomain: string,
+) => {
+  const result: any = await apiRequest(
+    'get',
+    `project/${projectId}/${appId}/realtime?allowedDomain=${allowedDomain}`
   );
   return result;
 };

--- a/frontend/src/apis/analytics.ts
+++ b/frontend/src/apis/analytics.ts
@@ -284,7 +284,7 @@ export const realtimeDryRun = async (
 ) => {
   const result: any = await apiRequest(
     'get',
-    `project/${projectId}/${appId}/realtimeDryRun?enable=${enable}`
+    `reporting/${projectId}/${appId}/realtimeDryRun?enable=${enable}`
   );
   return result;
 };
@@ -292,11 +292,11 @@ export const realtimeDryRun = async (
 export const embedRealtimeUrl = async (
   projectId: string,
   appId: string,
-  allowedDomain: string,
+  allowedDomain: string
 ) => {
   const result: any = await apiRequest(
     'get',
-    `project/${projectId}/${appId}/realtime?allowedDomain=${allowedDomain}`
+    `reporting/${projectId}/${appId}/realtime?allowedDomain=${allowedDomain}`
   );
   return result;
 };

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -588,6 +588,10 @@ ul.menu-list li.checkbox-item {
   gap: 5px;
 }
 
+.cs-analytics-realtime-tips {
+  margin-top: 4px;
+}
+
 .cs-analytics-realtime-auto-refresh {
   float: right;
 }

--- a/frontend/src/pages/analytics/realtime/AnalyticsRealtime.tsx
+++ b/frontend/src/pages/analytics/realtime/AnalyticsRealtime.tsx
@@ -25,18 +25,23 @@ import {
   SpaceBetween,
   Toggle,
 } from '@cloudscape-design/components';
-import { embedRealtimeUrl, getPipelineDetailByProjectId, realtimeDryRun } from 'apis/analytics';
+import {
+  embedRealtimeUrl,
+  getPipelineDetailByProjectId,
+  realtimeDryRun,
+} from 'apis/analytics';
 import Loading from 'components/common/Loading';
 import AnalyticsNavigation from 'components/layouts/AnalyticsNavigation';
 import CustomBreadCrumb from 'components/layouts/CustomBreadCrumb';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
+import { buildDocumentLink } from 'ts/url';
 import { defaultStr } from 'ts/utils';
 import ExploreEmbedFrame from '../comps/ExploreEmbedFrame';
 
 const AnalyticsRealtime: React.FC = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { projectId, appId } = useParams();
 
   let intervalId: any = 0;
@@ -45,6 +50,7 @@ const AnalyticsRealtime: React.FC = () => {
   const [loadingData, setLoadingData] = useState(false);
   const [loadingDruRun, setLoadingDryRun] = useState(false);
   const [loadingFrameData, setLoadingFrameData] = useState(false);
+  const [alertVisible, setAlertVisible] = useState(true);
   const [enableStreamModule, setEnableStreamModule] = useState(false);
   const [dashboardEmbedUrl, setDashboardEmbedUrl] = useState('');
   const [autoRefreshText, setAutoRefreshText] = useState(
@@ -58,7 +64,7 @@ const AnalyticsRealtime: React.FC = () => {
       const { success, data }: ApiResponse<any> = await embedRealtimeUrl(
         defaultStr(projectId),
         defaultStr(appId),
-        window.location.origin,
+        window.location.origin
       );
       if (success && data.EmbedUrl) {
         setDashboardEmbedUrl(data.EmbedUrl);
@@ -86,7 +92,7 @@ const AnalyticsRealtime: React.FC = () => {
       setDashboardEmbedUrl('');
     }
     setLoadingDryRun(false);
-  }
+  };
 
   const loadPipeline = async () => {
     setLoadingData(true);
@@ -196,105 +202,137 @@ const AnalyticsRealtime: React.FC = () => {
                 ) : (
                   <>
                     {enableStreamModule ? (
-                      <ColumnLayout columns={2}>
-                        <div>
-                          <Toggle
-                            disabled={loadingDruRun}
-                            onChange={({ detail }) =>
-                              getRealtimeDryRun(detail.checked)
-                            }
-                            checked={checked}
-                          >
-                            {checked
-                              ? t('analytics:labels.realtimeStarted')
-                              : t('analytics:labels.realtimeStopped')}
-                          </Toggle>
-                        </div>
-                        <div className="cs-analytics-realtime-auto-refresh">
-                          <Button
-                            iconName="refresh"
-                            variant="icon"
-                            disabled={!checked}
-                            onClick={() => getRealtime()}
-                          />
-                          <ButtonDropdown
-                            disabled={!checked}
-                            items={[
-                              {
-                                text: defaultStr(
-                                  t('analytics:realtime.autoRefresh.close')
-                                ),
-                                id: 'close',
-                              },
-                              {
-                                text: defaultStr(
-                                  t('analytics:realtime.autoRefresh.seconds15')
-                                ),
-                                id: 'seconds15',
-                              },
-                              {
-                                text: defaultStr(
-                                  t('analytics:realtime.autoRefresh.seconds30')
-                                ),
-                                id: 'seconds30',
-                              },
-                              {
-                                text: defaultStr(
-                                  t('analytics:realtime.autoRefresh.minute1')
-                                ),
-                                id: 'minute1',
-                              },
-                              {
-                                text: defaultStr(
-                                  t('analytics:realtime.autoRefresh.minute5')
-                                ),
-                                id: 'minute5',
-                              },
-                              {
-                                text: defaultStr(
-                                  t('analytics:realtime.autoRefresh.minute10')
-                                ),
-                                id: 'minute10',
-                              },
-                            ]}
-                            onItemClick={(e) => {
-                              if (e.detail.id === 'close') {
-                                setAutoRefreshText(
-                                  t('analytics:realtime.autoRefresh.title')
-                                );
-                                setAutoRefreshInterval(0);
-                              } else if (e.detail.id === 'seconds15') {
-                                setAutoRefreshText(
-                                  t('analytics:realtime.autoRefresh.seconds15')
-                                );
-                                setAutoRefreshInterval(15000);
-                              } else if (e.detail.id === 'seconds30') {
-                                setAutoRefreshText(
-                                  t('analytics:realtime.autoRefresh.seconds30')
-                                );
-                                setAutoRefreshInterval(30000);
-                              } else if (e.detail.id === 'minute1') {
-                                setAutoRefreshText(
-                                  t('analytics:realtime.autoRefresh.minute1')
-                                );
-                                setAutoRefreshInterval(60000);
-                              } else if (e.detail.id === 'minute5') {
-                                setAutoRefreshText(
-                                  t('analytics:realtime.autoRefresh.minute5')
-                                );
-                                setAutoRefreshInterval(300000);
-                              } else if (e.detail.id === 'minute10') {
-                                setAutoRefreshText(
-                                  t('analytics:realtime.autoRefresh.minute10')
-                                );
-                                setAutoRefreshInterval(600000);
+                      <div>
+                        <ColumnLayout columns={2}>
+                          <div>
+                            <Toggle
+                              disabled={loadingDruRun}
+                              onChange={({ detail }) =>
+                                getRealtimeDryRun(detail.checked)
                               }
-                            }}
-                          >
-                            {autoRefreshText}
-                          </ButtonDropdown>
-                        </div>
-                      </ColumnLayout>
+                              checked={checked}
+                            >
+                              {checked
+                                ? t('analytics:labels.realtimeStarted')
+                                : t('analytics:labels.realtimeStopped')}
+                            </Toggle>
+                          </div>
+                          <div className="cs-analytics-realtime-auto-refresh">
+                            <Button
+                              iconName="refresh"
+                              variant="icon"
+                              disabled={!checked}
+                              onClick={() => getRealtime()}
+                            />
+                            <ButtonDropdown
+                              disabled={!checked}
+                              items={[
+                                {
+                                  text: defaultStr(
+                                    t('analytics:realtime.autoRefresh.close')
+                                  ),
+                                  id: 'close',
+                                },
+                                {
+                                  text: defaultStr(
+                                    t(
+                                      'analytics:realtime.autoRefresh.seconds15'
+                                    )
+                                  ),
+                                  id: 'seconds15',
+                                },
+                                {
+                                  text: defaultStr(
+                                    t(
+                                      'analytics:realtime.autoRefresh.seconds30'
+                                    )
+                                  ),
+                                  id: 'seconds30',
+                                },
+                                {
+                                  text: defaultStr(
+                                    t('analytics:realtime.autoRefresh.minute1')
+                                  ),
+                                  id: 'minute1',
+                                },
+                                {
+                                  text: defaultStr(
+                                    t('analytics:realtime.autoRefresh.minute5')
+                                  ),
+                                  id: 'minute5',
+                                },
+                                {
+                                  text: defaultStr(
+                                    t('analytics:realtime.autoRefresh.minute10')
+                                  ),
+                                  id: 'minute10',
+                                },
+                              ]}
+                              onItemClick={(e) => {
+                                if (e.detail.id === 'close') {
+                                  setAutoRefreshText(
+                                    t('analytics:realtime.autoRefresh.title')
+                                  );
+                                  setAutoRefreshInterval(0);
+                                } else if (e.detail.id === 'seconds15') {
+                                  setAutoRefreshText(
+                                    t(
+                                      'analytics:realtime.autoRefresh.seconds15'
+                                    )
+                                  );
+                                  setAutoRefreshInterval(15000);
+                                } else if (e.detail.id === 'seconds30') {
+                                  setAutoRefreshText(
+                                    t(
+                                      'analytics:realtime.autoRefresh.seconds30'
+                                    )
+                                  );
+                                  setAutoRefreshInterval(30000);
+                                } else if (e.detail.id === 'minute1') {
+                                  setAutoRefreshText(
+                                    t('analytics:realtime.autoRefresh.minute1')
+                                  );
+                                  setAutoRefreshInterval(60000);
+                                } else if (e.detail.id === 'minute5') {
+                                  setAutoRefreshText(
+                                    t('analytics:realtime.autoRefresh.minute5')
+                                  );
+                                  setAutoRefreshInterval(300000);
+                                } else if (e.detail.id === 'minute10') {
+                                  setAutoRefreshText(
+                                    t('analytics:realtime.autoRefresh.minute10')
+                                  );
+                                  setAutoRefreshInterval(600000);
+                                }
+                              }}
+                            >
+                              {autoRefreshText}
+                            </ButtonDropdown>
+                          </div>
+                        </ColumnLayout>
+                        {alertVisible && (
+                          <div className="cs-analytics-realtime-tips">
+                            <Alert
+                              dismissible
+                              statusIconAriaLabel="Info"
+                              header={t('analytics:realtime.costTipTitle')}
+                              onDismiss={() => setAlertVisible(false)}
+                            >
+                              {t('analytics:realtime.costTipContent')}
+                              <Link
+                                href={buildDocumentLink(
+                                  i18n.language,
+                                  '',
+                                  '/plan-deployment/cost'
+                                )}
+                                external
+                              >
+                                {t('analytics:realtime.costTipLink')}
+                              </Link>
+                            </Alert>
+                          </div>
+                        )}
+                      </div>
                     ) : (
                       <Alert
                         statusIconAriaLabel="Info"

--- a/frontend/src/pages/analytics/realtime/AnalyticsRealtime.tsx
+++ b/frontend/src/pages/analytics/realtime/AnalyticsRealtime.tsx
@@ -25,7 +25,7 @@ import {
   SpaceBetween,
   Toggle,
 } from '@cloudscape-design/components';
-import { embedRealtimeUrl, getPipelineDetailByProjectId } from 'apis/analytics';
+import { embedRealtimeUrl, getPipelineDetailByProjectId, realtimeDryRun } from 'apis/analytics';
 import Loading from 'components/common/Loading';
 import AnalyticsNavigation from 'components/layouts/AnalyticsNavigation';
 import CustomBreadCrumb from 'components/layouts/CustomBreadCrumb';
@@ -43,6 +43,7 @@ const AnalyticsRealtime: React.FC = () => {
 
   const [checked, setChecked] = React.useState(false);
   const [loadingData, setLoadingData] = useState(false);
+  const [loadingDruRun, setLoadingDryRun] = useState(false);
   const [loadingFrameData, setLoadingFrameData] = useState(false);
   const [enableStreamModule, setEnableStreamModule] = useState(false);
   const [dashboardEmbedUrl, setDashboardEmbedUrl] = useState('');
@@ -58,7 +59,6 @@ const AnalyticsRealtime: React.FC = () => {
         defaultStr(projectId),
         defaultStr(appId),
         window.location.origin,
-        checked
       );
       if (success && data.EmbedUrl) {
         setDashboardEmbedUrl(data.EmbedUrl);
@@ -69,6 +69,24 @@ const AnalyticsRealtime: React.FC = () => {
     }
     setLoadingFrameData(false);
   };
+
+  const getRealtimeDryRun = async (checked) => {
+    setLoadingDryRun(true);
+    try {
+      const { success }: ApiResponse<any> = await realtimeDryRun(
+        defaultStr(projectId),
+        defaultStr(appId),
+        checked
+      );
+      if (success) {
+        setLoadingDryRun(false);
+        setChecked(checked);
+      }
+    } catch (error) {
+      setDashboardEmbedUrl('');
+    }
+    setLoadingDryRun(false);
+  }
 
   const loadPipeline = async () => {
     setLoadingData(true);
@@ -181,8 +199,9 @@ const AnalyticsRealtime: React.FC = () => {
                       <ColumnLayout columns={2}>
                         <div>
                           <Toggle
+                            disabled={loadingDruRun}
                             onChange={({ detail }) =>
-                              setChecked(detail.checked)
+                              getRealtimeDryRun(detail.checked)
                             }
                             checked={checked}
                           >

--- a/src/control-plane/backend/lambda/api/middle-ware/auth-role.ts
+++ b/src/control-plane/backend/lambda/api/middle-ware/auth-role.ts
@@ -32,7 +32,8 @@ routerRoles.set('POST /api/project/:pid/:aid/dashboard/*', [IUserRole.ADMIN, IUs
 routerRoles.set('PUT /api/project/:pid/:aid/dashboard/*', [IUserRole.ADMIN, IUserRole.ANALYST]);
 routerRoles.set('DELETE /api/project/:pid/:aid/dashboard/*', [IUserRole.ADMIN, IUserRole.ANALYST]);
 routerRoles.set('GET /api/project/:pid/analyzes', [IUserRole.ADMIN, IUserRole.ANALYST]);
-routerRoles.set('GET /api/project/:pid/:aid/realtime', [IUserRole.ADMIN, IUserRole.ANALYST, IUserRole.ANALYST_READER]);
+routerRoles.set('GET /api/reporting/:pid/:aid/realtime', [IUserRole.ADMIN, IUserRole.ANALYST]);
+routerRoles.set('GET /api/reporting/:pid/:aid/realtimeDryRun', [IUserRole.ADMIN, IUserRole.ANALYST]);
 
 routerRoles.set('ALL /api/env/*', [IUserRole.ADMIN, IUserRole.OPERATOR]);
 routerRoles.set('ALL /api/app/*', [IUserRole.ADMIN, IUserRole.OPERATOR]);

--- a/src/control-plane/backend/lambda/api/router/project.ts
+++ b/src/control-plane/backend/lambda/api/router/project.ts
@@ -70,18 +70,6 @@ router_project.get(
   });
 
 router_project.get(
-  '/:projectId/:appId/realtimeDryRun',
-  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
-    return projectServ.getRealtimeDryRun(req, res, next);
-  });
-
-router_project.get(
-  '/:projectId/:appId/realtime',
-  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
-    return projectServ.getRealtime(req, res, next);
-  });
-
-router_project.get(
   '',
   validate([
     query().custom((value: any, { req }: any) => defaultPageValueValid(value, {

--- a/src/control-plane/backend/lambda/api/router/project.ts
+++ b/src/control-plane/backend/lambda/api/router/project.ts
@@ -69,6 +69,11 @@ router_project.get(
     return projectServ.getAnalyzes(req, res, next);
   });
 
+router_project.get(
+  '/:projectId/:appId/realtimeDryRun',
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return projectServ.getRealtimeDryRun(req, res, next);
+  });
 
 router_project.get(
   '/:projectId/:appId/realtime',

--- a/src/control-plane/backend/lambda/api/router/reporting.ts
+++ b/src/control-plane/backend/lambda/api/router/reporting.ts
@@ -103,6 +103,19 @@ router_reporting.post(
     return reportingServ.cleanQuickSightResources(req, res, next);
   });
 
+router_reporting.get(
+  '/:projectId/:appId/realtimeDryRun',
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return reportingServ.getRealtimeDryRun(req, res, next);
+  });
+
+router_reporting.get(
+  '/:projectId/:appId/realtime',
+  async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return reportingServ.getRealtime(req, res, next);
+  });
+
+
 export {
   router_reporting,
 };

--- a/src/control-plane/backend/lambda/api/service/reporting.ts
+++ b/src/control-plane/backend/lambda/api/service/reporting.ts
@@ -27,7 +27,12 @@ import {
   sleep,
   SolutionVersion,
   OUTPUT_REPORTING_QUICKSIGHT_REDSHIFT_DATABASE_NAME,
+  OUTPUT_STREAMING_INGESTION_FLINK_APP_ARN,
+  SINK_STREAM_NAME_PREFIX,
+  OUTPUT_REPORT_DASHBOARDS_SUFFIX,
+  DEFAULT_DASHBOARD_NAME,
 } from '@aws/clickstream-base-lib';
+import { ApplicationStatus } from '@aws-sdk/client-kinesis-analytics-v2';
 import { AnalysisDefinition, AnalysisSummary, ConflictException, DashboardSummary, DashboardVersionDefinition, DataSetIdentifierDeclaration, DataSetSummary, DayOfWeek, InputColumn, QuickSight, ResourceStatus, ThrottlingException, paginateListAnalyses, paginateListDashboards, paginateListDataSets } from '@aws-sdk/client-quicksight';
 import { v4 as uuidv4 } from 'uuid';
 import { PipelineServ } from './pipeline';
@@ -67,13 +72,16 @@ import {
   warmupRedshift,
 } from './quicksight/reporting-utils';
 import { EventAndCondition, ExploreAnalyticsType, GroupingCondition, SQLParameters, buildColNameWithPrefix, buildEventAnalysisView, buildEventPathAnalysisView, buildEventPropertyAnalysisView, buildFunnelTableView, buildFunnelView, buildNodePathAnalysisView, buildRetentionAnalysisView } from './quicksight/sql-builder';
-import { FULL_SOLUTION_VERSION, awsAccountId } from '../common/constants';
+import { FULL_SOLUTION_VERSION, awsAccountId, awsPartition } from '../common/constants';
 import { PipelineStackType } from '../common/model-ln';
 import { logger } from '../common/powertools';
 import { SDKClient } from '../common/sdk-client';
 import { ApiFail, ApiSuccess } from '../common/types';
-import { getStackOutputFromPipelineStatus } from '../common/utils';
-import { IPipeline } from '../model/pipeline';
+import { getReportingDashboardsUrl, getStackName, getStackOutputFromPipelineStatus, getStreamEnableAppIdsFromPipeline } from '../common/utils';
+import { CPipeline, IPipeline } from '../model/pipeline';
+import { IDashboard } from '../model/project';
+import { describeStack } from '../store/aws/cloudformation';
+import { describeApplication, updateFlinkApplication } from '../store/aws/flink';
 import { QuickSightUserArns, deleteExploreUser, generateEmbedUrlForRegisteredUser, getClickstreamUserArn, waitDashboardSuccess } from '../store/aws/quicksight';
 import { ClickStreamStore } from '../store/click-stream-store';
 import { DynamoDbStore } from '../store/dynamodb/dynamodb-store';
@@ -1301,6 +1309,205 @@ export class ReportingService {
     }
   };
 
+  public async getRealtimeDryRun(req: any, res: any, next: any) {
+    try {
+      const { projectId, appId } = req.params;
+      const enable = req.query.enable === 'true';
+      const pipeline = await pipelineServ.getPipelineByProjectId(projectId);
+      if (!pipeline) {
+        return res
+          .status(404)
+          .json(new ApiFail('The latest pipeline not found.'));
+      }
+      if (!pipeline.reporting?.quickSight?.accountName) {
+        return res
+          .status(400)
+          .json(new ApiFail('The latest pipeline not enable reporting.'));
+      }
+      if (!pipeline.streaming?.appIdStreamList?.includes(appId)) {
+        return res
+          .status(400)
+          .json(new ApiFail('The appId not allow to enable realtime.'));
+      }
+      const flinkAppArn = getStackOutputFromPipelineStatus(
+        pipeline.stackDetails ?? pipeline.status?.stackDetails,
+        PipelineStackType.STREAMING,
+        OUTPUT_STREAMING_INGESTION_FLINK_APP_ARN,
+      );
+      const flinkAppName = flinkAppArn?.split('/').pop();
+      if (!flinkAppName) {
+        return res
+          .status(404)
+          .json(new ApiFail('The flink application not found.'));
+      }
+      // check flink application status
+      const flinkApplication = await describeApplication(
+        pipeline.region,
+        flinkAppName,
+      );
+      if (
+        !flinkApplication ||
+      (flinkApplication.ApplicationDetail?.ApplicationStatus !==
+        ApplicationStatus.READY &&
+        flinkApplication.ApplicationDetail?.ApplicationStatus !==
+          ApplicationStatus.RUNNING)
+      ) {
+        return res
+          .status(400)
+          .json(new ApiFail('The flink application status not allow update, please try again later.'));
+      }
+
+      const streamEnableAppIds = getStreamEnableAppIdsFromPipeline(
+        pipeline.streaming?.appIdRealtimeList ?? [],
+        appId,
+        enable,
+      );
+      const streamingSinkKinesisConfig =
+    await this.getStreamingSinkKinesisConfig(pipeline, streamEnableAppIds);
+      logger.debug(
+        `streamingSinkKinesisConfig: ${JSON.stringify(
+          streamingSinkKinesisConfig,
+        )}`,
+      );
+      const updateRes = await updateFlinkApplication(
+        pipeline.region,
+        flinkAppName,
+        flinkApplication,
+        streamEnableAppIds,
+        streamingSinkKinesisConfig,
+      );
+      if (!updateRes) {
+        return res
+          .status(500)
+          .json(new ApiFail('Failed to update Flink application.'));
+      }
+      const pipe = new CPipeline(pipeline);
+      await pipe.realtime(enable, appId);
+      return res.json(
+        new ApiSuccess('OK'),
+      );
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  private getPresetAppDashboard(
+    pipeline: IPipeline,
+    appId: string,
+    realtime: boolean = false,
+  ) {
+    const stackDashboards = getReportingDashboardsUrl(
+      pipeline.stackDetails ?? pipeline.status?.stackDetails,
+      PipelineStackType.REPORTING,
+      OUTPUT_REPORT_DASHBOARDS_SUFFIX,
+    );
+    if (stackDashboards.length === 0) {
+      return undefined;
+    }
+    const appDashboard = stackDashboards.find(
+      (item: any) => item.appId === appId,
+    );
+    if (appDashboard) {
+      if (realtime) {
+        const presetDashboard: IDashboard = {
+          id: appDashboard.realtimeDashboardId,
+          name: 'Realtime Dashboard',
+          description:
+            'Realtime user lifecycle analysis dashboard created by solution.',
+          projectId: pipeline.projectId,
+          appId: appId,
+          region: pipeline.region,
+          sheets: [],
+          createAt: pipeline.createAt,
+          updateAt: pipeline.updateAt,
+        };
+        return presetDashboard;
+      }
+      const presetDashboard: IDashboard = {
+        id: appDashboard.dashboardId,
+        name: DEFAULT_DASHBOARD_NAME,
+        description:
+          'Out-of-the-box user lifecycle analysis dashboard created by solution.',
+        projectId: pipeline.projectId,
+        appId: appId,
+        region: pipeline.region,
+        sheets: [],
+        createAt: pipeline.createAt,
+        updateAt: pipeline.updateAt,
+      };
+      return presetDashboard;
+    }
+    return undefined;
+  }
+
+  public async getRealtime(req: any, res: any, next: any) {
+    try {
+      const { projectId, appId } = req.params;
+      const { allowedDomain } = req.query;
+      const pipeline = await pipelineServ.getPipelineByProjectId(projectId);
+      if (!pipeline) {
+        return res
+          .status(404)
+          .json(new ApiFail('The latest pipeline not found.'));
+      }
+
+      const principals = await getClickstreamUserArn(
+        SolutionVersion.Of(pipeline.templateVersion ?? FULL_SOLUTION_VERSION),
+        pipeline.reporting?.quickSight?.user ?? '',
+      );
+      const presetRealtimeDashboard = this.getPresetAppDashboard(
+        pipeline,
+        appId,
+        true,
+      );
+      const embed = await generateEmbedUrlForRegisteredUser(
+        pipeline.region,
+        principals.publishUserArn,
+        allowedDomain,
+        {
+          initialPath: `/dashboards/${presetRealtimeDashboard?.id}`,
+        },
+      );
+      return res.json(
+        new ApiSuccess(embed),
+      );
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  private async getStreamingSinkKinesisConfig(
+    pipeline: IPipeline,
+    streamEnableAppIds: string[],
+  ) {
+    const enableConfigs: any[] = [];
+    try {
+      const streamingStack = await describeStack(
+        pipeline.region,
+        getStackName(
+          pipeline.pipelineId,
+          PipelineStackType.STREAMING,
+          pipeline.ingestionServer.sinkType,
+        ),
+      );
+      if (!streamingStack) {
+        return enableConfigs;
+      }
+      const streamingStackIdPrefix =
+      streamingStack?.StackId?.split('/')[2].split('-')[0];
+      for (let appId of streamEnableAppIds) {
+        enableConfigs.push({
+          appId: appId,
+          streamArn: `arn:${awsPartition}:kinesis:${pipeline.region}:${awsAccountId}:stream/${SINK_STREAM_NAME_PREFIX}${pipeline.projectId}_${appId}_${streamingStackIdPrefix}`,
+        });
+      }
+      return enableConfigs;
+    } catch (error) {
+      logger.error('Failed to parse sink kinesis');
+      return enableConfigs;
+    }
+  }
+
 }
 
 async function _cleanDatasets(quickSight: QuickSight) {
@@ -1410,3 +1617,4 @@ function _needExploreUserVersion(pipeline: IPipeline) {
   return oldVersions.includes(version);
 
 }
+

--- a/src/control-plane/backend/lambda/api/test/api/realtime.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/realtime.test.ts
@@ -1,0 +1,360 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { OUTPUT_STREAMING_INGESTION_FLINK_APP_ARN } from '@aws/clickstream-base-lib';
+import { StackStatus } from '@aws-sdk/client-cloudformation';
+import { ApplicationStatus, DescribeApplicationCommand, StartApplicationCommand, StopApplicationCommand, UpdateApplicationCommand } from '@aws-sdk/client-kinesis-analytics-v2';
+import {
+  QueryCommand,
+} from '@aws-sdk/lib-dynamodb';
+import request from 'supertest';
+import { mockClients, resetAllMockClient } from './aws-sdk-mock-util';
+import { MOCK_APP_ID, MOCK_PIPELINE_ID, MOCK_PROJECT_ID, MOCK_SOLUTION_VERSION, appExistedMock, projectExistedMock } from './ddb-mock';
+import { PipelineStackType, PipelineStatusType } from '../../common/model-ln';
+import { app, server } from '../../index';
+import 'aws-sdk-client-mock-jest';
+
+describe('Realtime test', () => {
+  beforeEach(() => {
+    resetAllMockClient();
+  });
+  it('Check flink status', async () => {
+    projectExistedMock(mockClients.ddbMock, true);
+    appExistedMock(mockClients.ddbMock, true);
+    mockClients.ddbMock.on(QueryCommand).resolvesOnce(
+      {
+        Items: [
+          {
+            name: 'Pipeline-01',
+            pipelineId: MOCK_PROJECT_ID,
+            status: {
+              status: PipelineStatusType.ACTIVE,
+            },
+            streaming: {
+              appIdStreamList: [MOCK_APP_ID],
+              appIdRealtimeList: [],
+            },
+            reporting: {
+              quickSight: {
+                accountName: 'clickstream-acc-xxx',
+              },
+            },
+            stackDetails: [
+              {
+                stackName: `Clickstream-Streaming-${MOCK_PIPELINE_ID}`,
+                stackType: PipelineStackType.STREAMING,
+                stackStatus: StackStatus.CREATE_COMPLETE,
+                stackStatusReason: '',
+                stackTemplateVersion: MOCK_SOLUTION_VERSION,
+                outputs: [
+                  {
+                    OutputKey: OUTPUT_STREAMING_INGESTION_FLINK_APP_ARN,
+                    OutputValue: 'arn:aws:kinesisanalytics:us-east-1:555555555555:application/ClickstreamStreamingIngestion204CC39E-F3mJRaAOKJaL',
+                  },
+                ],
+              },
+            ],
+            executionArn: 'arn:aws:states:us-east-1:555555555555:execution:clickstream-stack-workflow:111-111-111',
+          },
+        ],
+      },
+    );
+    mockClients.kinesisAnalyticsV2Mock.on(DescribeApplicationCommand).resolves({
+      ApplicationDetail: {
+        ApplicationARN: 'arn:aws:kinesisanalytics:us-east-1:555555555555:application/ClickstreamStreamingIngestion204CC39E-F3',
+        ApplicationStatus: ApplicationStatus.RUNNING,
+        ApplicationDescription: 'ClickstreamStreamingIngestion204CC39E-F3',
+        ApplicationName: 'ClickstreamStreamingIngestion204CC39E-F3',
+        ApplicationVersionId: 1,
+        RuntimeEnvironment: 'FLINK-1_13',
+        ApplicationConfigurationDescription: {
+          EnvironmentPropertyDescriptions: {
+            PropertyGroupDescriptions: [
+              {
+                PropertyGroupId: 'EnvironmentProperties',
+                PropertyMap: {
+                  'FlinkApplicationProperties::FlinkParallelism': '1',
+                  'FlinkApplicationProperties::JobPlan': 'xxxx',
+                  'FlinkApplicationProperties::RuntimeMode': 'STREAMING',
+                  'FlinkApplicationProperties::SavepointConfiguration': 'xxxx',
+                  'FlinkApplicationProperties::CheckpointConfiguration': 'xxxx',
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+    mockClients.kinesisAnalyticsV2Mock.on(UpdateApplicationCommand).resolves({
+      ApplicationDetail: {
+        ApplicationARN: 'arn:aws:kinesisanalytics:us-east-1:555555555555:application/ClickstreamStreamingIngestion204CC39E-F3',
+        ApplicationStatus: ApplicationStatus.UPDATING,
+        ApplicationDescription: 'ClickstreamStreamingIngestion204CC39E-F3',
+        ApplicationName: 'ClickstreamStreamingIngestion204CC39E-F3',
+        ApplicationVersionId: 1,
+        RuntimeEnvironment: 'FLINK-1_13',
+      },
+    });
+    const res = await request(app).get(`/api/reporting/${MOCK_PROJECT_ID}/${MOCK_APP_ID}/realtimeDryRun?enable=true`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.message).toEqual('');
+    expect(res.body.success).toEqual(true);
+    expect(mockClients.kinesisAnalyticsV2Mock).toHaveReceivedCommandTimes(DescribeApplicationCommand, 1);
+    expect(mockClients.kinesisAnalyticsV2Mock).toHaveReceivedCommandTimes(UpdateApplicationCommand, 1);
+    expect(mockClients.kinesisAnalyticsV2Mock).toHaveReceivedCommandTimes(StartApplicationCommand, 0);
+  });
+  it('Check flink status when app is updating', async () => {
+    projectExistedMock(mockClients.ddbMock, true);
+    appExistedMock(mockClients.ddbMock, true);
+    mockClients.ddbMock.on(QueryCommand).resolvesOnce(
+      {
+        Items: [
+          {
+            name: 'Pipeline-01',
+            pipelineId: MOCK_PROJECT_ID,
+            status: {
+              status: PipelineStatusType.ACTIVE,
+            },
+            streaming: {
+              appIdStreamList: [MOCK_APP_ID],
+              appIdRealtimeList: [],
+            },
+            reporting: {
+              quickSight: {
+                accountName: 'clickstream-acc-xxx',
+              },
+            },
+            stackDetails: [
+              {
+                stackName: `Clickstream-Streaming-${MOCK_PIPELINE_ID}`,
+                stackType: PipelineStackType.STREAMING,
+                stackStatus: StackStatus.CREATE_COMPLETE,
+                stackStatusReason: '',
+                stackTemplateVersion: MOCK_SOLUTION_VERSION,
+                outputs: [
+                  {
+                    OutputKey: OUTPUT_STREAMING_INGESTION_FLINK_APP_ARN,
+                    OutputValue: 'arn:aws:kinesisanalytics:us-east-1:555555555555:application/ClickstreamStreamingIngestion204CC39E-F3mJRaAOKJaL',
+                  },
+                ],
+              },
+            ],
+            executionArn: 'arn:aws:states:us-east-1:555555555555:execution:clickstream-stack-workflow:111-111-111',
+          },
+        ],
+      },
+    );
+    mockClients.kinesisAnalyticsV2Mock.on(DescribeApplicationCommand).resolves({
+      ApplicationDetail: {
+        ApplicationARN: 'arn:aws:kinesisanalytics:us-east-1:555555555555:application/ClickstreamStreamingIngestion204CC39E-F3',
+        ApplicationStatus: ApplicationStatus.UPDATING,
+        ApplicationDescription: 'ClickstreamStreamingIngestion204CC39E-F3',
+        ApplicationName: 'ClickstreamStreamingIngestion204CC39E-F3',
+        ApplicationVersionId: 1,
+        RuntimeEnvironment: 'FLINK-1_13',
+        ApplicationConfigurationDescription: {
+          EnvironmentPropertyDescriptions: {
+            PropertyGroupDescriptions: [
+              {
+                PropertyGroupId: 'EnvironmentProperties',
+                PropertyMap: {
+                  'FlinkApplicationProperties::FlinkParallelism': '1',
+                  'FlinkApplicationProperties::JobPlan': 'xxxx',
+                  'FlinkApplicationProperties::RuntimeMode': 'STREAMING',
+                  'FlinkApplicationProperties::SavepointConfiguration': 'xxxx',
+                  'FlinkApplicationProperties::CheckpointConfiguration': 'xxxx',
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+    const res = await request(app).get(`/api/reporting/${MOCK_PROJECT_ID}/${MOCK_APP_ID}/realtimeDryRun?enable=true`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toEqual('The flink application status not allow update, please try again later.');
+    expect(res.body.success).toEqual(false);
+    expect(mockClients.kinesisAnalyticsV2Mock).toHaveReceivedCommandTimes(DescribeApplicationCommand, 1);
+    expect(mockClients.kinesisAnalyticsV2Mock).toHaveReceivedCommandTimes(UpdateApplicationCommand, 0);
+  });
+  it('Enable realtime - the first app', async () => {
+    projectExistedMock(mockClients.ddbMock, true);
+    appExistedMock(mockClients.ddbMock, true);
+    mockClients.ddbMock.on(QueryCommand).resolvesOnce(
+      {
+        Items: [
+          {
+            name: 'Pipeline-01',
+            pipelineId: MOCK_PROJECT_ID,
+            status: {
+              status: PipelineStatusType.ACTIVE,
+            },
+            streaming: {
+              appIdStreamList: [MOCK_APP_ID],
+              appIdRealtimeList: [],
+            },
+            reporting: {
+              quickSight: {
+                accountName: 'clickstream-acc-xxx',
+              },
+            },
+            stackDetails: [
+              {
+                stackName: `Clickstream-Streaming-${MOCK_PIPELINE_ID}`,
+                stackType: PipelineStackType.STREAMING,
+                stackStatus: StackStatus.CREATE_COMPLETE,
+                stackStatusReason: '',
+                stackTemplateVersion: MOCK_SOLUTION_VERSION,
+                outputs: [
+                  {
+                    OutputKey: OUTPUT_STREAMING_INGESTION_FLINK_APP_ARN,
+                    OutputValue: 'arn:aws:kinesisanalytics:us-east-1:555555555555:application/ClickstreamStreamingIngestion204CC39E-F3mJRaAOKJaL',
+                  },
+                ],
+              },
+            ],
+            executionArn: 'arn:aws:states:us-east-1:555555555555:execution:clickstream-stack-workflow:111-111-111',
+          },
+        ],
+      },
+    );
+    mockClients.kinesisAnalyticsV2Mock.on(DescribeApplicationCommand).resolves({
+      ApplicationDetail: {
+        ApplicationARN: 'arn:aws:kinesisanalytics:us-east-1:555555555555:application/ClickstreamStreamingIngestion204CC39E-F3',
+        ApplicationStatus: ApplicationStatus.READY,
+        ApplicationDescription: 'ClickstreamStreamingIngestion204CC39E-F3',
+        ApplicationName: 'ClickstreamStreamingIngestion204CC39E-F3',
+        ApplicationVersionId: 1,
+        RuntimeEnvironment: 'FLINK-1_13',
+        ApplicationConfigurationDescription: {
+          EnvironmentPropertyDescriptions: {
+            PropertyGroupDescriptions: [
+              {
+                PropertyGroupId: 'EnvironmentProperties',
+                PropertyMap: {
+                  'FlinkApplicationProperties::FlinkParallelism': '1',
+                  'FlinkApplicationProperties::JobPlan': 'xxxx',
+                  'FlinkApplicationProperties::RuntimeMode': 'STREAMING',
+                  'FlinkApplicationProperties::SavepointConfiguration': 'xxxx',
+                  'FlinkApplicationProperties::CheckpointConfiguration': 'xxxx',
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+    mockClients.kinesisAnalyticsV2Mock.on(UpdateApplicationCommand).resolves({
+      ApplicationDetail: {
+        ApplicationARN: 'arn:aws:kinesisanalytics:us-east-1:555555555555:application/ClickstreamStreamingIngestion204CC39E-F3',
+        ApplicationStatus: ApplicationStatus.UPDATING,
+        ApplicationDescription: 'ClickstreamStreamingIngestion204CC39E-F3',
+        ApplicationName: 'ClickstreamStreamingIngestion204CC39E-F3',
+        ApplicationVersionId: 1,
+        RuntimeEnvironment: 'FLINK-1_13',
+      },
+    });
+    mockClients.kinesisAnalyticsV2Mock.on(StartApplicationCommand).resolves({});
+    const res = await request(app).get(`/api/reporting/${MOCK_PROJECT_ID}/${MOCK_APP_ID}/realtimeDryRun?enable=true`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.message).toEqual('');
+    expect(res.body.success).toEqual(true);
+    expect(mockClients.kinesisAnalyticsV2Mock).toHaveReceivedCommandTimes(DescribeApplicationCommand, 1);
+    expect(mockClients.kinesisAnalyticsV2Mock).toHaveReceivedCommandTimes(UpdateApplicationCommand, 1);
+    expect(mockClients.kinesisAnalyticsV2Mock).toHaveReceivedCommandTimes(StartApplicationCommand, 1);
+  });
+  it('Disable realtime - the last app', async () => {
+    projectExistedMock(mockClients.ddbMock, true);
+    appExistedMock(mockClients.ddbMock, true);
+    mockClients.ddbMock.on(QueryCommand).resolvesOnce(
+      {
+        Items: [
+          {
+            name: 'Pipeline-01',
+            pipelineId: MOCK_PROJECT_ID,
+            status: {
+              status: PipelineStatusType.ACTIVE,
+            },
+            streaming: {
+              appIdStreamList: [MOCK_APP_ID],
+              appIdRealtimeList: [MOCK_APP_ID],
+            },
+            reporting: {
+              quickSight: {
+                accountName: 'clickstream-acc-xxx',
+              },
+            },
+            stackDetails: [
+              {
+                stackName: `Clickstream-Streaming-${MOCK_PIPELINE_ID}`,
+                stackType: PipelineStackType.STREAMING,
+                stackStatus: StackStatus.CREATE_COMPLETE,
+                stackStatusReason: '',
+                stackTemplateVersion: MOCK_SOLUTION_VERSION,
+                outputs: [
+                  {
+                    OutputKey: OUTPUT_STREAMING_INGESTION_FLINK_APP_ARN,
+                    OutputValue: 'arn:aws:kinesisanalytics:us-east-1:555555555555:application/ClickstreamStreamingIngestion204CC39E-F3mJRaAOKJaL',
+                  },
+                ],
+              },
+            ],
+            executionArn: 'arn:aws:states:us-east-1:555555555555:execution:clickstream-stack-workflow:111-111-111',
+          },
+        ],
+      },
+    );
+    mockClients.kinesisAnalyticsV2Mock.on(DescribeApplicationCommand).resolves({
+      ApplicationDetail: {
+        ApplicationARN: 'arn:aws:kinesisanalytics:us-east-1:555555555555:application/ClickstreamStreamingIngestion204CC39E-F3',
+        ApplicationStatus: ApplicationStatus.RUNNING,
+        ApplicationDescription: 'ClickstreamStreamingIngestion204CC39E-F3',
+        ApplicationName: 'ClickstreamStreamingIngestion204CC39E-F3',
+        ApplicationVersionId: 1,
+        RuntimeEnvironment: 'FLINK-1_13',
+        ApplicationConfigurationDescription: {
+          EnvironmentPropertyDescriptions: {
+            PropertyGroupDescriptions: [
+              {
+                PropertyGroupId: 'EnvironmentProperties',
+                PropertyMap: {
+                  'FlinkApplicationProperties::FlinkParallelism': '1',
+                  'FlinkApplicationProperties::JobPlan': 'xxxx',
+                  'FlinkApplicationProperties::RuntimeMode': 'STREAMING',
+                  'FlinkApplicationProperties::SavepointConfiguration': 'xxxx',
+                  'FlinkApplicationProperties::CheckpointConfiguration': 'xxxx',
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+    mockClients.kinesisAnalyticsV2Mock.on(StopApplicationCommand).resolves({});
+    const res = await request(app).get(`/api/reporting/${MOCK_PROJECT_ID}/${MOCK_APP_ID}/realtimeDryRun?enable=false`);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.message).toEqual('');
+    expect(res.body.success).toEqual(true);
+    expect(mockClients.kinesisAnalyticsV2Mock).toHaveReceivedCommandTimes(DescribeApplicationCommand, 1);
+    expect(mockClients.kinesisAnalyticsV2Mock).toHaveReceivedCommandTimes(UpdateApplicationCommand, 0);
+    expect(mockClients.kinesisAnalyticsV2Mock).toHaveReceivedCommandTimes(StopApplicationCommand, 1);
+  });
+  afterAll((done) => {
+    server.close();
+    done();
+  });
+});


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. check flink status before switch changed
2. move realtime api router to reporting and add auth
3. add cost tips

<img width="1132" alt="截屏2024-07-05 17 06 15" src="https://github.com/awslabs/clickstream-analytics-on-aws/assets/18416040/c5a991ca-619f-4c73-8c8b-fcbc100fde3a">

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend