### PR TITLE
fix: dashboard create failed when reporting user arn is empty

### DIFF
--- a/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
+++ b/src/control-plane/backend/lambda/api/store/aws/quicksight.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-import { DASHBOARD_ADMIN_PERMISSION_ACTIONS, DATASET_ADMIN_PERMISSION_ACTIONS, DEFAULT_DASHBOARD_NAME_PREFIX, FOLDER_CONTRIBUTOR_PERMISSION_ACTIONS, FOLDER_OWNER_PERMISSION_ACTIONS, QUICKSIGHT_DASHBOARD_INFIX, QUICKSIGHT_DATASET_INFIX, QUICKSIGHT_RESOURCE_NAME_PREFIX, SolutionVersion, sleep } from '@aws/clickstream-base-lib';
+import { DASHBOARD_ADMIN_PERMISSION_ACTIONS, DATASET_ADMIN_PERMISSION_ACTIONS, DEFAULT_DASHBOARD_NAME_PREFIX, FOLDER_CONTRIBUTOR_PERMISSION_ACTIONS, FOLDER_OWNER_PERMISSION_ACTIONS, QUICKSIGHT_DASHBOARD_INFIX, QUICKSIGHT_DATASET_INFIX, QUICKSIGHT_RESOURCE_NAME_PREFIX, SolutionVersion, isEmpty, sleep } from '@aws/clickstream-base-lib';
 import {
   IdentityType,
   UserRole,
@@ -275,9 +275,9 @@ export const getClickstreamUserArn = async (templateVersion: SolutionVersion, us
   const isChinaRegion = process.env.AWS_REGION?.startsWith('cn');
   const quickSightEmbedRoleName = QuickSightEmbedRoleArn?.split(':role/')[1];
   const partition = isChinaRegion ? 'aws-cn' : 'aws';
-  const publishUserName = userArn ? userArn.split('/').pop() :
+  const publishUserName = !isEmpty(userArn) ? userArn!.split('/').pop() :
     `${quickSightEmbedRoleName}/${QUICKSIGHT_PUBLISH_USER_NAME}`;
-  const publishUserArn = userArn ?? `arn:${partition}:quicksight:${identityRegion}:${awsAccountId}:user/${QUICKSIGHT_NAMESPACE}/${publishUserName}`;
+  const publishUserArn = isEmpty(userArn) ? `arn:${partition}:quicksight:${identityRegion}:${awsAccountId}:user/${QUICKSIGHT_NAMESPACE}/${publishUserName}` : userArn;
 
   if (templateVersion.greaterThan(SolutionVersion.V_1_1_4)) {
     // remove explore user
@@ -289,9 +289,9 @@ export const getClickstreamUserArn = async (templateVersion: SolutionVersion, us
     };
   }
 
-  const exploreUserName = userArn ? userArn.split('/').pop() :
+  const exploreUserName = !isEmpty(userArn) ? userArn!.split('/').pop() :
     `${quickSightEmbedRoleName}/${QUICKSIGHT_EXPLORE_USER_NAME}`;
-  const exploreUserArn = userArn ?? `arn:${partition}:quicksight:${identityRegion}:${awsAccountId}:user/${QUICKSIGHT_NAMESPACE}/${exploreUserName}`;
+  const exploreUserArn = isEmpty(userArn) ? `arn:${partition}:quicksight:${identityRegion}:${awsAccountId}:user/${QUICKSIGHT_NAMESPACE}/${exploreUserName}` : userArn;
   return {
     publishUserArn: publishUserArn ?? '',
     publishUserName: publishUserName ?? '',

--- a/src/control-plane/backend/lambda/api/test/api/analytics-dashboard.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/analytics-dashboard.test.ts
@@ -47,7 +47,6 @@ describe('Analytics dashboard test', () => {
     quickSightMock.on(CreateAnalysisCommand).resolves({});
     quickSightMock.on(CreateFolderMembershipCommand).resolves({});
     quickSightMock.on(CreateDashboardCommand).callsFake(input => {
-      console.log(input.Permissions[0].Principal);
       expect(
         input.Permissions[0].Principal === 'arn:aws:quicksight:us-east-1:555555555555:user/default/QuickSightEmbeddingRole/ClickstreamPublishUser',
       ).toBeTruthy();

--- a/src/control-plane/backend/lambda/api/test/api/analytics-dashboard.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/analytics-dashboard.test.ts
@@ -69,8 +69,8 @@ describe('Analytics dashboard test', () => {
     expect(res.body.message).toEqual('Dashboard created.');
     expect(res.body.success).toEqual(true);
     expect(quickSightMock).toHaveReceivedCommandTimes(CreateDataSetCommand, 1);
-    expect(quickSightMock).toHaveReceivedCommandTimes(CreateAnalysisCommand, 0);
     expect(quickSightMock).toHaveReceivedCommandTimes(CreateDashboardCommand, 1);
+    expect(quickSightMock).toHaveReceivedCommandTimes(CreateAnalysisCommand, 0);
     expect(quickSightMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 1);
     expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
     expect(ddbMock).toHaveReceivedCommandTimes(QueryCommand, 1);

--- a/src/control-plane/backend/lambda/api/test/api/analytics-dashboard.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/analytics-dashboard.test.ts
@@ -44,10 +44,14 @@ describe('Analytics dashboard test', () => {
     });
     ddbMock.on(PutCommand).resolvesOnce({});
     quickSightMock.on(CreateDataSetCommand).resolvesOnce({});
-    quickSightMock.on(CreateDashboardCommand).resolvesOnce({});
-    quickSightMock.on(CreateDashboardCommand).resolves({});
     quickSightMock.on(CreateAnalysisCommand).resolves({});
     quickSightMock.on(CreateFolderMembershipCommand).resolves({});
+    quickSightMock.on(CreateDashboardCommand).callsFake(input => {
+      console.log(input.Permissions[0].Principal);
+      expect(
+        input.Permissions[0].Principal === 'arn:aws:quicksight:us-east-1:555555555555:user/default/QuickSightEmbeddingRole/ClickstreamPublishUser',
+      ).toBeTruthy();
+    });
     const res = await request(app)
       .post(`/api/project/${MOCK_PROJECT_ID}/${MOCK_APP_ID}/dashboard`)
       .set('X-Click-Stream-Request-Id', MOCK_TOKEN)
@@ -66,8 +70,8 @@ describe('Analytics dashboard test', () => {
     expect(res.body.message).toEqual('Dashboard created.');
     expect(res.body.success).toEqual(true);
     expect(quickSightMock).toHaveReceivedCommandTimes(CreateDataSetCommand, 1);
-    expect(quickSightMock).toHaveReceivedCommandTimes(CreateDashboardCommand, 1);
     expect(quickSightMock).toHaveReceivedCommandTimes(CreateAnalysisCommand, 0);
+    expect(quickSightMock).toHaveReceivedCommandTimes(CreateDashboardCommand, 1);
     expect(quickSightMock).toHaveReceivedCommandTimes(CreateFolderMembershipCommand, 1);
     expect(ddbMock).toHaveReceivedCommandTimes(GetCommand, 1);
     expect(ddbMock).toHaveReceivedCommandTimes(QueryCommand, 1);


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend