### PR TITLE
chore: set the default RetentionHours of real-time events to 24 hours

### DIFF
--- a/frontend/public/locales/en-US/pipeline.json
+++ b/frontend/public/locales/en-US/pipeline.json
@@ -318,9 +318,7 @@
     "streamingTitle": "Real-time analysis settings",
     "streamingDesc": "Enable real-time analysis for this pipeline",
     "enableStreaming": "Enable real-time analysis",
-    "enableStreamingDesc": "Enabling real-time analysis will create the real-time data processing resources (i.e., Flink application) for this pipeline. Note that additional cost apply.",
-    "streamingDataRangeTitle": "Real-time data range",
-    "streamingDataRangeDesc": "Real-time data range is the period to keep the real-time data for, data exceed the data range will be deleted from the real-time data table and won’t be displayed in the dashboard."
+    "enableStreamingDesc": "Enabling real-time analysis will create the real-time data processing resources (i.e., Flink application) for this pipeline. Note that additional cost apply."
   },
   "detail": {
     "ingestion": "Ingestion",

--- a/frontend/public/locales/en-US/user.json
+++ b/frontend/public/locales/en-US/user.json
@@ -1,6 +1,7 @@
 {
   "labels": {
-    "title": "User",
+    "title": "Users",
+    "tableTitle": "User List",
     "tableColumnUserId": "User ID",
     "tableColumnName": "User name",
     "tableColumnRole": "Role",

--- a/frontend/public/locales/zh-CN/pipeline.json
+++ b/frontend/public/locales/zh-CN/pipeline.json
@@ -318,9 +318,7 @@
     "streamingTitle": "实时分析配置",
     "streamingDesc": "启用此管道的实时分析",
     "enableStreaming": "启用实时分析",
-    "enableStreamingDesc": "启用实时分析将为该管道创建实时数据处理资源（即Flink应用）。请注意，需要支付额外费用。",
-    "streamingDataRangeTitle": "实时数据范围",
-    "streamingDataRangeDesc": "实时数据范围是保留实时数据的时间段，超过数据范围的数据将从实时数据表中删除，不会显示在仪表板中。"
+    "enableStreamingDesc": "启用实时分析将为该管道创建实时数据处理资源（即Flink应用）。请注意，需要支付额外费用。"
   },
   "detail": {
     "ingestion": "数据摄取",

--- a/frontend/public/locales/zh-CN/user.json
+++ b/frontend/public/locales/zh-CN/user.json
@@ -1,6 +1,7 @@
 {
   "labels": {
     "title": "用户",
+    "tableTitle": "用户列表",
     "tableColumnUserId": "用户ID",
     "tableColumnName": "用户名",
     "tableColumnRole": "角色",

--- a/frontend/src/pages/pipelines/create/CreatePipeline.tsx
+++ b/frontend/src/pages/pipelines/create/CreatePipeline.tsx
@@ -968,10 +968,7 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
     } else {
       createPipelineObj.streaming = {
         appIdStreamList: pipelineInfo.streaming?.appIdStreamList ?? [],
-        retentionHours:
-          pipelineInfo.selectedStreamingDataRangeUnit?.value === 'day'
-            ? parseInt(pipelineInfo.streamingDataRangeValue) * 24
-            : parseInt(pipelineInfo.streamingDataRangeValue) || 1,
+        retentionHours: 24,
       };
     }
     return createPipelineObj;
@@ -1888,14 +1885,6 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
                   };
                 });
               }}
-              changeStreamingDataRangeValue={(value) => {
-                setPipelineInfo((prev) => {
-                  return {
-                    ...prev,
-                    streamingDataRangeValue: value,
-                  };
-                });
-              }}
             />
           ),
         },
@@ -2708,7 +2697,7 @@ const CreatePipeline: React.FC<CreatePipelineProps> = (
     pipelineInfo.enableStreaming =
       pipelineInfo.streaming?.appIdStreamList !== undefined;
     const reverseStreamingDataRange = reverseFreshnessInHour(
-      pipelineInfo.streaming?.retentionHours ?? 1
+      pipelineInfo.streaming?.retentionHours ?? 24
     );
     pipelineInfo.streamingDataRangeValue = reverseStreamingDataRange.value;
     pipelineInfo.selectedStreamingDataRangeUnit =

--- a/frontend/src/pages/pipelines/create/CreatePipeline.tsx
+++ b/frontend/src/pages/pipelines/create/CreatePipeline.tsx
@@ -968,7 +968,6 @@ const Content: React.FC<ContentProps> = (props: ContentProps) => {
     } else {
       createPipelineObj.streaming = {
         appIdStreamList: pipelineInfo.streaming?.appIdStreamList ?? [],
-        retentionHours: 24,
       };
     }
     return createPipelineObj;
@@ -2696,14 +2695,6 @@ const CreatePipeline: React.FC<CreatePipelineProps> = (
   const setUpdateStreaming = async (pipelineInfo: IExtPipeline) => {
     pipelineInfo.enableStreaming =
       pipelineInfo.streaming?.appIdStreamList !== undefined;
-    const reverseStreamingDataRange = reverseFreshnessInHour(
-      pipelineInfo.streaming?.retentionHours ?? 24
-    );
-    pipelineInfo.streamingDataRangeValue = reverseStreamingDataRange.value;
-    pipelineInfo.selectedStreamingDataRangeUnit =
-      EVENT_REFRESH_UNIT_LIST.filter(
-        (type) => type.value === reverseStreamingDataRange.unit
-      )[0];
   };
 
   const setUpdateQuickSightUser = async (pipelineInfo: IExtPipeline) => {

--- a/frontend/src/pages/pipelines/create/CreatePipeline.tsx
+++ b/frontend/src/pages/pipelines/create/CreatePipeline.tsx
@@ -59,7 +59,6 @@ import {
   DEFAULT_TRANSFORM_SDK_IDS,
   EIngestionType,
   ENetworkType,
-  EVENT_REFRESH_UNIT_LIST,
   EXCUTION_UNIT_LIST,
   EXECUTION_TYPE_LIST,
   ExecutionType,

--- a/frontend/src/pages/pipelines/create/steps/ConfigIngestion.tsx
+++ b/frontend/src/pages/pipelines/create/steps/ConfigIngestion.tsx
@@ -42,7 +42,6 @@ import {
   DEFAULT_MSK_SINK_INTERVAL,
   EIngestionType,
   ENetworkType,
-  EVENT_REFRESH_UNIT_LIST,
   MAX_KDS_BATCH_SIZE,
   MAX_KDS_SINK_INTERVAL,
   MAX_MSK_BATCH_SIZE,
@@ -66,7 +65,6 @@ import {
 } from 'ts/url';
 import {
   checkDisable,
-  defaultSelectOptions,
   defaultStr,
   isDisabled,
   isStreamingDisabled,
@@ -119,7 +117,6 @@ interface ConfigIngestionProps {
   changeAckownledge: () => void;
 
   changeEnableStreaming: (enable: boolean) => void;
-  changeStreamingDataRangeValue: (value: string) => void;
 
   publicSubnetError: boolean;
   privateSubnetError: boolean;
@@ -186,7 +183,6 @@ const ConfigIngestion: React.FC<ConfigIngestionProps> = (
     changeAckownledge,
     changeEnableALBAuthentication,
     changeEnableStreaming,
-    changeStreamingDataRangeValue,
     publicSubnetError,
     privateSubnetError,
     privateSubnetDiffWithPublicError,
@@ -222,13 +218,6 @@ const ConfigIngestion: React.FC<ConfigIngestionProps> = (
     useState<SelectProps.Options>([]);
   const [ssmSecretOptionList, setSsmSecretOptionList] =
     useState<SelectProps.Options>([]);
-  const [selectedStreamingDataRangeUnit, setSelectedStreamingDataRangeUnit] =
-    useState(
-      defaultSelectOptions(
-        EVENT_REFRESH_UNIT_LIST[0],
-        pipelineInfo.selectedStreamingDataRangeUnit
-      )
-    );
 
   // get subnet list
   const getSubnetListByRegionAndVPC = async (region: string, vpcId: string) => {
@@ -1065,39 +1054,6 @@ const ConfigIngestion: React.FC<ConfigIngestionProps> = (
               >
                 <b>{t('pipeline:create.enableStreaming')}</b>
               </Toggle>
-              <FormField
-                label={t('pipeline:create.streamingDataRangeTitle')}
-                description={t('pipeline:create.streamingDataRangeDesc')}
-              >
-                <div className="flex">
-                  <div style={{ width: 250 }}>
-                    <Input
-                      disabled={isStreamingDisabled(update, pipelineInfo)}
-                      type="number"
-                      placeholder="3"
-                      value={pipelineInfo.streamingDataRangeValue}
-                      onChange={(e) => {
-                        if (!POSITIVE_INTEGER_REGEX.test(e.detail.value)) {
-                          return false;
-                        }
-                        changeStreamingDataRangeValue(e.detail.value);
-                      }}
-                    />
-                  </div>
-                  <div className="ml-10">
-                    <Select
-                      disabled={isStreamingDisabled(update, pipelineInfo)}
-                      selectedOption={selectedStreamingDataRangeUnit}
-                      onChange={({ detail }) => {
-                        setSelectedStreamingDataRangeUnit(
-                          detail.selectedOption
-                        );
-                      }}
-                      options={EVENT_REFRESH_UNIT_LIST}
-                    />
-                  </div>
-                </div>
-              </FormField>
             </SpaceBetween>
           </SpaceBetween>
         </Container>

--- a/frontend/src/pages/projects/Projects.tsx
+++ b/frontend/src/pages/projects/Projects.tsx
@@ -198,6 +198,7 @@ const Projects: React.FC = () => {
       content={
         <ContentLayout
           headerVariant="high-contrast"
+          disableOverlap
           header={
             <ProjectsHeader
               totalProject={totalCount}

--- a/frontend/src/pages/user/UserHeader.tsx
+++ b/frontend/src/pages/user/UserHeader.tsx
@@ -15,9 +15,9 @@ import { Header } from '@cloudscape-design/components';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-const PluginHeader: React.FC = () => {
+const UserHeader: React.FC = () => {
   const { t } = useTranslation();
-  return <Header variant="h1">{t('plugin:plugins')}</Header>;
+  return <Header variant="h1">{t('user:labels.title')}</Header>;
 };
 
-export default PluginHeader;
+export default UserHeader;

--- a/frontend/src/pages/user/UserList.tsx
+++ b/frontend/src/pages/user/UserList.tsx
@@ -27,6 +27,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { IUserRole, TABLE_FILTER_OPTIONS, TIME_FORMAT } from 'ts/const';
 import { defaultStr } from 'ts/utils';
+import UserHeader from './UserHeader';
 import UserTable from './UserTable';
 
 interface IUserTableItem {
@@ -247,7 +248,7 @@ const UserList: React.FC = () => {
       headerVariant="high-contrast"
       toolsHide
       content={
-        <ContentLayout headerVariant="high-contrast">
+        <ContentLayout headerVariant="high-contrast" header={<UserHeader />}>
           <UserTable
             tableColumnDefinitions={COLUMN_DEFINITIONS}
             tableContentDisplay={CONTENT_DISPLAY}
@@ -255,7 +256,7 @@ const UserList: React.FC = () => {
             tableI18nStrings={{
               loadingText: t('user:labels.tableLoading') || 'Loading',
               emptyText: t('user:labels.tableEmpty'),
-              headerTitle: t('user:labels.title'),
+              headerTitle: t('user:labels.tableTitle'),
               filteringAriaLabel: t('user:labels.filteringAriaLabel'),
               filteringPlaceholder: t('user:labels.filteringPlaceholder'),
               groupPropertiesText: t('button.groupPropertiesText'),

--- a/frontend/src/pages/user/UserTableHeader.tsx
+++ b/frontend/src/pages/user/UserTableHeader.tsx
@@ -136,7 +136,7 @@ export function UserTableHeader({
         }
         {...props}
       >
-        {t('user:labels.title')}
+        {t('user:labels.tableTitle')}
       </Header>
     </div>
   );

--- a/frontend/src/types/pipeline.d.ts
+++ b/frontend/src/types/pipeline.d.ts
@@ -166,7 +166,7 @@ declare global {
     };
     timezone?: IAppTimezone[];
     streaming?: {
-      retentionHours: number;
+      retentionHours?: number;
       appIdStreamList: string[];
       appIdRealtimeList?: string[];
     };

--- a/frontend/test/service-available.test.tsx
+++ b/frontend/test/service-available.test.tsx
@@ -106,9 +106,6 @@ describe('Test AGA service available', () => {
         changeEnableStreaming={() => {
           return;
         }}
-        changeStreamingDataRangeValue={() => {
-          return;
-        }}
         changePublicSubnets={() => {
           return;
         }}
@@ -268,9 +265,6 @@ describe('Test AGA service available', () => {
           },
         }}
         changeEnableStreaming={() => {
-          return;
-        }}
-        changeStreamingDataRangeValue={() => {
           return;
         }}
         changePublicSubnets={() => {
@@ -1009,9 +1003,6 @@ describe('Test MSK service available', () => {
           },
         }}
         changeEnableStreaming={() => {
-          return;
-        }}
-        changeStreamingDataRangeValue={() => {
           return;
         }}
         changePublicSubnets={() => {

--- a/src/control-plane/backend/lambda/api/model/pipeline.ts
+++ b/src/control-plane/backend/lambda/api/model/pipeline.ts
@@ -222,7 +222,7 @@ export interface Reporting {
 }
 
 export interface Streaming {
-  readonly retentionHours: number;
+  readonly retentionHours?: number;
   readonly appIdStreamList: string[];
   readonly appIdRealtimeList?: string[];
   readonly bucket?: S3Bucket;

--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -1690,9 +1690,9 @@ export class CStreamingStack extends JSONObject {
   })
     RedshiftUserParam?: string;
 
-  @JSONObject.optional('1')
+  @JSONObject.optional('24')
   @JSONObject.custom( (stack :CStreamingStack, _key:string, _value:any) => {
-    return stack._pipeline?.streaming?.retentionHours ?? '1';
+    return stack._pipeline?.streaming?.retentionHours ?? '24';
   })
     RetentionHours?: string;
 

--- a/src/control-plane/backend/lambda/api/model/stacks.ts
+++ b/src/control-plane/backend/lambda/api/model/stacks.ts
@@ -1690,12 +1690,6 @@ export class CStreamingStack extends JSONObject {
   })
     RedshiftUserParam?: string;
 
-  @JSONObject.optional('24')
-  @JSONObject.custom( (stack :CStreamingStack, _key:string, _value:any) => {
-    return stack._pipeline?.streaming?.retentionHours ?? '24';
-  })
-    RetentionHours?: string;
-
   @JSONObject.optional(CLICKSTREAM_TRANSFORMER_NAME_PARAMETER)
   @JSONObject.custom( (stack :CStreamingStack, _key:string, _value:any) => {
     if (!stack._pipeline?.dataProcessing?.transformPlugin || stack._pipeline?.dataProcessing?.transformPlugin === 'BUILT-IN-1') {

--- a/src/control-plane/backend/lambda/api/service/application.ts
+++ b/src/control-plane/backend/lambda/api/service/application.ts
@@ -261,7 +261,6 @@ export class ApplicationServ {
       latestPipeline.streaming = {
         ...latestPipeline.streaming,
         appIdStreamList: streamEnableAppIds,
-        retentionHours: latestPipeline.streaming?.retentionHours ?? 1,
       };
       const pipeline = new CPipeline(latestPipeline);
       await pipeline.updateStreamingApp(streamEnableAppIds);

--- a/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
@@ -1201,10 +1201,6 @@ export const STREAMING_BASE_PARAMETERS = [
     ParameterValue: `#.${getStackPrefix()}-DataModelingRedshift-6666-6666.BIUserName`,
   },
   {
-    ParameterKey: 'RetentionHours',
-    ParameterValue: '24',
-  },
-  {
     ParameterKey: 'TransformerName',
     ParameterValue: 'clickstream',
   },

--- a/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-mock.ts
@@ -1202,7 +1202,7 @@ export const STREAMING_BASE_PARAMETERS = [
   },
   {
     ParameterKey: 'RetentionHours',
-    ParameterValue: '1',
+    ParameterValue: '24',
   },
   {
     ParameterKey: 'TransformerName',

--- a/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
@@ -2300,7 +2300,6 @@ describe('Workflow test', () => {
       ...cloneDeep(KINESIS_DATA_PROCESSING_NEW_REDSHIFT_QUICKSIGHT_PIPELINE),
       templateVersion: FULL_SOLUTION_VERSION,
       streaming: {
-        retentionHours: 24,
         appIdStreamList: ['app1', 'app2'],
         bucket: {
           name: 'EXAMPLE_BUCKET',

--- a/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
@@ -2300,7 +2300,7 @@ describe('Workflow test', () => {
       ...cloneDeep(KINESIS_DATA_PROCESSING_NEW_REDSHIFT_QUICKSIGHT_PIPELINE),
       templateVersion: FULL_SOLUTION_VERSION,
       streaming: {
-        retentionHours: 1,
+        retentionHours: 24,
         appIdStreamList: ['app1', 'app2'],
         bucket: {
           name: 'EXAMPLE_BUCKET',

--- a/src/streaming-ingestion/parameter.ts
+++ b/src/streaming-ingestion/parameter.ts
@@ -190,7 +190,7 @@ export function createStackParameters(scope: Construct): {
   const retentionHoursParam = new CfnParameter(scope, 'RetentionHours', {
     description: 'The retention hours of events in the event table',
     type: 'Number',
-    default: 1.0,
+    default: 24.0,
     minValue: 0.01,
   });
 

--- a/test/streaming-ingestion/streaming-ingestion-stack.test.ts
+++ b/test/streaming-ingestion/streaming-ingestion-stack.test.ts
@@ -199,7 +199,7 @@ describe('common parameter test of StreamingIngestionStack', () => {
   test('Should has Parameter RetentionHours', () => {
     template.hasParameter('RetentionHours', {
       Type: 'Number',
-      Default: 1.0,
+      Default: 24.0,
       MinValue: 0.01,
     });
   });


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [x] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend