### PR TITLE
fix: handle the large size of custom parameters exceeding maximum VARCHAR

### DIFF
--- a/src/analytics/private/sqls/redshift/sp-scan-metadata.sql
+++ b/src/analytics/private/sqls/redshift/sp-scan-metadata.sql
@@ -152,6 +152,7 @@ BEGIN
 				WHERE
 					custom_parameters IS NOT NULL
 					AND event_timestamp < end_timestamp
+					AND LEN(custom_parameters_json_str) < 50000
 			) AS ep,
 			ep.custom_parameters_array AS cp
 		);
@@ -182,6 +183,7 @@ BEGIN
 					custom_parameters IS NOT NULL
 					AND event_timestamp >= start_timestamp
 					AND event_timestamp < end_timestamp
+					AND LEN(custom_parameters_json_str) < 50000
 			) AS ep,
 			ep.custom_parameters_array AS cp
 		);
@@ -291,7 +293,8 @@ BEGIN
 			FROM
 				{{schema}}.user_v2
 			WHERE
-				user_properties IS NOT NULL	
+				user_properties IS NOT NULL
+				AND LEN(user_properties_json_str) < 50000
 		) as u,
 		u.user_properties_array AS up
 	);	


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

handle custom_parameters more than 65535 case

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [ ] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [x] deploy data modeling
    - [x] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend