### PR TITLE
fix: scale time of ecs fargate service and ingestion v2 output key

### DIFF
--- a/src/ingestion-server/common-resources/ingestion-common-resources.ts
+++ b/src/ingestion-server/common-resources/ingestion-common-resources.ts
@@ -123,6 +123,7 @@ export class IngestionCommonResources extends Construct {
 
     new CfnOutput(this, id + OUTPUT_INGESTION_SERVER_DNS_SUFFIX, {
       value: ingestionServerDNS,
+      key: id + OUTPUT_INGESTION_SERVER_DNS_SUFFIX,
       description: 'Server DNS',
     });
 
@@ -131,6 +132,7 @@ export class IngestionCommonResources extends Construct {
         `https://${props.domainName}${props.serverEndpointPath}`,
         `http://${ingestionServerDNS}${props.serverEndpointPath}`).toString(),
       description: 'Server Url',
+      key: id + OUTPUT_INGESTION_SERVER_URL_SUFFIX,
     });
   }
 }

--- a/src/ingestion-server/server-v2/private/ecs-fargate-service.ts
+++ b/src/ingestion-server/server-v2/private/ecs-fargate-service.ts
@@ -99,8 +99,8 @@ export class ECSFargateService extends AbstractECSService {
 
     scalableTarget.scaleOnCpuUtilization('CpuScaling', {
       targetUtilizationPercent: props.fleetProps.scaleOnCpuUtilizationPercent || 50,
-      scaleInCooldown: Duration.seconds(45),
-      scaleOutCooldown: Duration.seconds(1),
+      scaleInCooldown: Duration.minutes(45),
+      scaleOutCooldown: Duration.minutes(1),
     });
 
     const ecsServiceInfo: ECSFargateServiceResult = {

--- a/test/ingestion-server/server/ingestion-server-v2.test.ts
+++ b/test/ingestion-server/server/ingestion-server-v2.test.ts
@@ -140,6 +140,20 @@ test('ECS service ScalingPolicy is configured', () => {
   template.resourceCountIs('AWS::ApplicationAutoScaling::ScalingPolicy', 1);
 });
 
+test('ECS service ScalingPolicy ScaleInCooldown is 45 minutes and ScaleOutCooldown is 1 minute', () => {
+  const app = new App();
+  let commonTestStackProps = generateCommonTestStackProps();
+  commonTestStackProps.withMskConfig = true;
+  const stack = new TestStackV2(app, 'test', commonTestStackProps);
+  const template = Template.fromStack(stack);
+  const scalingPolicy = findFirstResource(
+    template,
+    'AWS::ApplicationAutoScaling::ScalingPolicy',
+  )?.resource;
+  expect(scalingPolicy.Properties.TargetTrackingScalingPolicyConfiguration.ScaleInCooldown == 2700).toBeTruthy();
+  expect(scalingPolicy.Properties.TargetTrackingScalingPolicyConfiguration.ScaleOutCooldown == 60).toBeTruthy();
+});
+
 test('The ECS service has one task which has two containers', () => {
   const app = new App();
   let commonTestStackProps = generateCommonTestStackProps();

--- a/test/ingestion-server/server/ingestion-server.test.ts
+++ b/test/ingestion-server/server/ingestion-server.test.ts
@@ -174,6 +174,21 @@ test('ECS service ScalingPolicy is configured', () => {
   template.resourceCountIs('AWS::ApplicationAutoScaling::ScalingPolicy', 1);
 });
 
+test('ECS service ScalingPolicy ScaleInCooldown is 45 minutes and ScaleOutCooldown is 1 minute', () => {
+  const app = new App();
+  const stack = new TestStack(app
+    , 'test', {
+      withMskConfig: true,
+    });
+  const template = Template.fromStack(stack);
+  const scalingPolicy = findFirstResource(
+    template,
+    'AWS::ApplicationAutoScaling::ScalingPolicy',
+  )?.resource;
+  expect(scalingPolicy.Properties.TargetTrackingScalingPolicyConfiguration.ScaleInCooldown == 2700).toBeTruthy();
+  expect(scalingPolicy.Properties.TargetTrackingScalingPolicyConfiguration.ScaleOutCooldown == 60).toBeTruthy();
+});
+
 test('ALB default protocol is http', () => {
   const app = new App();
   const stack = new TestStack(app, 'test', {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

fix scale time to minute for fargate, ingestion v2 output key


## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [x] deploy ingestion server
    - [ ] with MSK sink
    - [x] with KDS sink
    - [x] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend