### PR TITLE
tests: make spark ETL tests more stable when running in parallel

### DIFF
--- a/src/data-pipeline/spark-etl/build.gradle
+++ b/src/data-pipeline/spark-etl/build.gradle
@@ -9,6 +9,10 @@ buildscript {
   }
 }
 
+plugins {
+    id 'org.gradle.test-retry' version '1.5.2'
+}
+
 apply plugin: 'idea'
 apply plugin: 'java'
 apply plugin: 'application'
@@ -87,11 +91,43 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
+
 test {
     forkEvery = 1
-    maxParallelForks = Math.min(Runtime.runtime.availableProcessors().intdiv(2) ?: 1, 6)
+    maxParallelForks = Math.min(Runtime.runtime.availableProcessors().intdiv(2) ?: 1, 16)
     maxHeapSize = "4g"
     minHeapSize = "1g"
+
+    retry {
+        maxRetries = 3
+        maxFailures = 20
+        failOnPassedAfterRetry = false
+    }
+
+    testLogging {
+        showStandardStreams = false
+        showExceptions true
+        exceptionFormat "full"
+    }
+
+    beforeTest { descriptor ->
+        logger.lifecycle("Running test: ${descriptor}")
+    }
+
+    afterTest { descriptor, result -> 
+        logger.lifecycle("Finished test: ${descriptor} with result: ${result.resultType}")
+        if (result.resultType == TestResult.ResultType.FAILURE) {
+            logger.lifecycle("Test failed: ${descriptor}. Retrying in 3 seconds...")
+            Thread.sleep(3000)
+        }
+    }
+
+    afterSuite { desc, result ->
+        if (!desc.parent) {
+            logger.lifecycle("Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)")
+        }
+    }
+
 }
 
 application {

--- a/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/BaseSparkTest.java
+++ b/src/data-pipeline/spark-etl/src/test/java/software/aws/solution/clickstream/BaseSparkTest.java
@@ -149,6 +149,7 @@ public class BaseSparkTest extends BaseTest {
         System.setProperty(DATABASE_PROP, dbName);
         System.setProperty(USER_KEEP_DAYS_PROP, String.valueOf(365 * 100));
         System.setProperty(ITEM_KEEP_DAYS_PROP, String.valueOf(365 * 100));
+        System.setProperty("debug.local.path", "/tmp/spark-debug-" + UUID.randomUUID());
         String uniqueTempDir = "/tmp/spark-test-" + UUID.randomUUID();
 
         spark = SparkSession.builder()


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend