### PR TITLE
chore: clear expired streaming data

### DIFF
--- a/src/analytics/private/sqls/redshift/sp-clear-expired-data.sql
+++ b/src/analytics/private/sqls/redshift/sp-clear-expired-data.sql
@@ -70,6 +70,11 @@ BEGIN
         END IF;        
 	END LOOP;
 
+    -- clean event streaming mv table expired records
+    IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'mv_tbl__ods_events_streaming_mv__0' AND schemaname = '{{schema}}') THEN
+        DELETE FROM {{schema}}.mv_tbl__ods_events_streaming_mv__0 WHERE approximate_arrival_timestamp < current_date - INTERVAL '1 day';
+    END IF;
+
 EXCEPTION WHEN OTHERS THEN
     CALL {{schema}}.{{sp_clickstream_log_non_atomic}}(log_name, 'error', 'error message:' || SQLERRM);    
 END;


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

clear expired streaming data, tested when mv_tbl__ods_events_streaming_mv__0 is existing and not

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend