### PR TITLE
chore: segments UI polish

### DIFF
--- a/frontend/public/locales/en-US/analytics.json
+++ b/frontend/public/locales/en-US/analytics.json
@@ -413,11 +413,11 @@
     "attributionSelectTouchpointEventInfo": "Events to be included in the attribution analysis, e.g., click events for promotion spot, landing page visits."
   },
   "segment": {
-    "title": "User Segments",
-    "desc": "User Segments description",
+    "title": "Segments",
+    "desc": "A segment is a subset of your users",
     "options": {
       "withInSession": "Within a session",
-      "withOutSession": "Without a session",
+      "withOutSession": "Across sessions",
       "directlyFollow": "Directly followed",
       "indirectlyFollow": "Indirectly followed"
     },
@@ -427,8 +427,8 @@
       "userIs": "User is",
       "userIsNot": "User is not",
       "doneInSequence": "User has done in sequence",
-      "userInGroup": "User in segment group",
-      "userNotInGroup": "User not in segment group"
+      "userInGroup": "User in segment",
+      "userNotInGroup": "User not in segment"
     },
     "calculateOption": {
       "NUMBER_OF_TOTAL": "Total number (PV)",
@@ -474,7 +474,9 @@
       "filterByTimeRange": "Filter by a date and time range",
       "appTimezone": "the app's timezone",
       "importSegmentTitle": "Import Segment",
-      "importSegmentDesc": "Define a segment, then import the segment manually"
+      "importSegmentDesc": "Define a segment, then import the segment manually",
+      "importSegmentGuideTitle": "Add users to segment",
+      "importSegmentGuide": "After saving the segment, please follow the <guide_anchor>guide</guide_anchor> to add users into the segment."
     },
     "details": {
       "title": "Segment Details",
@@ -498,7 +500,8 @@
       "segmentUserSample": "User Samples",
       "segmentUserSampleDesc": "User samples from latest completed segment refresh",
       "noSampleData": "No sample data available",
-      "importedSegment": "Imported Segment"
+      "importedSegment": "Imported Segment",
+      "segmentId": "Segment ID"
     },
     "valid": {
       "nameEmptyError": "Please input segment name.",

--- a/frontend/public/locales/zh-CN/analytics.json
+++ b/frontend/public/locales/zh-CN/analytics.json
@@ -413,13 +413,13 @@
     "attributionSelectTouchpointEventInfo": "参与归因分析的事件，通常为推广运营为的点击事件、落地页的进入。"
   },
   "segment": {
-    "title": "用户分群",
-    "desc": "用户分群描述",
+    "title": "分群",
+    "desc": "分群是您用户的一个子集",
     "options": {
       "withInSession": "在同一个会话",
-      "withOutSession": "不在同一个会话",
-      "directlyFollow": "直接关联",
-      "indirectlyFollow": "间接关联"
+      "withOutSession": "跨多个会话",
+      "directlyFollow": "直接跟随",
+      "indirectlyFollow": "间接跟随"
     },
     "type": {
       "userDone": "用户做过",
@@ -427,8 +427,8 @@
       "userIs": "用户是",
       "userIsNot": "用户不是",
       "doneInSequence": "用户依次做过",
-      "userInGroup": "用户在分群组",
-      "userNotInGroup": "用户不在分群组"
+      "userInGroup": "用户在分群",
+      "userNotInGroup": "用户不在分群"
     },
     "calculateOption": {
       "NUMBER_OF_TOTAL": "总次数 (PV)",
@@ -474,7 +474,9 @@
       "filterByTimeRange": "按日期和时间范围过滤",
       "appTimezone": "应用程序使用时区",
       "importSegmentTitle": "导入分群",
-      "importSegmentDesc": "自定义分群，并手动导入分群用户"
+      "importSegmentDesc": "自定义分群，并手动导入分群用户",
+      "importSegmentGuideTitle": "添加用户到分群中",
+      "importSegmentGuide": "保存分群后，请按照<guide_anchor>指南</guide_anchor>将用户添加到分群中。"
     },
     "details": {
       "title": "分群详细信息",
@@ -498,7 +500,8 @@
       "segmentUserSample": "用户取样",
       "segmentUserSampleDesc": "从最近一次分群刷新结果中取样的用户",
       "noSampleData": "无可用样例数据",
-      "importedSegment": "导入分群"
+      "importedSegment": "导入分群",
+      "segmentId": "分群ID"
     },
     "valid": {
       "nameEmptyError": "请输入分群名称。",

--- a/frontend/src/pages/analytics/analytics-utils.ts
+++ b/frontend/src/pages/analytics/analytics-utils.ts
@@ -29,6 +29,7 @@ import {
   MetadataValueType,
   OUTPUT_REPORTING_QUICKSIGHT_DATA_SOURCE_ARN,
   ParameterCondition,
+  Segment,
   SegmentCriteria,
   SegmentFilter,
   SegmentFilterConditionType,
@@ -1383,6 +1384,28 @@ export const convertCronExpByTimeRange = (
   }
 
   return '';
+};
+
+export const convertCronToRefreshSchedule = (
+  segment: Segment | undefined,
+  timezone: string
+) => {
+  if (!segment) {
+    return '';
+  }
+
+  const type = segment.refreshSchedule.cron;
+  if (type === 'Manual') {
+    return type;
+  } else if (type === 'Custom') {
+    return type + ' | ' + segment.refreshSchedule.cronExpression;
+  } else {
+    const segmentObj = segment.uiRenderingObject.segmentObject;
+    const day = defaultStr(segmentObj.autoRefreshDayOption?.label);
+    const time = defaultStr(segmentObj.autoRefreshTimeOption?.label);
+    const tz = moment.tz(timezone).format('z');
+    return `${type} | ${day} ${time} (${tz})`;
+  }
 };
 
 export const convertSegmentListToFilterOptions = (

--- a/frontend/src/pages/analytics/segments/ImportUserSegment.tsx
+++ b/frontend/src/pages/analytics/segments/ImportUserSegment.tsx
@@ -34,11 +34,7 @@ import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { INIT_SEGMENT_OBJ } from 'ts/const';
-import {
-  buildDocumentLink,
-  FAQ_LINK_CN,
-  FAQ_LINK_EN,
-} from 'ts/url';
+import { buildDocumentLink, FAQ_LINK_CN, FAQ_LINK_EN } from 'ts/url';
 import { defaultStr } from 'ts/utils';
 
 const ImportUserSegment: React.FC = () => {
@@ -193,7 +189,11 @@ const ImportUserSegment: React.FC = () => {
                       guide_anchor: (
                         <Link
                           external
-                          href={buildDocumentLink(i18n.language, FAQ_LINK_EN, FAQ_LINK_CN)}
+                          href={buildDocumentLink(
+                            i18n.language,
+                            FAQ_LINK_EN,
+                            FAQ_LINK_CN
+                          )}
                         />
                       ),
                     }}

--- a/frontend/src/pages/analytics/segments/ImportUserSegment.tsx
+++ b/frontend/src/pages/analytics/segments/ImportUserSegment.tsx
@@ -13,7 +13,9 @@
 
 import { Segment } from '@aws/clickstream-base-lib';
 import {
+  Alert,
   AppLayout,
+  Box,
   Button,
   Container,
   ContentLayout,
@@ -21,6 +23,7 @@ import {
   FormField,
   Header,
   Input,
+  Link,
   SpaceBetween,
 } from '@cloudscape-design/components';
 import { importSegment } from 'apis/segments';
@@ -28,13 +31,18 @@ import AnalyticsNavigation from 'components/layouts/AnalyticsNavigation';
 import CustomBreadCrumb from 'components/layouts/CustomBreadCrumb';
 import HelpInfo from 'components/layouts/HelpInfo';
 import React, { useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
+import { INIT_SEGMENT_OBJ } from 'ts/const';
+import {
+  buildDocumentLink,
+  FAQ_LINK_CN,
+  FAQ_LINK_EN,
+} from 'ts/url';
 import { defaultStr } from 'ts/utils';
-import { INIT_SEGMENT_OBJ } from '../../../ts/const';
 
 const ImportUserSegment: React.FC = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { projectId, appId } = useParams();
   const navigate = useNavigate();
   const [segmentName, setSegmentName] = useState<string>('');
@@ -174,6 +182,24 @@ const ImportUserSegment: React.FC = () => {
                   </SpaceBetween>
                 </Container>
               </Form>
+              <Box margin={{ top: 'xl' }}>
+                <Alert
+                  statusIconAriaLabel="Info"
+                  header={t('analytics:segment.comp.importSegmentGuideTitle')}
+                >
+                  <Trans
+                    i18nKey="analytics:segment.comp.importSegmentGuide"
+                    components={{
+                      guide_anchor: (
+                        <Link
+                          external
+                          href={buildDocumentLink(i18n.language, FAQ_LINK_EN, FAQ_LINK_CN)}
+                        />
+                      ),
+                    }}
+                  />
+                </Alert>
+              </Box>
             </ContentLayout>
           }
           headerSelector="#header"

--- a/frontend/src/pages/analytics/segments/UserSegmentDetails.tsx
+++ b/frontend/src/pages/analytics/segments/UserSegmentDetails.tsx
@@ -46,11 +46,11 @@ import {
 import AnalyticsNavigation from 'components/layouts/AnalyticsNavigation';
 import CustomBreadCrumb from 'components/layouts/CustomBreadCrumb';
 import HelpInfo from 'components/layouts/HelpInfo';
-import moment from 'moment-timezone';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { createDownloadLink, defaultStr, ternary } from 'ts/utils';
+import { convertCronToRefreshSchedule } from '../analytics-utils';
 
 const UserSegmentDetails: React.FC = () => {
   const { t } = useTranslation();
@@ -372,6 +372,12 @@ const UserSegmentDetails: React.FC = () => {
                           </div>
                           <div>
                             <Box variant="awsui-key-label">
+                              {t('analytics:segment.details.segmentId')}
+                            </Box>
+                            <Box margin={{ top: 'xxs' }}>{defaultStr(segment?.segmentId, '-')}</Box>
+                          </div>
+                          <div>
+                            <Box variant="awsui-key-label">
                               {t('analytics:segment.details.createdBy')}
                             </Box>
                             <Box margin={{ top: 'xxs' }}>
@@ -385,7 +391,7 @@ const UserSegmentDetails: React.FC = () => {
                               {t('analytics:segment.details.refreshSchedule')}
                             </Box>
                             <Box margin={{ top: 'xxs' }}>
-                              {getRefreshSchedule(segment, timezone)}
+                              {convertCronToRefreshSchedule(segment, timezone)}
                             </Box>
                           </div>
                           <div>
@@ -637,25 +643,6 @@ const UserSegmentDetails: React.FC = () => {
       </div>
     </div>
   );
-};
-
-const getRefreshSchedule = (segment, timezone) => {
-  if (!segment) {
-    return '';
-  }
-
-  const type = segment.refreshSchedule.cron;
-  if (type === 'Manual') {
-    return type;
-  } else if (type === 'Custom') {
-    return type + ' | ' + segment.refreshSchedule.cronExpression;
-  } else {
-    const segmentObj = segment.uiRenderingObject.segmentObject;
-    const day = segmentObj.autoRefreshDayOption?.label ?? '';
-    const time = segmentObj.autoRefreshTimeOption?.label ?? '';
-    const tz = moment.tz(timezone).format('z');
-    return `${type} | ${day} ${time}(${tz})`;
-  }
 };
 
 const getAutoRefreshExpiration = (

--- a/frontend/src/pages/analytics/segments/UserSegmentDetails.tsx
+++ b/frontend/src/pages/analytics/segments/UserSegmentDetails.tsx
@@ -374,7 +374,9 @@ const UserSegmentDetails: React.FC = () => {
                             <Box variant="awsui-key-label">
                               {t('analytics:segment.details.segmentId')}
                             </Box>
-                            <Box margin={{ top: 'xxs' }}>{defaultStr(segment?.segmentId, '-')}</Box>
+                            <Box margin={{ top: 'xxs' }}>
+                              {defaultStr(segment?.segmentId, '-')}
+                            </Box>
                           </div>
                           <div>
                             <Box variant="awsui-key-label">

--- a/frontend/src/pages/analytics/segments/UserSegments.tsx
+++ b/frontend/src/pages/analytics/segments/UserSegments.tsx
@@ -141,7 +141,7 @@ const UserSegments: React.FC = () => {
       const { timezone } = appApiResponse.data;
       setTimezone(timezone);
     }
-  }
+  };
 
   useEffect(() => {
     if (projectId && appId) {

--- a/frontend/src/pages/analytics/segments/UserSegments.tsx
+++ b/frontend/src/pages/analytics/segments/UserSegments.tsx
@@ -22,6 +22,7 @@ import {
   SpaceBetween,
   Table,
 } from '@cloudscape-design/components';
+import { getApplicationDetail } from 'apis/application';
 import { deleteSegment, getSegmentsList } from 'apis/segments';
 import AnalyticsNavigation from 'components/layouts/AnalyticsNavigation';
 import CustomBreadCrumb from 'components/layouts/CustomBreadCrumb';
@@ -32,6 +33,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { TIME_FORMAT } from 'ts/const';
 import { defaultStr } from 'ts/utils';
+import { convertCronToRefreshSchedule } from '../analytics-utils';
 
 const UserSegments: React.FC = () => {
   const { t } = useTranslation();
@@ -52,6 +54,7 @@ const UserSegments: React.FC = () => {
   const [segmentList, setSegmentList] = useState<Segment[]>([]);
   const [selectedSegment, setSelectedSegment] = useState<Segment[]>([]);
   const [loadingDelete, setLoadingDelete] = useState(false);
+  const [timezone, setTimezone] = useState('');
 
   const renderSegmentDetailsLink = (e: Segment) => {
     return (
@@ -80,7 +83,7 @@ const UserSegments: React.FC = () => {
       id: 'refreshSchedule',
       header: 'Refresh Schedule',
       cell: (e: Segment) => {
-        return e.refreshSchedule.cronExpression;
+        return convertCronToRefreshSchedule(e, timezone);
       },
     },
     {
@@ -129,9 +132,21 @@ const UserSegments: React.FC = () => {
     }
   };
 
+  const getTimezoneInfo = async (projectId: string, appId: string) => {
+    const appApiResponse = await getApplicationDetail({
+      id: appId,
+      pid: projectId,
+    });
+    if (appApiResponse.success) {
+      const { timezone } = appApiResponse.data;
+      setTimezone(timezone);
+    }
+  }
+
   useEffect(() => {
     if (projectId && appId) {
       listAllSegments();
+      getTimezoneInfo(projectId, appId);
     }
   }, [projectId, appId]);
 
@@ -174,10 +189,6 @@ const UserSegments: React.FC = () => {
                               window.location.href = hrefPath + 'edit';
                             } else if (e.detail.id === 'detail') {
                               navigate(hrefPath + 'details');
-                            } else if (e.detail.id === 'import') {
-                              navigate(
-                                `/analytics/${projectId}/app/${appId}/segments/import`
-                              );
                             }
                           }}
                           loading={loadingDelete}
@@ -206,14 +217,19 @@ const UserSegments: React.FC = () => {
                               id: 'delete',
                               disabled: selectedSegment.length === 0,
                             },
-                            {
-                              text: defaultStr(t('button.import')),
-                              id: 'import',
-                            },
                           ]}
                         >
                           {t('button.actions')}
                         </ButtonDropdown>
+                        <Button
+                          onClick={() => {
+                            navigate(
+                              `/analytics/${projectId}/app/${appId}/segments/import`
+                            );
+                          }}
+                        >
+                          {t('button.import')}
+                        </Button>
                         <Button
                           iconAlign="right"
                           iconName="add-plus"

--- a/frontend/src/pages/analytics/segments/components/SegmentEditor.tsx
+++ b/frontend/src/pages/analytics/segments/components/SegmentEditor.tsx
@@ -396,27 +396,31 @@ const SegmentEditor: React.FC<SegmentEditorProps> = (
               )}
             </FormField>
 
-            {segmentObject.refreshType === 'auto' && <FormField
-              label={t('analytics:segment.comp.expirationSettings')}
-              description={t('analytics:segment.comp.expirationSettingsDesc')}
-            >
-              <DatePicker
-                value={segmentObject.expireDate}
-                isDateEnabled={(date) => date.getTime() > new Date().getTime()}
-                onChange={(e) => {
-                  updateSegmentObject('expireDate', e.detail.value);
-                  updateSegmentObject('refreshSchedule', {
-                    ...segmentObject.refreshSchedule,
-                    expireAfter: ternary(
-                      e.detail.value,
-                      new Date(e.detail.value).getTime(),
-                      0
-                    ),
-                  });
-                }}
-                placeholder="YYYY/MM/DD"
-              />
-            </FormField>}
+            {segmentObject.refreshType === 'auto' && (
+              <FormField
+                label={t('analytics:segment.comp.expirationSettings')}
+                description={t('analytics:segment.comp.expirationSettingsDesc')}
+              >
+                <DatePicker
+                  value={segmentObject.expireDate}
+                  isDateEnabled={(date) =>
+                    date.getTime() > new Date().getTime()
+                  }
+                  onChange={(e) => {
+                    updateSegmentObject('expireDate', e.detail.value);
+                    updateSegmentObject('refreshSchedule', {
+                      ...segmentObject.refreshSchedule,
+                      expireAfter: ternary(
+                        e.detail.value,
+                        new Date(e.detail.value).getTime(),
+                        0
+                      ),
+                    });
+                  }}
+                  placeholder="YYYY/MM/DD"
+                />
+              </FormField>
+            )}
           </SpaceBetween>
         </Container>
 

--- a/frontend/src/pages/analytics/segments/components/SegmentEditor.tsx
+++ b/frontend/src/pages/analytics/segments/components/SegmentEditor.tsx
@@ -255,7 +255,7 @@ const SegmentEditor: React.FC<SegmentEditorProps> = (
                     updateSegmentObject('refreshSchedule', {
                       cron: 'Manual',
                       cronExpression: undefined,
-                      expireAfter: segmentObject.refreshSchedule.expireAfter,
+                      expireAfter: 0,
                     });
                   } else {
                     updateSegmentObject('autoRefreshOption', {
@@ -396,7 +396,7 @@ const SegmentEditor: React.FC<SegmentEditorProps> = (
               )}
             </FormField>
 
-            <FormField
+            {segmentObject.refreshType === 'auto' && <FormField
               label={t('analytics:segment.comp.expirationSettings')}
               description={t('analytics:segment.comp.expirationSettingsDesc')}
             >
@@ -416,7 +416,7 @@ const SegmentEditor: React.FC<SegmentEditorProps> = (
                 }}
                 placeholder="YYYY/MM/DD"
               />
-            </FormField>
+            </FormField>}
           </SpaceBetween>
         </Container>
 

--- a/src/base-lib/src/common/utils.ts
+++ b/src/base-lib/src/common/utils.ts
@@ -115,7 +115,7 @@ export const getDateTimeWithTimezoneString = (
 ) => {
   return moment
     .tz(moment(timestamp), timezone)
-    .format('YYYY-MM-DD HH:mm:ss(z)');
+    .format('YYYY-MM-DD HH:mm:ss (z)');
 };
 
 export const getLocaleDateString = (timestamp: number, timezone: string) => {

--- a/src/base-lib/test/utils.test.ts
+++ b/src/base-lib/test/utils.test.ts
@@ -35,7 +35,7 @@ describe('utils functions tests', () => {
   });
 
   test('returns locale date time with timezone', () => {
-    expect(getDateTimeWithTimezoneString(1714981584000, 'Asia/Shanghai')).toEqual('2024-05-06 15:46:24(CST)');
+    expect(getDateTimeWithTimezoneString(1714981584000, 'Asia/Shanghai')).toEqual('2024-05-06 15:46:24 (CST)');
   });
 
   test('returns locale date string', () => {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

1. Show readable string for Refresh Schedule in segment list page
2. Hide Expiration settings when Refresh method is Manual
3. Move Import button out of Actions dropdown
4. Add guide for import page, the link is a placeholder, will update after segments doc is updated
5. Some other UI polish and wording changes

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend