### PR TITLE
chore: change repo name to clickstream-proxy and clickstream-worker

### DIFF
--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -302,13 +302,13 @@ do_cmd mkdir -p $image_root_dir
 
 # copy nginx image to the deployment folder
 nginx_image_source_path="$source_dir/src/ingestion-server/server/images/nginx"
-nginx_image_dist_path="$image_root_dir/clickstream-nginx"
+nginx_image_dist_path="$image_root_dir/clickstream-proxy"
 do_cmd cp -rf $nginx_image_source_path $nginx_image_dist_path
 do_replace_1 $nginx_image_dist_path/Dockerfile \$PLATFORM_ARG ${SOLUTION_ECR_IMAGE_PLATFORM}
 
 # copy vector image to the deployment folder
 vector_image_source_path="$source_dir/src/ingestion-server/server/images/vector"
-vector_image_dist_path="$image_root_dir/clickstream-vector"
+vector_image_dist_path="$image_root_dir/clickstream-worker"
 do_cmd cp -rf $vector_image_source_path $vector_image_dist_path
 do_replace_1 $vector_image_dist_path/Dockerfile \$PLATFORM_ARG ${SOLUTION_ECR_IMAGE_PLATFORM}
 

--- a/deployment/cdk-solution-helper/index.js
+++ b/deployment/cdk-solution-helper/index.js
@@ -199,9 +199,7 @@ function updateECRImagesForECSTaskDefinition(template) {
     const resourceName = tDef.Metadata['aws:cdk:path'].split("/").slice(-2, -1);
     for (let cDef of tDef.Properties.ContainerDefinitions) {
       const cName = cDef.Name;
-      // TODO change back to cName
-      const repoSuffix = cName === 'worker' ? 'vector' : 'nginx';
-      const newImage = `%%PUBLIC_ECR_REGISTRY%%/clickstream-${repoSuffix}:%%PUBLIC_ECR_TAG%%`;
+      const newImage = `%%PUBLIC_ECR_REGISTRY%%/clickstream-${cName}:%%PUBLIC_ECR_TAG%%`;
 
       cDef.Image["Fn::Sub"] = newImage;
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend