### PR TITLE
chore: use launch template to replace launch configuration

### DIFF
--- a/src/ingestion-server/server/ingestion-server.ts
+++ b/src/ingestion-server/server/ingestion-server.ts
@@ -160,7 +160,7 @@ export class IngestionServer extends Construct {
     }
 
     // ECS Cluster
-    const { ecsService, httpContainerName, autoScalingGroup, ecsCluster } =
+    const { ecsService, httpContainerName, autoScalingGroup, ecsCluster, ec2Role } =
       createECSClusterAndService(this, {
         ...props,
         ecsSecurityGroup,
@@ -169,7 +169,7 @@ export class IngestionServer extends Construct {
 
     const mskClusterName = props.kafkaSinkConfig?.mskClusterName;
     if (mskClusterName) {
-      const autoScalingGroupRole = autoScalingGroup.role;
+      const autoScalingGroupRole = ec2Role;
       grantMskReadWrite(
         this,
         autoScalingGroupRole,

--- a/src/ingestion-server/server/private/cfn-nag.ts
+++ b/src/ingestion-server/server/private/cfn-nag.ts
@@ -20,10 +20,12 @@ const cfnNagList = [
     paths_endswith: [
       'IngestionServer/clickstream-ingestion-service-ecs-asg/InstanceRole/DefaultPolicy/Resource',
       'IngestionServer/clickstream-ingestion-service-ecs-asg/DrainECSHook/Function/ServiceRole/DefaultPolicy/Resource',
+      'IngestionServer/clickstream-ingestion-service-ecs-role/DefaultPolicy/Resource',
       'IngestionServer/clickstream-ingestion-service-ecs-task-def/ExecutionRole/DefaultPolicy/Resource',
       'IngestionServer/ECSFargateCluster/ecs-fargate-service/clickstream-ingestion-service-ecs-fargate-task-def/ExecutionRole/DefaultPolicy/Resource',
       'IngestionServer/ECSEc2Cluster/clickstream-ingestion-service-ecs-service/clickstream-ingestion-service-ecs-task-def/ExecutionRole/DefaultPolicy/Resource',
       'IngestionServer/ECSEc2Cluster/clickstream-ingestion-service-ecs-asg/InstanceRole/DefaultPolicy/Resource',
+      'IngestionServer/ECSEc2Cluster/clickstream-ingestion-service-ecs-role/DefaultPolicy/Resource',
       'IngestionServer/ECSEc2Cluster/clickstream-ingestion-service-ecs-asg/DrainECSHook/Function/ServiceRole/DefaultPolicy/Resource',
     ],
     rules_to_suppress: [

--- a/src/ingestion-server/server/private/ecs-cluster.ts
+++ b/src/ingestion-server/server/private/ecs-cluster.ts
@@ -18,7 +18,7 @@ import {
   CfnWarmPool,
   HealthCheck,
 } from 'aws-cdk-lib/aws-autoscaling';
-import { ISecurityGroup, SubnetType } from 'aws-cdk-lib/aws-ec2';
+import { ISecurityGroup, SubnetType, UserData, LaunchTemplate, LaunchTemplateHttpTokens } from 'aws-cdk-lib/aws-ec2';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import {
   Cluster,
@@ -29,6 +29,7 @@ import {
   AmiHardwareType,
   CfnClusterCapacityProviderAssociations,
 } from 'aws-cdk-lib/aws-ecs';
+import { ServicePrincipal, Role, ManagedPolicy, IRole } from 'aws-cdk-lib/aws-iam';
 import { Construct, IConstruct } from 'constructs';
 import { createProxyAndWorkerECRImages } from './ecr';
 
@@ -48,6 +49,7 @@ export interface EcsServiceResult {
 export interface EcsClusterResult extends EcsServiceResult {
   ecsCluster: Cluster;
   autoScalingGroup: AutoScalingGroup;
+  ec2Role: IRole;
 }
 
 export function createECSClusterAndService(
@@ -66,7 +68,7 @@ export function createECSClusterAndService(
 
   const ecsConfig = {
     instanceType: ecsAsgSetting.instanceType,
-    machineImage: EcsOptimizedImage.amazonLinux2(
+    machineImage: EcsOptimizedImage.amazonLinux2023(
       arch === Platform.LINUX_ARM64 ? AmiHardwareType.ARM : AmiHardwareType.STANDARD,
     ),
     platform: arch,
@@ -78,26 +80,41 @@ export function createECSClusterAndService(
     notifications = { notifications: [{ topic: props.notificationsTopic }] };
   }
 
-  const autoScalingGroup = new AutoScalingGroup(scope, `${RESOURCE_ID_PREFIX}ecs-asg`, {
-    vpc,
-    vpcSubnets: props.vpcSubnets,
-    associatePublicIpAddress: props.vpcSubnets.subnetType == SubnetType.PUBLIC,
-    instanceType: ecsConfig.instanceType,
+  const ec2Role = new Role(scope, `${RESOURCE_ID_PREFIX}ecs-role`, {
+    assumedBy: new ServicePrincipal('ec2.amazonaws.com'),
+  });
+
+  ec2Role.addManagedPolicy(ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'));
+
+  const userData = UserData.forLinux();
+
+  const launchTemplate = new LaunchTemplate(scope, `${RESOURCE_ID_PREFIX}ecs-launch-template`, {
     machineImage: ecsConfig.machineImage,
-    maxCapacity: ecsAsgSetting.serverMax,
-    minCapacity: ecsAsgSetting.serverMin,
-    healthCheck: HealthCheck.ec2({
-      grace: Duration.seconds(60),
-    }),
+    instanceType: ecsConfig.instanceType,
     securityGroup: props.ecsSecurityGroup,
-    ...notifications,
+    associatePublicIpAddress: props.vpcSubnets.subnetType == SubnetType.PUBLIC,
+    userData,
     blockDevices: [
       {
         deviceName: '/dev/xvda',
         volume: BlockDeviceVolume.ebs(30),
       },
     ],
+    role: ec2Role,
     requireImdsv2: true,
+    httpTokens: LaunchTemplateHttpTokens.REQUIRED,
+  });
+
+  const autoScalingGroup = new AutoScalingGroup(scope, `${RESOURCE_ID_PREFIX}ecs-asg`, {
+    vpc,
+    vpcSubnets: props.vpcSubnets,
+    launchTemplate,
+    maxCapacity: ecsAsgSetting.serverMax,
+    minCapacity: ecsAsgSetting.serverMin,
+    healthCheck: HealthCheck.ec2({
+      grace: Duration.seconds(60),
+    }),
+    ...notifications,
   });
 
   if (Token.isUnresolved(ecsAsgSetting.warmPoolSize)) {
@@ -117,7 +134,7 @@ export function createECSClusterAndService(
     }
   }
 
-  addPoliciesToAsgRole(autoScalingGroup.role);
+  addPoliciesToAsgRole(ec2Role);
 
   const capacityProvider = new AsgCapacityProvider(
     scope,
@@ -143,7 +160,7 @@ export function createECSClusterAndService(
     autoScalingGroup,
   });
   Aspects.of(scope).add(new AddDefaultCapacityProviderStrategyAspect(capacityProvider));
-  return { ...ecsServiceInfo, autoScalingGroup, ecsCluster };
+  return { ...ecsServiceInfo, autoScalingGroup, ecsCluster, ec2Role };
 }
 
 

--- a/test/ingestion-server/server/TestTask-v2.ts
+++ b/test/ingestion-server/server/TestTask-v2.ts
@@ -25,6 +25,7 @@ import {
   SecurityGroup,
   SubnetType,
   Vpc,
+  InstanceType,
 } from 'aws-cdk-lib/aws-ec2';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Stream } from 'aws-cdk-lib/aws-kinesis';
@@ -146,6 +147,8 @@ export interface TestStackV2Props extends StackProps {
   mskSecurityGroupId?: string;
   mskClusterName?: string;
 
+  ecsInfraType: string;
+
   withKinesisSinkConfig: boolean;
   kinesisDataStreamArn?: string;
 
@@ -178,6 +181,7 @@ export class TestStackV2 extends Stack {
       serverMin: 1,
       enableAuthentication: 'No',
       protocol: 'HTTP',
+      ecsInfraType: 'FARGATE',
       serverMax: 1,
       scaleOnCpuUtilizationPercent: 50,
       workerStopTimeout: 60,
@@ -232,6 +236,7 @@ export class TestStackV2 extends Stack {
       taskMin: props.serverMin || 1,
       taskMax: props.serverMax || 1,
       scaleOnCpuUtilizationPercent: props.scaleOnCpuUtilizationPercent || 50,
+      instanceType: new InstanceType('c6i.large'),
     };
 
     const serverProps: IngestionServerV2Props = {
@@ -248,7 +253,7 @@ export class TestStackV2 extends Stack {
       devMode: props.devMode,
       projectId: 'test-project',
       workerStopTimeout: props.workerStopTimeout,
-      ecsInfraType: 'FARGATE',
+      ecsInfraType: props.ecsInfraType,
       albTargetGroupArn: 'arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/test/xxxx',
       ecsSecurityGroupArn: 'arn:aws:ec2:us-east-1:111111111111:security-group/sg-xxxx',
       loadBalancerFullName: 'test-load-balancer',

--- a/test/ingestion-server/server/ingestion-server.test.ts
+++ b/test/ingestion-server/server/ingestion-server.test.ts
@@ -873,11 +873,11 @@ test('Check EC2 IMDSv2 Enabled', () => {
   const template = Template.fromStack(stack);
   const launchConfiguration = findFirstResource(
     template,
-    'AWS::AutoScaling::LaunchConfiguration',
+    'AWS::EC2::LaunchTemplate',
   )?.resource;
 
   const properties = launchConfiguration.Properties;
-  expect(properties.MetadataOptions.HttpTokens == 'required').toBeTruthy();
+  expect(properties.LaunchTemplateData.MetadataOptions.HttpTokens == 'required').toBeTruthy();
 });
 
 


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

use launch template to replace launch configuration



## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [x] add new test cases
- [x] all code changes are covered by unit tests
- [x] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [x] deploy ingestion server
    - [x] with MSK sink
    - [x] with KDS sink
    - [x] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend