### PR TITLE
chore: add ECS Fargate type in cost

### DIFF
--- a/docs/en/plan-deployment/cost.md
+++ b/docs/en/plan-deployment/cost.md
@@ -31,7 +31,7 @@ The following are cost estimations for monthly data volumes of 10/100/1000 RPS (
 Ingestion module includes the following cost components:
 
 - Application load balancer and public IPv4 addresses
-- EC2 for ECS
+- EC2 for ECS / Fargate for ECS
 - Data sink (Kinesis Data Streams | Kafka | Direct to S3)
 - S3 storage
 
@@ -42,6 +42,8 @@ Key assumptions include:
 - KDS configuration (on-demand, provision)
 - 10/100/1000RPS
 - Three public subnets are used
+
+### EC2 Type
 
 | Request Per Second | ALB cost | EC2 cost  |  Buffer type      | Buffer cost | S3 cost   |  Total (USD/Month) |
 | ------------------ | --- | ---  |  --------------   | ----------- | ---  |  --------- |
@@ -57,6 +59,23 @@ Key assumptions include:
 |                         |  $262.8   |  $122  |  Kinesis (Provisioned 10 shard)   |    $180         |   $14  |     $578.8  |
 |           |  $262.8   | $122  |      MSK (m5.large * 2, connector MCU * 2~3)              |      $590       |  $14  |     $988.8
 |           |  $262.8   | $122   |      None              |            |  $14   |     $398.8 
+
+### Fargate Type
+
+| Request Per Second | ALB cost | Fargate cost  |  Buffer type      | Buffer cost | S3 cost   |  Total (USD/Month) |
+| ------------------ | --- | ---  |  --------------   | ----------- | ---  |  --------- |
+| 10RPS (49GB/month)             |  $28.8  |  $18 |  Kinesis (On-Demand) |    $38       |   $3  |     $87.8  |
+|                    |  $28.8  |  $18 |  Kinesis (Provisioned 2 shard)   |      $22       |  $3   |   $71.8  |
+|                    |  $28.8  |  $18 |  MSK (m5.large * 2, connector MCU * 1)   |       $417      |   $3  |     $466.8   |
+|                         | $28.8    |  $18 |  None              |             |  $3    |      $49.8   |
+|100RPS (490GB/month)          |  $53.8  |  $18  |  Kinesis(On-demand)              |      $115       |  $4   |     $190.8 |
+|                         | $53.8    |   $18 |  Kinesis (Provisioned 2 shard)   |      $26       | $4    |     $101.8  |
+|           |   $53.8  |  $18  |   MSK (m5.large * 2, connector MCU * 1)              |      $417       |  $4   |     $492.8
+|           |   $53.8  |  $18 |      None              |             |  $4    |     $75.8
+|1000RPS (4900GB/month)          |   $262.8  |   $72 |      Kinesis(On-demand)              |      $1051       |  $14   |    $1399.8 |
+|                         |  $262.8   |  $72  |  Kinesis (Provisioned 10 shard)   |    $180         |   $14  |     $528.8  |
+|           |  $262.8   | $72  |      MSK (m5.large * 2, connector MCU * 2~3)              |      $590       |  $14  |     $938.8
+|           |  $262.8   | $72   |      None              |            |  $14   |     $348.8 
 
 ### Data transfer
 There are associated costs when data is transferred from EC2 to the downstream data sink. Below is an example of data transfer costs based on 1000 RPS and a 2KB request payload.

--- a/docs/zh/plan-deployment/cost.md
+++ b/docs/zh/plan-deployment/cost.md
@@ -33,7 +33,7 @@ weight: 1
 摄入模块包括以下成本组成部分：
 
 - 应用程序负载均衡器和公有IPv4地址
-- 用于ECS的EC2实例
+- 用于ECS的EC2实例 / 用于ECS的Fargate
 - 数据宿 - Data sink（Kinesis Data Streams | Kafka | 直接到S3）
 - S3存储
 - 数据传输出（DTO）
@@ -45,6 +45,8 @@ weight: 1
 - KDS配置（按需，预配）
 - 10/100/1000 RPS
 - 使用三个公有子网
+
+### EC2 类型
 
 | 每日数据量/每秒请求数（RPS） | ALB 费用  | EC2 费用 |  缓冲类型（Buffer type） | 缓冲费用（Buffer cost） | S3 费用   |   总计（美元/月） |
 | ------------------ | --- | ---- | ------------- | ----------- | ---  |  --------- |
@@ -61,6 +63,22 @@ weight: 1
 |           |  $262.8   | $122  |      MSK (m5.large * 2, connector MCU * 2~3)              |      $590       |  $14  |     $988.8
 |           |  $262.8   | $122 |      无缓冲              |            |  $14   |     $398.8
 
+### Fargate 类型
+
+| Request Per Second | ALB cost | Fargate cost  |  Buffer type      | Buffer cost | S3 cost   |  Total (USD/Month) |
+| ------------------ | --- | ---  |  --------------   | ----------- | ---  |  --------- |
+| 10RPS (49GB/month)             |  $28.8  |  $18 |  Kinesis (On-Demand) |    $38       |   $3  |     $87.8  |
+|                    |  $28.8  |  $18 |  Kinesis (Provisioned 2 shard)   |      $22       |  $3   |   $71.8  |
+|                    |  $28.8  |  $18 |  MSK (m5.large * 2, connector MCU * 1)   |       $417      |   $3  |     $466.8   |
+|                         | $28.8    |  $18 |  None              |             |  $3    |      $49.8   |
+|100RPS (490GB/month)          |  $53.8  |  $18  |  Kinesis(On-demand)              |      $115       |  $4   |     $190.8 |
+|                         | $53.8    |   $18 |  Kinesis (Provisioned 2 shard)   |      $26       | $4    |     $101.8  |
+|           |   $53.8  |  $18  |   MSK (m5.large * 2, connector MCU * 1)              |      $417       |  $4   |     $492.8
+|           |   $53.8  |  $18 |      None              |             |  $4    |     $75.8
+|1000RPS (4900GB/month)          |   $262.8  |   $72 |      Kinesis(On-demand)              |      $1051       |  $14   |    $1399.8 |
+|                         |  $262.8   |  $72  |  Kinesis (Provisioned 10 shard)   |    $180         |   $14  |     $528.8  |
+|           |  $262.8   | $72  |      MSK (m5.large * 2, connector MCU * 2~3)              |      $590       |  $14  |     $938.8
+|           |  $262.8   | $72   |      None              |            |  $14   |     $348.8 
 
 ### 数据传输
 当数据通过EC2发送到下游的数据宿，会产生数据的费用。下面是以1000RPS，每个请求的有效载荷为2KB为例的费用。

--- a/docs/zh/plan-deployment/cost.md
+++ b/docs/zh/plan-deployment/cost.md
@@ -65,7 +65,7 @@ weight: 1
 
 ### Fargate 类型
 
-| Request Per Second | ALB cost | Fargate cost  |  Buffer type      | Buffer cost | S3 cost   |  Total (USD/Month) |
+| 每日数据量/每秒请求数（RPS） | ALB 费用  | Fargate 费用 |  缓冲类型（Buffer type） | 缓冲费用（Buffer cost） | S3 费用   |   总计（美元/月） |
 | ------------------ | --- | ---  |  --------------   | ----------- | ---  |  --------- |
 | 10RPS (49GB/month)             |  $28.8  |  $18 |  Kinesis (On-Demand) |    $38       |   $3  |     $87.8  |
 |                    |  $28.8  |  $18 |  Kinesis (Provisioned 2 shard)   |      $22       |  $3   |   $71.8  |


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

update cost document for fargate

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend