### PR TITLE
chore: update base OS of ingestion servers to Amazon Linux 2023

### DIFF
--- a/src/ingestion-server/server-v2/private/ecs-ec2-cluster.ts
+++ b/src/ingestion-server/server-v2/private/ecs-ec2-cluster.ts
@@ -87,7 +87,7 @@ function createECSClusterAndService(
 
   const ecsConfig = {
     instanceType: ecsAsgSetting.instanceType,
-    machineImage: EcsOptimizedImage.amazonLinux2(
+    machineImage: EcsOptimizedImage.amazonLinux2023(
       arch === Platform.LINUX_ARM64 ? AmiHardwareType.ARM : AmiHardwareType.STANDARD,
     ),
     platform: arch,


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

upgrade to linux2023
<img width="494" alt="Screenshot 2024-07-31 at 10 36 25" src="https://github.com/user-attachments/assets/b8072ba1-7734-404c-98c1-3029b6117cd6">



## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [x] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [x] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend