### PR TITLE
fix: retry failed when stackTemplateVersion is null

### DIFF
--- a/src/control-plane/backend/lambda/api/service/stack.ts
+++ b/src/control-plane/backend/lambda/api/service/stack.ts
@@ -442,7 +442,7 @@ export class StackManager {
   private getStackStatusByName(stackName: string, statusDetail: PipelineStatusDetail[]) {
     for (let detail of statusDetail) {
       if (detail.stackName === stackName) {
-        if (detail.stackTemplateVersion !== this.pipeline.templateVersion) {
+        if (detail.stackTemplateVersion && detail.stackTemplateVersion !== this.pipeline.templateVersion) {
           return StackStatus.UPDATE_FAILED;
         }
         return detail.stackStatus;

--- a/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
+++ b/src/control-plane/backend/lambda/api/test/api/pipeline-mock.ts
@@ -2064,3 +2064,42 @@ export const RETRY_PIPELINE_WITH_WORKFLOW_FAILED: IPipeline = {
   },
 };
 
+export const RETRY_PIPELINE_WITH_WORKFLOW_CREATE_FAILED: IPipeline = {
+  ...BASE_RETRY_PIPELINE,
+  lastAction: 'Create',
+  stackDetails: [
+    BASE_STATUS.stackDetails[0],
+    BASE_STATUS.stackDetails[1],
+    BASE_STATUS.stackDetails[2],
+    {
+      ...BASE_STATUS.stackDetails[3],
+      stackStatus: StackStatus.CREATE_FAILED,
+    },
+    {
+      ...BASE_STATUS.stackDetails[4],
+      stackId: '',
+      stackStatus: undefined,
+      stackStatusReason: '',
+      stackTemplateVersion: '',
+      stackType: PipelineStackType.STREAMING,
+      outputs: [],
+    },
+    BASE_STATUS.stackDetails[5],
+    {
+      ...BASE_STATUS.stackDetails[6],
+      stackId: '',
+      stackStatus: undefined,
+      stackStatusReason: '',
+      stackTemplateVersion: '',
+      stackType: PipelineStackType.REPORTING,
+      outputs: [],
+    },
+    BASE_STATUS.stackDetails[7],
+  ],
+  executionDetail: {
+    name: MOCK_EXECUTION_ID,
+    status: ExecutionStatus.FAILED,
+    executionArn: 'arn:aws:states:us-east-1:111122223333:execution:MyPipelineStateMachine:main-5ab07c6e-b6ac-47ea-bf3a-02ede7391807',
+  },
+};
+

--- a/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
+++ b/src/control-plane/backend/lambda/api/test/api/workflow.test.ts
@@ -64,6 +64,7 @@ import {
   MSK_WITH_CONNECTOR_INGESTION_PIPELINE,
   RETRY_PIPELINE_WITH_WORKFLOW,
   RETRY_PIPELINE_WITH_WORKFLOW_AND_ROLLBACK_COMPLETE,
+  RETRY_PIPELINE_WITH_WORKFLOW_CREATE_FAILED,
   RETRY_PIPELINE_WITH_WORKFLOW_FAILED,
   RETRY_PIPELINE_WITH_WORKFLOW_WHEN_UPDATE_EMPTY,
   RETRY_PIPELINE_WITH_WORKFLOW_WHEN_UPDATE_FAILED,
@@ -2610,9 +2611,9 @@ describe('Workflow test', () => {
   });
   it('Generate Retry Workflow when create failed', async () => {
     dictionaryMock(ddbMock);
-    // KafkaConnector, DataModelingRedshift Failed
-    // Reporting Miss
-    const stackManager: StackManager = new StackManager({ ...RETRY_PIPELINE_WITH_WORKFLOW });
+    // DataModelingRedshift Failed
+    // Reporting Streaming Miss
+    const stackManager: StackManager = new StackManager({ ...RETRY_PIPELINE_WITH_WORKFLOW_CREATE_FAILED });
     stackManager.retryWorkflow();
     const expected = {
       Version: '2022-03-15',
@@ -2660,7 +2661,7 @@ describe('Workflow test', () => {
                             BucketPrefix: 'clickstream/workflow/main-3333-3333',
                           },
                           Input: {
-                            Action: 'Update',
+                            Action: 'Create',
                             Region: 'ap-southeast-1',
                             Parameters: [
                               ...BASE_KAFKACONNECTOR_BATCH_PARAMETERS,
@@ -2672,7 +2673,7 @@ describe('Workflow test', () => {
                           },
                         },
                         End: true,
-                        Type: WorkflowStateType.STACK,
+                        Type: WorkflowStateType.PASS,
                       },
                     },
                   },
@@ -2709,11 +2710,7 @@ describe('Workflow test', () => {
                   {
                     StartAt: 'Streaming',
                     States: {
-                      Streaming: replaceStackInputProps(StreamingStack,
-                        {
-                          Action: 'Update',
-                        },
-                      ),
+                      Streaming: StreamingStack,
                     },
                   },
                   {


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [x] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend