### PR TITLE
chore: update event attribute description to remove html tag

### DIFF
--- a/src/analytics/private/sqls/redshift/event-v2.sql
+++ b/src/analytics/private/sqls/redshift/event-v2.sql
@@ -110,7 +110,7 @@ CREATE TABLE IF NOT EXISTS {{schema}}.event_v2 (
     screen_view_previous_screen_id  varchar(255),
     -- METADATA {"name":"screen_view_previous_screen_unique_id","dataType":"string","scanValue":"false","category":"{{{category_screen_view}}}","displayName":{"en-US":"Previous screen unique ID","zh-CN":"上一个屏幕唯一ID"},"description":{"en-US":"The unique ID of previous screen during rendering","zh-CN":"App渲染上一个屏幕时生成唯一ID"}}
     screen_view_previous_screen_unique_id varchar(255),
-    screen_view_previous_time_msec bigint, 
+    screen_view_previous_time_msec bigint,
     screen_view_engagement_time_msec bigint,
     -- METADATA {"name":"screen_view_entrances","dataType":"boolean","scanValue":"true","category":"{{{category_screen_view}}}","displayName":{"en-US":"Session entry screen or not","zh-CN":"是否会话进入界面"},"description":{"en-US":"The first screen view event in a session is 1, others is 0","zh-CN":"会话中的第一个屏幕浏览事件该值为 1，其他则为 0"}}
     screen_view_entrances bool,
@@ -145,7 +145,7 @@ CREATE TABLE IF NOT EXISTS {{schema}}.event_v2 (
     search_key varchar(2048),
     -- METADATA {"name":"search_term","dataType":"string","scanValue":"false","category":"{{{category_search}}}","displayName":{"en-US":"Search term","zh-CN":"搜索内容"},"description":{"en-US":"The search content","zh-CN":"搜索内容"}}
     search_term varchar(2048),
-    -- METADATA {"name":"outbound_link_classes","dataType":"string","scanValue":"true","category":"{{{category_outbound}}}","displayName":{"en-US":"Link class","zh-CN":"外链类"},"description":{"en-US":"The content of class in tag <a>","zh-CN":"标签<a>中class里的内容"}}
+    -- METADATA {"name":"outbound_link_classes","dataType":"string","scanValue":"true","category":"{{{category_outbound}}}","displayName":{"en-US":"Link class","zh-CN":"外链类"},"description":{"en-US":"The content of class in anchor tag","zh-CN":"超链接标签中class里的内容"}}
     outbound_link_classes varchar(2048),
     -- METADATA {"name":"outbound_link_domain","dataType":"string","scanValue":"true","category":"{{{category_outbound}}}","displayName":{"en-US":"Outbound Link domain","zh-CN":"外链域名"},"description":{"en-US":"The domain of the outbound link","zh-CN":"外链域名"}}
     outbound_link_domain varchar(2048),

--- a/src/control-plane/backend/lambda/api/config/dictionary.json
+++ b/src/control-plane/backend/lambda/api/config/dictionary.json
@@ -138,7 +138,7 @@
     "data": {
       "PresetEvents": [
         {
-          "name": "_first_open",          
+          "name": "_first_open",
           "displayName": {
             "en-US": "First visit",
             "zh-CN": "首次访问"
@@ -149,7 +149,7 @@
           }
         },
         {
-          "name": "_session_start",        
+          "name": "_session_start",
           "displayName": {
             "en-US": "Session start",
             "zh-CN": "会话开始"
@@ -643,8 +643,8 @@
             "zh-CN": "外链类"
           },
           "description": {
-            "en-US": "The content of class in tag <a>",
-            "zh-CN": "标签<a>中class里的内容"
+            "en-US": "The content of class in anchor tag",
+            "zh-CN": "超链接标签中class里的内容"
           },
           "eventName": "_click"
         },
@@ -657,8 +657,8 @@
             "zh-CN": "外链的类"
           },
           "description": {
-            "en-US": "The domain of href in tag <a>",
-            "zh-CN": "标签 <a>中href里的域名"
+            "en-US": "The domain of href in anchor tag",
+            "zh-CN": "超链接标签中href里的域名"
           },
           "eventName": "_click"
         },
@@ -671,8 +671,8 @@
             "zh-CN": "外链ID"
           },
           "description": {
-            "en-US": "The content of id in tag <a>",
-            "zh-CN": "标签 <a>中id里的内容"
+            "en-US": "The content of id in anchor tag",
+            "zh-CN": "超链接标签中id里的内容"
           },
           "eventName": "_click"
         },
@@ -685,8 +685,8 @@
             "zh-CN": "外链地址"
           },
           "description": {
-            "en-US": "The content of href in tag <a>",
-            "zh-CN": "标签 <a>中href里的内容"
+            "en-US": "The content of href in anchor tag",
+            "zh-CN": "超链接标签中href里的内容"
           },
           "eventName": "_click"
         },
@@ -1477,7 +1477,7 @@
         },
         {
           "name": "_first_visit_date",
-          "dataType": "string", 
+          "dataType": "string",
           "category": "user_outer",
           "displayName": {
             "en-US": "First touch date",


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

Some preset event attribute description contains html <a> tag, which violates the XSS rule and prevents new segment from being created. Update event attribute description to remove html <a> tag.

Note that the UI already has input check to prevent user from adding description with html tags.

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend