### PR TITLE
chore: use fixed stack name for ingestion server when using v2 template

### DIFF
--- a/src/common/model.ts
+++ b/src/common/model.ts
@@ -46,6 +46,7 @@ export interface ExecutionDetail {
 
 export enum PipelineStackType {
   INGESTION = 'Ingestion',
+  INGESTION_V2 = 'IngestionV2',
   KAFKA_CONNECTOR = 'KafkaConnector',
   DATA_PROCESSING = 'DataProcessing',
   DATA_MODELING_REDSHIFT = 'DataModelingRedshift',

--- a/src/control-plane/backend/lambda/api/common/utils.ts
+++ b/src/control-plane/backend/lambda/api/common/utils.ts
@@ -285,6 +285,8 @@ function getIngestionStackType(pipeline: IPipeline): PipelineStackType {
     const ingestionStackTemplateUrl = getIngestionStackTemplateUrl(pipeline.workflow?.Workflow, pipeline);
     if (ingestionStackTemplateUrl && ingestionStackTemplateUrl?.includes('/ingestion-server-v2-stack.template.json')) {
       return PipelineStackType.INGESTION_V2;
+    } else if (ingestionStackTemplateUrl) {
+      return PipelineStackType.INGESTION;
     }
   }
   if (SolutionVersion.Of(pipeline.templateVersion ?? FULL_SOLUTION_VERSION).greaterThanOrEqualTo(SolutionVersion.V_1_2_0)) {

--- a/src/control-plane/backend/lambda/api/config/dictionary.json
+++ b/src/control-plane/backend/lambda/api/config/dictionary.json
@@ -17,7 +17,7 @@
       "Ingestion_s3": "ingestion-server-s3-stack.template.json",
       "Ingestion_kafka": "ingestion-server-kafka-stack.template.json",
       "Ingestion_kinesis": "ingestion-server-kinesis-stack.template.json",
-      "Ingestion_v2": "ingestion-server-v2-stack.template.json",
+      "IngestionV2": "ingestion-server-v2-stack.template.json",
       "KafkaConnector": "kafka-s3-sink-stack.template.json",
       "DataProcessing": "data-pipeline-stack.template.json",
       "DataModelingRedshift": "data-analytics-redshift-stack.template.json",

--- a/src/control-plane/backend/lambda/api/service/reporting.ts
+++ b/src/control-plane/backend/lambda/api/service/reporting.ts
@@ -1485,9 +1485,8 @@ export class ReportingService {
       const streamingStack = await describeStack(
         pipeline.region,
         getStackName(
-          pipeline.pipelineId,
+          pipeline,
           PipelineStackType.STREAMING,
-          pipeline.ingestionServer.sinkType,
         ),
       );
       if (!streamingStack) {

--- a/src/control-plane/backend/lambda/api/service/stack.ts
+++ b/src/control-plane/backend/lambda/api/service/stack.ts
@@ -68,8 +68,7 @@ export class StackManager {
     this.execWorkflow.Workflow = this.setWorkflowType(this.execWorkflow.Workflow, WorkflowStateType.PASS);
 
     for (let item of updateList) {
-      const stackName = getStackName(
-        this.pipeline.pipelineId, item.stackType, this.pipeline.ingestionServer.sinkType);
+      const stackName = getStackName(this.pipeline, item.stackType);
       this.execWorkflow.Workflow = this.updateStackParameter(
         this.execWorkflow.Workflow, stackName, item.parameterKey, item.parameterValue, 'Update');
       // Update saveWorkflow AppIds Parameter
@@ -129,29 +128,29 @@ export class StackManager {
     }
     if (retryStackTypes.includes(PipelineStackType.INGESTION)) {
       retryStackNames.push(
-        getStackName(this.pipeline.pipelineId, PipelineStackType.KAFKA_CONNECTOR, this.pipeline.ingestionServer.sinkType),
+        getStackName(this.pipeline, PipelineStackType.KAFKA_CONNECTOR),
       );
       retryStackNames.push(
-        getStackName(this.pipeline.pipelineId, PipelineStackType.STREAMING, this.pipeline.ingestionServer.sinkType),
+        getStackName(this.pipeline, PipelineStackType.STREAMING),
       );
     }
     if (retryStackTypes.includes(PipelineStackType.DATA_PROCESSING)) {
       retryStackNames.push(
-        getStackName(this.pipeline.pipelineId, PipelineStackType.ATHENA, this.pipeline.ingestionServer.sinkType),
+        getStackName(this.pipeline, PipelineStackType.ATHENA),
       );
       retryStackNames.push(
-        getStackName(this.pipeline.pipelineId, PipelineStackType.DATA_MODELING_REDSHIFT, this.pipeline.ingestionServer.sinkType),
+        getStackName(this.pipeline, PipelineStackType.DATA_MODELING_REDSHIFT),
       );
       retryStackNames.push(
-        getStackName(this.pipeline.pipelineId, PipelineStackType.REPORTING, this.pipeline.ingestionServer.sinkType),
+        getStackName(this.pipeline, PipelineStackType.REPORTING),
       );
     }
     if (retryStackTypes.includes(PipelineStackType.ATHENA) || retryStackTypes.includes(PipelineStackType.DATA_MODELING_REDSHIFT)) {
       retryStackNames.push(
-        getStackName(this.pipeline.pipelineId, PipelineStackType.REPORTING, this.pipeline.ingestionServer.sinkType),
+        getStackName(this.pipeline, PipelineStackType.REPORTING),
       );
       retryStackNames.push(
-        getStackName(this.pipeline.pipelineId, PipelineStackType.STREAMING, this.pipeline.ingestionServer.sinkType),
+        getStackName(this.pipeline, PipelineStackType.STREAMING),
       );
     }
     return Array.from(new Set(retryStackNames));
@@ -342,8 +341,7 @@ export class StackManager {
         }
       }
     } else if (state.Type === WorkflowStateType.STACK && state.Data?.Input.StackName) {
-      if (state.Data.Input.StackName ===
-        getStackName(this.pipeline.pipelineId, PipelineStackType.INGESTION, this.pipeline.ingestionServer.sinkType)) {
+      if (state.Data.Input.StackName.includes(PipelineStackType.INGESTION)) {
         state.Data.Input.TemplateURL = templateUrl;
         state.Data.Input.Parameters = removeParameters(
           [

--- a/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
@@ -1657,7 +1657,7 @@ export const KINESIS_DATA_PROCESSING_NEW_REDSHIFT_UPDATE_PIPELINE_WITH_V2_INGEST
                   TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/feature-rel/main/default/ingestion-server-v2-stack.template.json',
                   Action: 'Create',
                   Parameters: [],
-                  StackName: `${getStackPrefix()}-Ingestion-kinesis-${MOCK_PIPELINE_ID}`,
+                  StackName: `${getStackPrefix()}-Ingestion-${MOCK_PIPELINE_ID}`,
                 },
                 Callback: {
                   BucketPrefix: `clickstream/workflow/${MOCK_EXECUTION_ID}`,

--- a/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline.test.ts
@@ -3906,7 +3906,8 @@ describe('Pipeline test', () => {
         expressionAttributeValues[':timezone'].L.length === 0 &&
         expressionAttributeValues[':templateVersion'].S === SolutionVersion.V_1_2_0.fullVersion &&
         expressionAttributeValues[':tags'].L[0].M.value.S === SolutionVersion.V_1_2_0.fullVersion &&
-        dataProcessingInput.M.Tags.L[1].M.Value.S === SolutionVersion.V_1_2_0.fullVersion &&
+        dataProcessingInput.M.Tags.L[0].M.Value.S === SolutionVersion.V_1_2_0.fullVersion &&
+        dataProcessingInput.M.Tags.L[1].M.Value.S === 'test-value' &&
         dataProcessingInput.M.Parameters.L[0].M.ParameterValue.S === 'software.aws.solution.clickstream.TransformerV3,software.aws.solution.clickstream.UAEnrichmentV2,software.aws.solution.clickstream.IPEnrichmentV2,test.aws.solution.main' &&
         reportInput.M.Parameters.L[0].M.ParameterValue.S === 'Admin/fakeUser' &&
         reportInput.M.Parameters.L[1].M.ParameterValue.S === 'arn:aws:quicksight:us-west-2:555555555555:user/default/Admin/fakeUser' &&

--- a/src/control-plane/backend/lambda/api/test/api/workflow-version.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow-version.test.ts
@@ -161,7 +161,12 @@ describe('Workflow test with pipeline version', () => {
                   {
                     StartAt: 'Ingestion',
                     States: {
-                      Ingestion: setTagsToStack(IngestionStack, Tags),
+                      Ingestion: replaceStackInputProps(
+                        setTagsToStack(IngestionStack, Tags),
+                        {
+                          StackName: 'test-prefix-Clickstream-Ingestion-6666-6666',
+                        },
+                      ),
                     },
                   },
                   {
@@ -831,7 +836,12 @@ describe('Workflow test with pipeline version in China region', () => {
                   {
                     StartAt: 'Ingestion',
                     States: {
-                      Ingestion: setTagsToStack(IngestionStackCn, Tags),
+                      Ingestion: replaceStackInputProps(
+                        setTagsToStack(IngestionStackCn, Tags),
+                        {
+                          StackName: 'test-prefix-Clickstream-Ingestion-6666-6666',
+                        },
+                      ),
                     },
                   },
                   {

--- a/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
@@ -211,7 +211,7 @@ describe('Workflow test', () => {
                     States: {
                       Ingestion: replaceStackInputProps(IngestionStack,
                         {
-                          StackName: `${getStackPrefix()}-Ingestion-s3-6666-6666`,
+                          StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                           Parameters: [
                             ...INGESTION_S3_PARAMETERS,
                             APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -289,7 +289,7 @@ describe('Workflow test', () => {
                     States: {
                       Ingestion: replaceStackInputProps(IngestionStack,
                         {
-                          StackName: `${getStackPrefix()}-Ingestion-s3-6666-6666`,
+                          StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                           Parameters: [
                             ...INGESTION_S3_PRIVATE_PARAMETERS,
                             APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -366,7 +366,7 @@ describe('Workflow test', () => {
                     States: {
                       Ingestion: replaceStackInputProps(setTagsWithVersion(IngestionStack, SolutionVersion.V_1_2_0),
                         {
-                          StackName: `${getStackPrefix()}-Ingestion-s3-6666-6666`,
+                          StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                           Parameters: [
                             ...INGESTION_S3_FARGATE_PARAMETERS,
                             APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -448,7 +448,7 @@ describe('Workflow test', () => {
                     States: {
                       Ingestion: replaceStackInputProps(IngestionStack,
                         {
-                          StackName: `${getStackPrefix()}-Ingestion-s3-6666-6666`,
+                          StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                           Parameters: removeParameters([
                             ...INGESTION_S3_FARGATE_PARAMETERS,
                             APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -537,7 +537,7 @@ describe('Workflow test', () => {
                     States: {
                       Ingestion: replaceStackInputProps(IngestionStack,
                         {
-                          StackName: `${getStackPrefix()}-Ingestion-s3-6666-6666`,
+                          StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                           Parameters: [
                             ...INGESTION_S3_PARAMETERS,
                             APPREGISTRY_APPLICATION_EMPTY_ARN_PARAMETER,
@@ -612,7 +612,7 @@ describe('Workflow test', () => {
                     States: {
                       Ingestion: replaceStackInputProps(IngestionStack,
                         {
-                          StackName: `${getStackPrefix()}-Ingestion-kafka-6666-6666`,
+                          StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                           Parameters: [
                             ...INGESTION_KAFKA_PARAMETERS,
                             APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -687,7 +687,7 @@ describe('Workflow test', () => {
                       Ingestion: replaceStackProps(
                         replaceStackInputProps(IngestionStack,
                           {
-                            StackName: `${getStackPrefix()}-Ingestion-kafka-6666-6666`,
+                            StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                             Parameters: [
                               ...INGESTION_KAFKA_PARAMETERS,
                               APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -799,7 +799,7 @@ describe('Workflow test', () => {
                       Ingestion: replaceStackProps(
                         replaceStackInputProps(IngestionStack,
                           {
-                            StackName: `${getStackPrefix()}-Ingestion-kafka-6666-6666`,
+                            StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                             Parameters: [
                               ...INGESTION_MSK_PARAMETERS,
                               APPREGISTRY_APPLICATION_EMPTY_ARN_PARAMETER,
@@ -901,7 +901,7 @@ describe('Workflow test', () => {
                     States: {
                       Ingestion: replaceStackInputProps(IngestionStack,
                         {
-                          StackName: `${getStackPrefix()}-Ingestion-kinesis-6666-6666`,
+                          StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                           Parameters: [
                             ...INGESTION_KINESIS_ON_DEMAND_PARAMETERS,
                             APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -985,7 +985,7 @@ describe('Workflow test', () => {
                     States: {
                       Ingestion: replaceStackInputProps(IngestionStack,
                         {
-                          StackName: `${getStackPrefix()}-Ingestion-kinesis-6666-6666`,
+                          StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                           Parameters: [
                             ...INGESTION_KINESIS_PROVISIONED_PARAMETERS,
                             APPREGISTRY_APPLICATION_EMPTY_ARN_PARAMETER,
@@ -1060,7 +1060,7 @@ describe('Workflow test', () => {
                     States: {
                       Ingestion: replaceStackInputProps(IngestionStack,
                         {
-                          StackName: `${getStackPrefix()}-Ingestion-s3-6666-6666`,
+                          StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                           Parameters: [
                             ...INGESTION_S3_PARAMETERS,
                             APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -1150,7 +1150,7 @@ describe('Workflow test', () => {
                     States: {
                       Ingestion: replaceStackInputProps(IngestionStack,
                         {
-                          StackName: `${getStackPrefix()}-Ingestion-s3-6666-6666`,
+                          StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                           Parameters: [
                             ...INGESTION_S3_WITH_SPECIFY_PREFIX_PARAMETERS,
                             APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -1258,7 +1258,7 @@ describe('Workflow test', () => {
                       Ingestion: replaceStackProps(
                         replaceStackInputProps(IngestionStack,
                           {
-                            StackName: `${getStackPrefix()}-Ingestion-kafka-6666-6666`,
+                            StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                             Parameters: [
                               ...INGESTION_MSK_PARAMETERS,
                               APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -1392,7 +1392,7 @@ describe('Workflow test', () => {
                       Ingestion: replaceStackProps(
                         replaceStackInputProps(IngestionStack,
                           {
-                            StackName: `${getStackPrefix()}-Ingestion-kafka-6666-6666`,
+                            StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                             Parameters: [
                               ...INGESTION_MSK_PARAMETERS,
                               APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -1541,7 +1541,7 @@ describe('Workflow test', () => {
                     States: {
                       Ingestion: replaceStackInputProps(IngestionStack,
                         {
-                          StackName: `${getStackPrefix()}-Ingestion-kinesis-6666-6666`,
+                          StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                           Parameters: [
                             ...INGESTION_KINESIS_ON_DEMAND_PARAMETERS,
                             APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -1647,7 +1647,7 @@ describe('Workflow test', () => {
                     States: {
                       Ingestion: replaceStackInputProps(IngestionStack,
                         {
-                          StackName: `${getStackPrefix()}-Ingestion-kinesis-6666-6666`,
+                          StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                           Parameters: [
                             ...INGESTION_KINESIS_ON_DEMAND_PARAMETERS,
                             APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -1775,7 +1775,7 @@ describe('Workflow test', () => {
                     States: {
                       Ingestion: replaceStackInputProps(IngestionStack,
                         {
-                          StackName: `${getStackPrefix()}-Ingestion-kinesis-6666-6666`,
+                          StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                           Parameters: [
                             ...INGESTION_KINESIS_ON_DEMAND_PARAMETERS,
                             APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -1933,7 +1933,7 @@ describe('Workflow test', () => {
                     States: {
                       Ingestion: replaceStackInputProps(IngestionStack,
                         {
-                          StackName: `${getStackPrefix()}-Ingestion-kinesis-6666-6666`,
+                          StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                           Parameters: [
                             ...INGESTION_KINESIS_ON_DEMAND_PARAMETERS,
                             APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -2078,7 +2078,7 @@ describe('Workflow test', () => {
                     States: {
                       Ingestion: replaceStackInputProps(IngestionStack,
                         {
-                          StackName: `${getStackPrefix()}-Ingestion-kinesis-6666-6666`,
+                          StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                           Parameters: [
                             ...INGESTION_THIRDPARTY_SDK_KINESIS_ON_DEMAND_PARAMETERS,
                             APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -2201,7 +2201,7 @@ describe('Workflow test', () => {
                     States: {
                       Ingestion: replaceStackInputProps(IngestionStack,
                         {
-                          StackName: `${getStackPrefix()}-Ingestion-kinesis-6666-6666`,
+                          StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                           Parameters: [
                             ...INGESTION_KINESIS_ON_DEMAND_PARAMETERS,
                             APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -2338,7 +2338,7 @@ describe('Workflow test', () => {
                     States: {
                       Ingestion: replaceStackInputProps(IngestionStack,
                         {
-                          StackName: `${getStackPrefix()}-Ingestion-kinesis-6666-6666`,
+                          StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                           Parameters: [
                             ...INGESTION_KINESIS_ON_DEMAND_PARAMETERS,
                             APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -2397,10 +2397,18 @@ describe('Workflow test', () => {
                       Streaming: replaceStackInputProps(StreamingStack,
                         {
                           StackName: `${getStackPrefix()}-Streaming-6666-6666`,
-                          Parameters: [
-                            ...STREAMING_BASE_PARAMETERS,
-                            APPREGISTRY_APPLICATION_ARN_PARAMETER,
-                          ],
+                          Parameters: mergeParameters(
+                            [
+                              ...STREAMING_BASE_PARAMETERS,
+                              APPREGISTRY_APPLICATION_ARN_PARAMETER,
+                            ],
+                            [
+                              {
+                                ParameterKey: 'KinesisSourceStreamArn.#',
+                                ParameterValue: `#.${getStackPrefix()}-Ingestion-6666-6666.KinesisArn`,
+                              },
+                            ],
+                          ),
                           Tags: Tags,
                           TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main/v1.0.0/default/streaming-ingestion-stack.template.json',
                         },
@@ -2486,7 +2494,7 @@ describe('Workflow test', () => {
                       Ingestion: replaceStackProps(
                         replaceStackInputProps(IngestionStack,
                           {
-                            StackName: `${getStackPrefix()}-Ingestion-kafka-6666-6666`,
+                            StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                             Parameters: [
                               ...INGESTION_MSK_WITHOUT_APP_PARAMETERS,
                               APPREGISTRY_APPLICATION_ARN_PARAMETER,
@@ -4482,7 +4490,7 @@ describe('Workflow test', () => {
                   Input: {
                     Action: 'Create',
                     Region: 'ap-northeast-1',
-                    StackName: 'Clickstream-Ingestion-kinesis-80a00964678e487d8425bca0000f5d08',
+                    StackName: 'Clickstream-Ingestion-80a00964678e487d8425bca0000f5d08',
                     TemplateURL: 'https://EXAMPLE-BUCKET.s3.us-east-1.amazonaws.com/clickstream-branch-main-express/v0.8.0-main-202305281546-dc6d410d/default/ingestion-server-kinesis-stack.template.json',
                     Parameters: [],
                     Tags: [],
@@ -4932,7 +4940,7 @@ describe('Workflow test with boundary', () => {
                     States: {
                       Ingestion: replaceStackInputProps(IngestionStack,
                         {
-                          StackName: `${getStackPrefix()}-Ingestion-s3-6666-6666`,
+                          StackName: `${getStackPrefix()}-Ingestion-6666-6666`,
                           Parameters: [
                             ...INGESTION_S3_PARAMETERS,
                             APPREGISTRY_APPLICATION_ARN_PARAMETER,


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [x] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend