### PR TITLE
fix: change the download url of kafka s3 connector plugin

### DIFF
--- a/src/kafka-s3-connector-stack.ts
+++ b/src/kafka-s3-connector-stack.ts
@@ -107,7 +107,7 @@ export class KafkaS3SinkConnectorStack extends Stack {
       minValue: 1,
     });
 
-    const defaultPluginUrl = 'https://d1i4a15mxbxib1.cloudfront.net/api/plugins/confluentinc/kafka-connect-s3/versions/10.2.2/confluentinc-kafka-connect-s3-10.2.2.zip';
+    const defaultPluginUrl = 'https://d2p6pa21dvn84.cloudfront.net/api/plugins/confluentinc/kafka-connect-s3/versions/10.2.2/confluentinc-kafka-connect-s3-10.2.2.zip';
     const pluginUrlParam = new CfnParameter(this, 'PluginUrl', {
       description: 'S3 sink plugin download url',
       type: 'String',

--- a/test/ingestion-server/kafka-s3-connector/kafka-s3-connector-stack.test.ts
+++ b/test/ingestion-server/kafka-s3-connector/kafka-s3-connector-stack.test.ts
@@ -68,7 +68,7 @@ test('Parameters settings are as expected', () => {
     [
       'PluginUrl',
       'String',
-      'https://d1i4a15mxbxib1.cloudfront.net/api/plugins/confluentinc/kafka-connect-s3/versions/10.2.2/confluentinc-kafka-connect-s3-10.2.2.zip',
+      'https://d2p6pa21dvn84.cloudfront.net/api/plugins/confluentinc/kafka-connect-s3/versions/10.2.2/confluentinc-kafka-connect-s3-10.2.2.zip',
     ],
     ['RotateIntervalMS', 'Number', '3000000'],
     ['FlushSize', 'Number', '50000'],


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

change kafka connector plugin endpoint according below document

https://docs.confluent.io/platform/current/connect/confluent-hub/index.html

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [x] deploy ingestion server
    - [x] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend