### PR TITLE
fix: update flink parallelism when app enable/disable streaming

### DIFF
--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -686,6 +686,15 @@ export class CPipeline {
       parameterKey: 'AppIds',
       parameterValue: appIds.join(','),
     });
+    let parallelism = '1';
+    if (appIds.length > 1) {
+      parallelism = appIds.length.toString();
+    }
+    updateList.push({
+      stackType: PipelineStackType.STREAMING,
+      parameterKey: 'Parallelism',
+      parameterValue: parallelism,
+    });
     // update workflow
     this.stackManager.updateWorkflowForApp(updateList);
     // create new execution

--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -1709,6 +1709,15 @@ export class CStreamingStack extends JSONObject {
   })
     TransformerName?: string;
 
+  @JSONObject.optional('1')
+  @JSONObject.custom( (stack :CStreamingStack, _key:string, _value:any) => {
+    if (!stack._resources?.appIds || stack._resources?.appIds.length === 0) {
+      return '1';
+    }
+    return stack._resources?.appIds.length.toString();
+  })
+    Parallelism?: string;
+
   @JSONObject.optional('')
   @JSONObject.custom( (stack:CStreamingStack, _key:string, _value:string) => {
     return getAppRegistryApplicationArn(stack._pipeline);

--- a/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
@@ -32,6 +32,11 @@ export function expectParameter(parameters: any, key: string, value: string | un
   console.log(`Expect Parameter: ${key}=${value}, Actual Parameter: ${parameter?.ParameterKey}=${parameter?.ParameterValue}`);
   return parameter?.ParameterValue === value;
 };
+export function expectJsonParameter(parameters: any, key: string, value: string | undefined) {
+  const parameter = parameters.find((p: any) => p.ParameterKey === key);
+  console.log(`Expect Parameter: ${key}=${value}, Actual Parameter: ${parameter?.ParameterKey}=${parameter?.ParameterValue}`);
+  return parameter?.ParameterValue === value;
+};
 
 export function mergeParameters(base: Parameter[], attach: Parameter[]) {
   // Deep Copy
@@ -1207,6 +1212,10 @@ export const STREAMING_BASE_PARAMETERS = [
   {
     ParameterKey: 'TransformerName',
     ParameterValue: 'clickstream',
+  },
+  {
+    ParameterKey: 'Parallelism',
+    ParameterValue: '1',
   },
 ];
 

--- a/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
@@ -2398,10 +2398,17 @@ describe('Workflow test', () => {
                       Streaming: replaceStackInputProps(StreamingStack,
                         {
                           StackName: `${getStackPrefix()}-Streaming-6666-6666`,
-                          Parameters: [
-                            ...STREAMING_BASE_PARAMETERS,
-                            APPREGISTRY_APPLICATION_ARN_PARAMETER,
-                          ],
+                          Parameters: mergeParameters(
+                            [
+                              ...STREAMING_BASE_PARAMETERS,
+                              APPREGISTRY_APPLICATION_ARN_PARAMETER,
+                            ],
+                            [
+                              {
+                                ParameterKey: 'Parallelism',
+                                ParameterValue: '2',
+                              },
+                            ]),
                           Tags: Tags,
                           TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/v1.0.0/default/streaming-ingestion-stack.template.json',
                         },


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend