### PR TITLE
fix: add missing policy action for assuming role update

### DIFF
--- a/src/control-plane/backend/stack-action-state-machine-construct.ts
+++ b/src/control-plane/backend/stack-action-state-machine-construct.ts
@@ -81,6 +81,7 @@ export class StackActionStateMachine extends Construct {
           'iam:TagRole',
           'iam:UntagRole',
           'iam:ListRoleTags',
+          'iam:UpdateAssumeRolePolicy',
         ],
         resources: [
           `arn:${Aws.PARTITION}:iam::${Aws.ACCOUNT_ID}:role/${props.conditionStringRolePrefix}*`,

--- a/test/control-plane/click-stream-api.test.ts
+++ b/test/control-plane/click-stream-api.test.ts
@@ -546,6 +546,7 @@ describe('Click Stream Api ALB deploy Construct Test', () => {
               'iam:TagRole',
               'iam:UntagRole',
               'iam:ListRoleTags',
+              'iam:UpdateAssumeRolePolicy',
             ],
             Effect: 'Allow',
             Resource: [
@@ -2291,6 +2292,7 @@ describe('Click Stream Api ALB deploy Construct With IAM Role Prefix', () => {
               'iam:TagRole',
               'iam:UntagRole',
               'iam:ListRoleTags',
+              'iam:UpdateAssumeRolePolicy',
             ],
             Effect: 'Allow',
             Resource: [


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

## Summary

(describe what this merge request does)

## Implementation highlights

(describe how the merge request does for feature changes, share the RFC link if it has)

## Test checklist

- [ ] add new test cases
- [x] all code changes are covered by unit tests
- [ ] end-to-end tests
  - [ ] deploy web console with CloudFront + S3 + API gateway
  - [ ] deploy web console within VPC
  - [ ] deploy ingestion server
    - [ ] with MSK sink
    - [ ] with KDS sink
    - [ ] with S3 sink
  - [ ] deploy data processing
  - [ ] deploy data modeling
    - [ ] new Redshift Serverless
    - [ ] provisioned Redshift
    - [ ] Athena
  - [ ] deploy with reporting
  - [ ] streaming ingestion
    - [ ] with Redshift Serverless
    - [ ] with provisioned Redshift

## Is it a breaking change

- [ ] add parameters without default value in stack
- [ ] introduce new service permission in stack
- [ ] introduce new top level stack module

## Miscellaneous

- [ ] introduce new symbol link source file(s) to be shared among infra code, web console frontend, and web console backend